### PR TITLE
fix(dashboard): Omit source line numbers from i18n catalogs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -344,6 +344,7 @@
         "@lingui/babel-plugin-lingui-macro": "^5.9.3",
         "@lingui/cli": "^5.9.3",
         "@lingui/core": "^5.9.3",
+        "@lingui/format-po": "^5.9.3",
         "@lingui/react": "^5.9.3",
         "@lingui/vite-plugin": "^5.9.3",
         "@tailwindcss/vite": "^4.2.2",

--- a/docs/docs/guides/extending-the-dashboard/localization/index.mdx
+++ b/docs/docs/guides/extending-the-dashboard/localization/index.mdx
@@ -44,7 +44,7 @@ and the [useLingui hook](https://lingui.dev/ref/react#uselingui).
 
 Create a `lingui.config.js` file in your project root, with references to any plugins that need to be localized:
 
-```js title="lingui.config.js
+```js title="lingui.config.js"
 import { defineConfig } from '@lingui/cli';
 
 export default defineConfig({
@@ -87,10 +87,57 @@ Since we set the "sourceLocale" to be "en", the `en.po` file will already be com
 open up the `de.po` file and add German translations for each of the strings, by filling out the empty `msgstr` values:
 
 ```text title="de.po"
-#: test-plugins/reviews/dashboard/review-list.tsx:51
+#: src/plugins/reviews/dashboard/review-list.tsx:51
 msgid "Welcome to Dashboard"
 msgstr "Willkommen zum Dashboard" # [!code highlight]
 ```
+
+## Reducing merge conflicts in your .po files
+
+The `#:` comment above each message records where the string was found, down to the line number. Those
+line numbers are recalculated on every extraction, so any edit that shifts code up or down rewrites
+them — adding one import at the top of a file changes the recorded line of every string below it, even
+though none of the strings themselves changed.
+
+If several people work on the same plugin, this can make the `.po` files a recurring source of merge
+conflicts that have nothing to do with the translations. You can turn the line numbers off by passing an
+explicit PO formatter to your config:
+
+```js title="lingui.config.js"
+import { defineConfig } from '@lingui/cli';
+import { formatter } from '@lingui/format-po'; // [!code highlight]
+
+export default defineConfig({
+    sourceLocale: 'en',
+    locales: ['en', 'de'],
+    format: formatter({ lineNumbers: false }), // [!code highlight]
+    catalogs: [
+        {
+            path: '<rootDir>/src/plugins/reviews/dashboard/i18n/{locale}',
+            include: ['<rootDir>/src/plugins/reviews/dashboard/**'],
+        },
+    ],
+});
+```
+
+The references then keep the file path and drop the line number, which is usually enough context for a
+translator to find the string:
+
+```text title="de.po"
+#: src/plugins/reviews/dashboard/review-list.tsx
+msgid "Welcome to Dashboard"
+msgstr "Willkommen zum Dashboard"
+```
+
+The next `npx lingui extract` rewrites every reference in your catalogs, so expect one large diff when
+you first make this change. After that the references only change when a string genuinely moves to a
+different file.
+
+:::note
+`formatter` comes from `@lingui/format-po`, which is installed as part of the Lingui CLI. If your package
+manager enforces strict dependency resolution (pnpm, or Yarn PnP), add it to your project explicitly with
+`npm install --save-dev @lingui/format-po`.
+:::
 
 ## Contributing a translation of the Dashboard itself
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -650,7 +650,7 @@
           "title": "Localization",
           "slug": "localization",
           "file": "docs/guides/extending-the-dashboard/localization/index.mdx",
-          "lastModified": "2026-07-23T09:49:01+02:00"
+          "lastModified": "2026-07-31T10:40:45+02:00"
         },
         {
           "title": "Deployment",

--- a/packages/dashboard/lingui.config.js
+++ b/packages/dashboard/lingui.config.js
@@ -1,7 +1,11 @@
 import { defineConfig } from '@lingui/cli';
+import { formatter } from '@lingui/format-po';
 
 export default defineConfig({
     sourceLocale: 'en',
+    // Line numbers in the `#:` reference comments churn on every unrelated edit
+    // to a source file, which makes the catalogs a constant source of merge conflicts.
+    format: formatter({ lineNumbers: false }),
     locales: [
         'he',
         'ar',

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -76,6 +76,7 @@
         "@lingui/babel-plugin-lingui-macro": "^5.9.3",
         "@lingui/cli": "^5.9.3",
         "@lingui/core": "^5.9.3",
+        "@lingui/format-po": "^5.9.3",
         "@lingui/react": "^5.9.3",
         "@lingui/vite-plugin": "^5.9.3",
         "@tailwindcss/vite": "^4.2.2",

--- a/packages/dashboard/src/i18n/locales/ar.po
+++ b/packages/dashboard/src/i18n/locales/ar.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "الاسم الكامل"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "تحديد عناصر"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "عرض التغييرات"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "رمز التتبع"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "سيتم تطبيق الصلاحيات المحددة على هذه القنوات."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "خيارات المنتج"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "معدل ضريبة جديد"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "تعيين مجموعة خيارات موجودة أو إنشاء مجموعة جديدة"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "دور جديد"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "شقة، جناح، إلخ."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "لا توجد عناصر أخرى"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "تحرير الرابط"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "أضف عنصرًا واحدًا على الأقل إلى الطلب"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "أضف منتجات لإنشاء طلب تجريبي"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "فشل إنشاء العنوان"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "تبديل الكل"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "تعديل قيمة JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "استخدام استراتيجية مصادقة خارجية: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "اختر سببًا..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "عنوان 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "فشل إضافة الدفع"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "تم التحديث"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "فشل تحديث الإعدادات العامة"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "تم تنفيذ الطلب بنجاح"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "هل أنت متأكد من حذف {0} {entityName}؟"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "حد نفاد المخزون العام"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "إدارة اللغات"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "جارٍ النسخ... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "تم الحذف بنجاح"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "إزالة من القناة الحالية"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "تم حذف {selectionLength} ملف"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "تم تحديث معدل الضريبة بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "أدخل سببًا مخصصًا..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "النوع"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "تحديد {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "عرض القيم"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "حذف الصف"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "الشروط"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "الحالي"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "لا توجد تنفيذات"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, zero {تعذر حذف {2} موقع مخزون: {messages}} one {تعذر حذف موقع مخزون واحد: {messages}} two {تعذر حذف موقعي مخزون: {messages}} few {تعذر حذف {2} مواقع مخزون: {messages}} many {تعذر حذف {2} موقع مخزون: {messages}} other {تعذر حذف {2} موقع مخزون: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "عند تمكين هذا، ستكون الأسعار المدخلة في كتالوج المنتجات شاملة للضريبة للمنطقة الضريبية الافتراضية."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "إنشاء أشكال لمنتجك"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "اكتمل طلب المسودة"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "التحديث التلقائي: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "فحوصات الصحة"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "تم حذف {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "فحوصات الصحة"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "البائعون"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "الخيارات"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {تم إلغاء مهمة واحدة بنجاح} two {تم إلغاء مهمتين بنجاح} few {تم إلغاء {fulfilled} مهام بنجاح} many {تم إلغاء {fulfilled} مهمة بنجاح} other {تم إلغاء {fulfilled} مهمة بنجاح}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "البائع"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "رمز المنتج:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "إضافة دفعة"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "اختبر طريقة الشحن هذه بمحاكاة طلب لمعرفة ما إذا كانت مؤهلة وما هي تكلفة الشحن."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "استكشف الإصدار المؤسسي"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "مواقع المخزون"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "معالج التنفيذ"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "الطلبات"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "تحديد الأدوار"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "تم إنشاء الدور بنجاح"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "هل أنت متأكد من حذف هذا الشكل؟"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "جميع الموارد تعمل بشكل جيد"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "فشل في إنشاء المسؤول"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "لا"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "تم تحديث شكل المنتج بنجاح"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "فشل حذف {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "تم تحديث المنتج بنجاح"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "فشل تحديث البلد"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "اكتب حرفين على الأقل للبحث..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "اسم العائلة"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "عنوان الرابط"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "تم تحديث مجموعة العملاء بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "تم تغيير الحقول المخصصة"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "تم إنشاء موقع المخزون بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "خطأ غير معروف"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "لا يمكن أن يكون إجمالي الاسترداد سالبًا"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "عرض التفاصيل"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "حدد قناة لتعيين {0} {entityType} إليها"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "تم إنشاء العميل بنجاح"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "آخر 7 أيام"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "فشل إنشاء القناة"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "وضع التطوير"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "دور جديد"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "فشل حذف الملفات: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "إعادة للمخزون"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "الرؤية"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "متغيرات المنتج"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "مجموعة عملاء جديدة"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "إنشاء \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "إعادة التسمية"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "اختر لغة العرض المفضلة وإعدادات المنطقة"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "تمت إزالة {successCount} مجموعة خيارات من القناة بنجاح"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "طريقة الشحن غير مؤهلة لهذا الطلب"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "فشل تحديث العنوان"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "تم حذف العنوان بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "معدل الضريبة"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "طلب المسودة غير جاهز للإكمال"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "مجموعة جديدة"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "الرؤى"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "تشغيل"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "فشل تحديث معدل الضريبة"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "هذا هو محتوى المجموعة <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "خاص"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "تم إنشاء خيار المنتج بنجاح"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "المنتج الأساسي"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "المدينة"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "المسؤولون"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "السعر الإجمالي: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "الانتقال إلى الصفحة التالية"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "إزالة الرابط"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "هذا الحقل للقراءة فقط"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "عدد الطلبات"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "تم تحديث الطلب بنجاح"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "وراثة الفلاتر"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "إدارة العروض المحفوظة العامة المرئية لجميع المستخدمين"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "بحث في طرق الدفع..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "تم إلغاء تعيين عنوان الشحن للطلب"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "إنشاء {enabledCount} متغيرات"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "تم نقل الدفع #{0} إلى {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "خطأ في تحميل سجل العميل: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "تمت إزالة {selectionLength} {entityType} من القناة بنجاح"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "إضافة قيمة خيار"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "الإعدادات العامة"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "بعد"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "تم تحديث خيار المنتج بنجاح"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "تحرير قيم الخصائص"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "جارٍ الإضافة..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "نقل المجموعات"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "الأدوار"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "عرض شبكي"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "فشل حذف العنوان"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "لا توجد طرق شحن متاحة"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "تم تحويل العرض العام إلى عرض شخصي بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "تم نقل التنفيذ"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "هل أنت متأكد من حذف {selectionLength} ملف؟"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "تسجيل الدخول"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "عرض قائمة"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "طلب تجريبي"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "اختر عميلاً للمتابعة"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "تم تعيين مجموعة الخيارات بنجاح"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "تشغيل الاختبار"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "معدل الضريبة: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "يرجى إضافة منتجات وإكمال عنوان الشحن لتشغيل الاختبار."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "تبديل صف الرأس"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "تحديد عنوان"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "فاحص أهلية الدفع"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "المنطقة الضريبية الافتراضية"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "طلب المسودة جاهز للإكمال"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "البيانات الوصفية"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "تصفية..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "قيمة خاصية جديدة"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "تم تحديث القناة بنجاح"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "عرض أقل"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "تاريخ قصير"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "العملات المتاحة"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "تحديد {0} عنصر"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "تاريخ الطلب"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "سيؤدي تدوير هذا المفتاح إلى إبطال المفتاح الحالي فورًا. ستتوقف أي عمليات تكامل تستخدمه عن العمل حتى يتم تحديثها بالمفتاح الجديد."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "البيانات التي تم تمريرها إلى المهمة"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "تأكيد التنقل"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "هدف الرابط"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "إكمال المسودة"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "الاسم"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "فشل تنفيذ الطلب"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "الإجمالي"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "أدخل معرف المعاملة لتسوية الاسترداد هذه"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "مفتاح API الخاص بك"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "هل أنت متأكد من حذف طلب المسودة هذا؟"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "تم إنشاء التنفيذ"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "تم العثور على {0} طريقة شحن مؤهلة"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "الأبعاد"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "إظهار كلمة المرور"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(الحد الأقصى: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "الشركة"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "إضافة عمود بعد"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "الإجراءات"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "الخصومات"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "أدخل ملاحظة الاسترداد"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "تمت إزالة بند الطلب"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "المحتوى:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "المفتاح"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "تأكيد"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "فشل إنشاء المجموعة"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "الانتقال إلى الصفحة الأولى"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "فشل إنشاء المنتج"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "العميل"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "خطأ في تحميل سجل الطلب: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "تم تعيين عنوان الشحن للطلب"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "نقطة التركيز"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "متغير واحد، بدون خيارات"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "حدد الحالة التالية للطلب"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "اللغة المحلية"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "المهام المجدولة"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "أدخل معرف المعاملة"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "تحديث البيانات"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "إضافة أو إزالة قيم الخصائص لـ {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "هذه هي قيم الخصائص للخاصية <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "تمت إضافة الدفع إلى الطلب بنجاح"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "تم تعيين عنوان الفوترة للطلب"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "فشل تحديث المنطقة"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "كلمة المرور"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "فشل الحذف"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "سيتم تنفيذ المهمة المجدولة"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "موقع مخزون جديد"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "الصلاحيات"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "تم تغيير عنوان الشحن"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "لم يتم العثور على منتجات"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "إضافة صف قبل"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "الانتقال إلى {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "هذا الشهر"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "فشل إنشاء الخاصية"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "فشل في إلغاء عناصر الطلب"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "معرف المعاملة"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "مخصص"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "إضافة مجموعة خيارات أخرى"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "اختر ما يجب فعله بالمخزون المتبقي"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "استكشاف المنصة والسحابة"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "كل 5 ثوانٍ"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "تم إنشاء المجموعة بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "السعر"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "طلب مسودة"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "النطاق"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "إضافة شرط"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "طريقة الشحن مؤهلة لهذا الطلب"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "المسؤولون"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "تمت الإزالة من المجموعة"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "العرض"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "لا يلزم دفع أو استرداد"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "تنزيل كملف .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "عند التمكين، يصبح العرض الترويجي متاحًا في المتجر"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "عند التتبع، سيتم تعديل مستويات مخزون أشكال المنتج تلقائيًا عند البيع. يمكن تجاوز هذا الإعداد بواسطة أشكال المنتج الفردية."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "تم تعيين طريقة الشحن للطلب"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "فشل تحديث العرض الترويجي"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "الصور"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "مفاتيح API"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "بحث {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "تحرير الملف"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "إلغاء الدفع"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "قائمة انتظار المهام"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "الملفات"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "عنوان البريد الإلكتروني"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "إعادة إنشاء الرابط المختصر من الحقل المصدر"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "الوراثة من الإعدادات العامة"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "لم يتم العثور على نتائج"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "الحالة الحالية"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "قم بتعيين عنوان الشحن واختيار طريقة الشحن"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "إيقاف"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "متجر الإعدادات"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "قائمة الانتظار"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "معدل ضريبة جديد"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "تم نقل الدفع"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "المتبقي:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "لم يتم العثور على أداة نسخ بالرمز \"{duplicatorCode}\" لـ {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "الأسعار تشمل الضريبة للمنطقة الضريبية الافتراضية"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "إجمالي الاسترداد:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "عرض نتيجة المهمة"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "اختبر طرق الشحن الخاصة بك بمحاكاة طلب جديد."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "لم يتم تحديد عناصر"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr "، {0} محدد"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "لم يتم العثور على بلدان"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "تم إنشاء المتغيرات بنجاح"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "إنشاء الرابط المختصر تلقائيًا"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "رسوم إضافية"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "طرق الدفع"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "المخزون"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "لم يتم العثور على عملاء"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "استخدام حد نفاد المخزون العام"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "مجموعة خيارات منتج جديدة"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "تم تحديث حالة الدفع بنجاح"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "إنشاء جديد"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "إجمالي الاسترداد"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "تم حذف العنوان"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "الأدوار المعيّنة لحسابك فقط هي المتاحة."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "تمت إضافة عنصر إلى الطلب"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "تحرير نقطة التركيز"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "لم يتم العثور على بائعين"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "ملف"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {تُستخدم مجموعة الخيارات هذه بواسطة منتج آخر واحد. ستؤثر التغييرات عليه أيضًا.} other {تتم مشاركة مجموعة الخيارات هذه عبر # منتجات. ستؤثر التغييرات على جميعها.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "عروضي المحفوظة"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "قناة جديدة"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "فشل إنشاء البائع"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "تكوين إعدادات النسخ لـ {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "لا توجد متغيرات تطابق عامل التصفية الحالي."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "العناوين"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "إضافة قيمة خيار جديدة إلى مجموعة الخيارات {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "تعديل الطلب #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "إضافة عمود قبل"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "لغات القناة"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "فشل إنشاء مجموعة الخيارات"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "صحيح"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "تحديد العميل"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "تم نقل الطلب"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "يحتوي هذا المنتج على أشكال موجودة ولكن لم يتم تحديد مجموعات خيارات. تحتاج إلى إضافة مجموعات خيارات قبل إنشاء أشكال جديدة."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "قبل"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "حذف طلب المسودة"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "الكتالوج"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "طريقة دفع جديدة"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "تم تحديث العرض الترويجي بنجاح"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {فشل إلغاء مهمة واحدة} two {فشل إلغاء مهمتين} few {فشل إلغاء {rejected} مهام} many {فشل إلغاء {rejected} مهمة} other {فشل إلغاء {rejected} مهمة}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "حدد قناة"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "لغة العرض"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "تفاصيل التنفيذ"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "التخلص من المخزون المتبقي"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "الآن"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "القنوات"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "تم تحويل العرض إلى عام بنجاح"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "قبل"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "الحجم"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "لم يتم العثور على ترجمة لـ {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "عميل جديد"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "أحدث الطلبات"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} المزيد"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "استخدام كعنوان فوترة افتراضي"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "حذف"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "تعطيل"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "المجموعات"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "إضافة شكل"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "فشل إنشاء البلد"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "البلدان"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "فشل إنشاء خيارات المنتج"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "فشل إعادة تسمية العرض"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "متاح"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "عادي"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "الفلاتر"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "مجموعات العملاء"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "العملاء"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "تنسيق نموذجي"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "خيار جديد"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "حد الاستخدام"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "جارٍ تحميل الإعدادات العامة..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "تم تحديث العنوان بنجاح"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "تم الإنشاء"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "جارٍ تحميل العناوين..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "حدد مجموعة مستهدفة لنقل {0} إليها."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "تم تحديث تفاصيل العميل"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "ليس في"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "تطبيق"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "خيار منتج جديد"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "الانتقال إلى الصفحة الأخيرة"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "إلغاء"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "تم إنشاء شكل المنتج بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "الاسترداد من هذه الطريقة"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "الرمز البريدي"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "أضف خيارات المنتج أولاً"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "فئة ضريبية جديدة"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "إضافة خيار"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "تم استكمال الاسترداد الجزئي"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "تعيين الحقول المخصصة"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "المجموعات"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "حذف المتغير"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "لم يتم إجراء تعديلات"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "منطقة الشحن الافتراضية"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "السبب:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "عنوان الشحن"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "الانتقال إلى {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "فئات الضرائب"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "المجموعات الخاصة غير مرئية في المتجر"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "عند التمكين، يصبح المنتج متاحًا في المتجر"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "تعذر تنفيذ المهمة المجدولة"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "مجموعات العملاء"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "معطل"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "عرض ترويجي جديد"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "عنوان الشحن الافتراضي"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "مطلوب استرداد"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "تنفيذ الطلب"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "ليس لديك إذن لعرض إعدادات القناة"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "آخر 30 يومًا"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "لا توجد قيم خصائص"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "سبب الاسترداد مطلوب"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "تعذرت إزالة مجموعة الخيارات"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "فشل تحديث الفئة الضريبية"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "تم تسوية الاسترداد بنجاح"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "تحديث"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "عنوان 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "تم إنشاء الطلب"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "تم تحديث الملف الشخصي بنجاح"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "النهاية"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "طريقة الدفع"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "تحرير"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "تم تحديث الشكل بنجاح"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "تصفية حسب اسم المجموعة"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "تمت إضافة الملاحظة"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "حدد الكميات للتنفيذ وقم بتكوين معالج التنفيذ"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "تم إلغاء عنوان الفوترة من الطلب"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "يبدأ في"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "نسخ"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "لا توجد نتائج"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "إعدادات الأعمدة"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, zero {تعذر حذف {count} موقع مخزون} one {تعذر حذف موقع مخزون واحد} two {تعذر حذف موقعي مخزون} few {تعذر حذف {count} مواقع مخزون} many {تعذر حذف {count} موقع مخزون} other {تعذر حذف {count} موقع مخزون}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "الرمز"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "فشل في إزالة مجموعات الخيارات"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "تم تسليم الطلب"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "النقل إلى {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "المخزون المتبقي"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "إزالة من المنطقة"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "حدد من اللغات المتاحة عالميًا لهذه القناة"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "هل أنت متأكد من حذف هذا العنوان؟"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "فشل في تعيين مجموعة الخيارات"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "فشل تحديث الملف"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "تم تحديث موقع المخزون بنجاح"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "تأكيد الإجراء"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "تم تحديث البلد بنجاح"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "الخصائص"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "فشل إضافة الملاحظة"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "فشل حذف الملاحظة"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "فشل توسيع مستند الاستعلام"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "فشل تحديث الملاحظة"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "استرداد الشحن"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "للقراءة فقط"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "فشل نسخ العرض العام"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "عرض {shown} من {total} • {selected} محدد"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "اختبار طريقة الشحن"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "قيم الخصائص"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "تم تحديث الملف بنجاح"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "السمة"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} عميل"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "مفاتيح API"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "حدد لغة"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "تسجيل الخروج"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "المحاولات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "رموز العملات المتاحة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "رموز اللغات المتاحة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "مسار التنقل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "الفئة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "القنوات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "العناصر الفرعية"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "الرمز"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "رمز القسيمة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "تاريخ الإنشاء"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "رمز العملة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "العميل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "مجموعة العملاء"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "العملاء"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "الحقول المخصصة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "البيانات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "رمز العملة الافتراضي"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "رمز اللغة الافتراضي"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "منطقة الشحن الافتراضية"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "المنطقة الضريبية الافتراضية"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "الوصف"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "المدة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "عنوان البريد الإلكتروني"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "مُفعّل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "ينتهي في"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "خطأ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "الملف المميز"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "الاسم الأول"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "رمز معالج التنفيذ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "المعرف"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "افتراضي"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "خاص"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "مسوى"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "اسم العائلة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "الاسم"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "تم الطلب في"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "معرف الأصل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "حد الاستخدام لكل عميل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "الصلاحيات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "الموضع"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "السعر"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "الأسعار تشمل الضريبة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "السعر مع الضريبة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "أشكال المنتجات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "التقدم"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "اسم الطابور"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "النتيجة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "إعادة المحاولة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "البائع"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "تاريخ التسوية"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "بنود الشحن"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "الرابط المختصر"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "تاريخ البداية"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "يبدأ في"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "الحالة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "مستويات المخزون"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "الرمز المميز"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "الإجمالي"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "الإجمالي مع الضريبة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "النوع"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "تاريخ التحديث"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "حد الاستخدام"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "المستخدم"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "القيمة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "قائمة القيم"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "المنطقة"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "الطريقة"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "ملخص الضرائب"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "يعين اللغات المتاحة لجميع القنوات. يمكن للقنوات الفردية بعد ذلك دعم مجموعة فرعية من هذه اللغات."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "تم نقل المجموعات بنجاح"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "مسجل"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "إلغاء المهمة"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "ينتهي في"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "الصفحة {0} من {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "المعدل"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "الحجم، اللون، إلخ."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "تصفح الفئات"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "المنطقة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "تم الإلغاء"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "تم الإنشاء"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "تم التسليم"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "في الانتظار"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "تم الشحن"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "حفظ العرض"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} محدد"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "البحث في مجموعات الخيارات..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "تعديل الطلب"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "العناصر المحددة"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "القيم"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "تم تعيين العميل للطلب"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "الخصائص"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {هل أنت متأكد أنك تريد إزالة عميل واحد من هذه المجموعة؟} two {هل أنت متأكد أنك تريد إزالة عميلين من هذه المجموعة؟} few {هل أنت متأكد أنك تريد إزالة {count} عملاء من هذه المجموعة؟} many {هل أنت متأكد أنك تريد إزالة {count} عميلاً من هذه المجموعة؟} other {هل أنت متأكد أنك تريد إزالة {count} عميل من هذه المجموعة؟}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "المخزون المتاح"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "تعذر بدء إعادة بناء فهرس البحث"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "عنوان الشحن"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "منطقة جديدة"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "مفتاح API جديد"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "حذف العمود"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "تعيين موجود"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "فارغ"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "هؤلاء هم العملاء في مجموعة العملاء <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "إدارة العروض العامة"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "القناة الافتراضية"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "إدراج صورة جديدة بالمصدر والعنوان والأبعاد"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "فشل إنشاء قيمة الخاصية"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "فشل تحديث خيار المنتج"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>نسيت كلمة المرور؟</0><1>طلب إعادة التعيين</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "رمز القسيمة"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "تم التحقق من العميل"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "الإعدادات العامة"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "الجدول الزمني"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "لا يمكن نقل مجموعة إلى فرع تابع لها"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "فئة ضريبية جديدة"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "لا توجد مواقع مخزون متاحة على القناة الحالية"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "تم إنشاء القناة بنجاح"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "تم تحديث العميل بنجاح"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "عرض البيانات"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "حذف العرض"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "أضف عنوانًا جديدًا للعميل."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "المزيد من العروض"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "تعديل خصائص الصورة المحددة"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "تم تطبيق العرض \"{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "تمت إزالة {successCount} خاصية من القناة بنجاح"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "منتج جديد"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "ملف جديد"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "إعادة حساب الشحن"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "حدد الخيارات التي يجب تطبيقها على الشكل الموجود \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "الملفات"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "سيؤدي هذا إلى إزالة جميع مجموعات الخيارات من هذا المنتج والعودة إلى اختيار إعداد المتغيرات."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "عنوان الفوترة"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "إضافة قيمة خاصية"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "يرجى تحديد مجموعة مستهدفة"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "راجع التغييرات قبل تطبيقها على الطلب."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "حدد دورًا"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "تم إلغاء الطلب"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "الخصم"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "جميع الأنواع"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "يمكن إكمال طلبات المسودة فقط"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "فشل تحديث المنتج"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "تعديل {0} بند"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "إضافة قيم الخصائص"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "بعد"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "القناة"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "فحوصات الصحة"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "المبلغ"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "رقم الهاتف"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "عميل جديد"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "الصورة"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "تم إنشاء المسؤول بنجاح"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "خيارات المنتج"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "تحديد البلد"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "جارٍ الإنشاء..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "هل أنت متأكد من حذف هذا العرض العام؟ لا يمكن التراجع عن هذا الإجراء وسيؤثر على جميع المستخدمين."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "إزالة مجموعة الخيارات إجبارياً"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "تمت الإضافة"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "سجل العميل"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "تم تحديث قيم الخصائص لـ {entityIdsLength} {entityType} بنجاح"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "فشل إزالة العميل من المجموعة"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "النظام"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "حد الاستخدام لكل عميل"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "تم تغيير عنوان الفوترة"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "حدد خيارًا"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "نسخ إلى الشخصي"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "إجمالي الاسترداد يتجاوز الحد الأقصى للمبلغ القابل للاسترداد وهو {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "حذف العرض العام"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "إنشاء"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "كل 30 ثانية"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "بلد جديد"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "من {0} إلى {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "فشل إنشاء العميل"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "تم تحديث نقطة التركيز"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "قيم الخيارات"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "عنوان الفوترة الافتراضي"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "لا يوجد عميل"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "فشل في إزالة البلدان من المنطقة"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "فشل إنشاء العرض الترويجي"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "اليوم"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "أمس"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "اسم الخيار"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "هل أنت متأكد أنك تريد إزالة {0} {1} من هذه المنطقة؟"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "جاري إضافة {0} رسوم إضافية"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "رابط URL"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "القيمة الاحتياطية: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "سجل الطلب"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "تجاوز"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "معرف المعاملة مطلوب"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "يطابق التعبير النمطي"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "تمت إعادة تسمية العرض العام بنجاح"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "لم يتم تحديد علامات"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "رجوع"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "تمت إعادة تسمية العرض بنجاح"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "تطبيق الفلتر"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "آخر نتيجة"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "تمت الإضافة إلى المجموعة"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "الرؤى"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "إنشاء الأشكال"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "جارٍ اختبار طريقة الشحن..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "داكن"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "نتائج الاختبار"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "إضافة عميل"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "حفظ التغييرات"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "تم تحديث العنوان"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "تمت معالجة الاسترداد بنجاح"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "منطقة جديدة"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "فشل في تحديث موضع المجموعة"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "استرداد"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "تعديل"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "لم يتم تكوين لغات عامة"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "إزالة {0} عنصر"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "تتبع"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "إنشاء شكل"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "قيم الخصائص لـ {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "حفظ التخطيط"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "تم التحقق من إعادة تعيين كلمة المرور"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "فشل حذف العرض"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "هل أنت متأكد من مغادرة هذه الصفحة؟ سيتم فقدان أي تغييرات غير محفوظة."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "تبديل عمود الرأس"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "عرض ترويجي جديد"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "اسم قيمة الخيار"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "آخر استخدام"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "هل هي الفئة الضريبية الافتراضية"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "تم تعيين الرابط المختصر"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "فشل تحديث نقطة التركيز"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "تم تحديث المنطقة بنجاح"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "الولاية/المحافظة"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "فشل في تحديث مجموعة الخيارات"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "الإعدادات الافتراضية للقناة"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "فشل إنشاء الفئة الضريبية"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "تعيين معايير التصفية لعمود {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "البلد"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "منتج بسيط"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "قائمة انتظار المهام"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "يرجى التأكد من حفظ مفتاح API قبل الإغلاق."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "تأكيد الحذف"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "فشل تعديل الطلب"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "يشمل ضريبة بنسبة {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "مقاييس الطلبات"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "حدد لغة العرض"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "طرق المصادقة"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "البداية"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "فشل في تدوير مفتاح API"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "في"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "بحث في الأدوار..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "أشكال المنتجات"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "إدارة العروض العامة"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "جاري المعالجة..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "تم العثور على {totalItems} {0}"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "اختر نطاق التاريخ"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "المنتج"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "تدوير مفتاح API"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "الفئة"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "جارٍ النقل..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "تعيين"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "تم إنشاء البائع بنجاح"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "تم تحديث طريقة الشحن بنجاح"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "فشل تحديث شكل المنتج"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "اسحب لإعادة الترتيب"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "المناطق"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "اختر ما يجب فعله بالمخزون المتبقي في {count, plural, zero {# موقع مخزون} one {موقع مخزون واحد} two {موقعي مخزون} few {# مواقع مخزون} many {# موقع مخزون} other {# موقع مخزون}} التي تحذفها. تنقل جميع المواقع المحددة مخزونها المتبقي إلى الموقع الوحيد الذي تختاره، أو يتم التخلص منه."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "البحث في قيم الفئات..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "ملاحظة"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "اللغات المتاحة"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "تحميل {0} إضافية ({remaining} متبقية)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "قيم الخصائص"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "فشل في إعادة ترتيب العناصر"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "إجمالي الطلبات"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "لم يتم العثور على طرق شحن مؤهلة لهذا الطلب."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "إضافة خيار منتج"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "الشحن"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "يجب استخدام useWidgetDimensions داخل DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "مجموعة الخيارات هذه مستخدمة من قبل متغيرات موجودة. قد تؤثر الإزالة الإجبارية على تلك المتغيرات. هل أنت متأكد؟"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "طلب تحديث البريد الإلكتروني"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "خطأ في الانتقال إلى الحالة"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "تم إنشاء مجموعة العملاء بنجاح"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "نافذة جديدة"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "تم تفويض الدفع"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "تم تحديث الدور بنجاح"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "حدد بلدًا"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "فشل تحديث طريقة الشحن"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, zero {تم حذف {deleted} موقع مخزون} one {تم حذف موقع مخزون واحد} two {تم حذف موقعي مخزون} few {تم حذف {deleted} مواقع مخزون} many {تم حذف {deleted} موقع مخزون} other {تم حذف {deleted} موقع مخزون}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "طرق الشحن"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "حدد عنوانًا"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "نعم"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "الرابط المختصر"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "تعيين نقطة التركيز"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "نهاية"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "حدد عملة"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "تحديث محتوى الملاحظة أو رؤيتها"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "أداة أحدث الطلبات"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "محتويات المجموعة {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "تم تغيير طريقة الشحن"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "وصف الضريبة"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "أصغر من أو يساوي"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "لا يساوي"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "تحديث"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "مثل الحجم"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "تسوية الدفع"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "القنوات"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "تم استرداد الشحن"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "نوع الملف"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "موقع مخزون جديد"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "تم استرداد {successfulRefundCount} دفعة/دفعات قبل الفشل. راجع سجل الطلب للتفاصيل."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "تحديد عنصر"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "منتج جديد"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "إدارة العلامات"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "العناصر المستردة"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "إضافة إجراء"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "تعيين خيارات إلى الشكل الموجود"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "نسخ {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "إزالة من المجموعة"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "فشل تحديث حالة التنفيذ"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "إنشاء متغير منتج جديد بالخيارات والأسعار والمخزون"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "الخصائص الخاصة غير مرئية في المتجر"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "حدد فئة ضريبية"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "تم الإنشاء"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "غير قيد التشغيل"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "معيّن"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "عنوان 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "تحديد اللغات المتاحة"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "إضافة {0} عنصر"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "إضافة صف بعد"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "إجمالي الضريبة"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "حالة طلب المسودة"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "تم إنشاء خيارات المنتج بنجاح"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "جارٍ تحميل المواقع…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "فشل إنشاء طريقة الدفع"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "تم إنشاء قيمة الخاصية بنجاح"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "التسويق"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "تم حذف طلب المسودة"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "أكبر من"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "أداة المقاييس"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "بحث في العملات..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "إزالة من القناة"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "العنوان"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "إدراج صورة"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "فشل تحديث البائع"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "تم إنشاء البلد بنجاح"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "تحديد البائع"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "جارٍ تحميل العلامات..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "تم إنشاء الخاصية بنجاح"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} متغير"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "فشل تسوية الدفع"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "لا يوجد عنوان فوترة"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, zero {تعذر حذف {2} موقع مخزون} one {تعذر حذف موقع مخزون واحد} two {تعذر حذف موقعي مخزون} few {تعذر حذف {2} مواقع مخزون} many {تعذر حذف {2} موقع مخزون} other {تعذر حذف {2} موقع مخزون}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "الخاصية"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "لا يمكن الإزالة من القناة النشطة"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "غير معين"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "إزالة إجبارية"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "قناة جديدة"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "اسم مجموعة الخيارات"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "و"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "فشل إنشاء مجموعة العملاء"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "فشل إنشاء الدور"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "اسم المنتج"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "تم تحديث حالة التنفيذ بنجاح"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "المنتجات"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "تم إنشاء العنوان"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "تم تدوير مفتاح API بنجاح"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "إضافة مجموعة خيارات"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "استرداد {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "أدخل الرابط المختصر يدويًا"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "لا توجد أدوات متاحة"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "فشل إلغاء الدفع"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "تم إلغاء الدفع بنجاح"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "تم نسخ العرض العام بنجاح"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "أنشأه"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "تصفية المتغيرات..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "إضافة سعر بعملة أخرى"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "عنوان البريد الإلكتروني أو المعرف"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "تم نقل الاسترداد #{0} إلى {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "العملاء"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "عنوان 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "فشل تحديث موقع المخزون"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "تم شحن الطلب"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "حفظ العنوان"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "جعله عامًا"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "حدد الحالة التالية"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "لا توجد تنبيهات"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "نقل {0} مجموعة إلى {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "اختبار"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "بين"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "تمت إضافة الملاحظة بنجاح"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "تم حذف الملاحظة بنجاح"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "تم تحديث الملاحظة بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "فشل تسوية الاسترداد"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "مستوى المخزون"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "إضافة عنصر"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "تم إنشاء مفتاح API بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "جارٍ تحميل المعاينة..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "العودة إلى البحث"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "تم نسخ العرض بنجاح"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "إزالة مجموعة الخيارات"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "الوصف"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "البلدان"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "عنوان الشارع 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "تم حذف العرض العام بنجاح"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "تحرير التخطيط"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "تعيين إلى القناة"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "هذا الأسبوع"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "تم إنشاء مجموعة خيارات المنتج بنجاح"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "إضافة دفعة يدوية بقيمة {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "في"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "البريد الإلكتروني"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "فشل في تحديث المسؤول"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "إدارة عروضك الشخصية المحفوظة لهذا الجدول"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "تصفية حسب العلامات"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "سجل الدخول للوصول إلى لوحة تحكم المسؤول"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "إضافة دفع إلى الطلب ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "خطأ"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "فاتح"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "إعادة تعيين"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "يساوي"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "إنشاء خيارات"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "تم تحديث كلمة المرور"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "لا يحتوي على"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "مجموعة الخيارات"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "قم بتحرير تفاصيل العنوان أدناه."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "تم إنشاء الفئة الضريبية بنجاح"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "فشل نقل المجموعات"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "فشل تحديث حالة الدفع"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "ملخص طلباتك"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "رفع"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "منتج بخيارات"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "عرض جميع النتائج {0}"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "معرّف البحث"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} المزيد"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "مجموعات الخيارات"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "الحقول المخصصة"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "جميع حالات الطلب المحتملة وتحولاتها. الحالة الحالية مميزة."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "الطلبات"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "أداة ملخص الطلبات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "إضافة عناصر"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "ترتيب دفعة إضافية"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "ترتيب الدفع"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "ملغي"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "تم الإنشاء"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "تم التسليم"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "مسودة"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "قيد التعديل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "تم تسليمه جزئياً"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "تم شحنه جزئياً"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "تم تفويض الدفع"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "تم تسوية الدفع"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "تم الشحن"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "الموارد المراقبة"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "معلومات الكيان"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "إجمالي الطلب"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "مرئي للمسؤولين فقط"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "الكمية"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "العلامات"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "مسؤول عام"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "بعض الموارد معطلة"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "الإجراءات المتاحة"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "إدراج رابط"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "إذا تم التمكين، سيتم وراثة الفلاتر من المجموعة الأصل ودمجها مع الفلاتر المعينة على هذه المجموعة."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "حدد منطقة"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "اختبار طرق الشحن"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "تم تسوية الدفع بنجاح"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "تمت إزالة {0} {1} من المنطقة"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "تمكين"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "طرق الدفع"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "تم التخويل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "تم الإلغاء"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "تم الإنشاء"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "تم الرفض"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "خطأ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "فشل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "في الانتظار"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "تم التسوية"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "متوسط قيمة الطلب"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "فشل إنشاء المنطقة"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "مستويات المخزون"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "فشل في تحديث مفتاح API"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "بنود الطلب"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "فشل إعادة تسمية العرض العام"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "إدراج رابط جديد بـ URL وخيارات الهدف"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "الارتفاع"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "مطلوب استرداد بقيمة {formattedDiff}. حدد مبالغ الدفع وأدخل ملاحظة للمتابعة."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "سعر الوحدة"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "نمط الجدول"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "فشل الدفع"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "إضافة قناة"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "فشل تحديث مجموعة خيارات المنتج"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "بحث في القنوات..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "إضافة مجموعات عملاء"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "اللغات المتاحة"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "إعادة تعيين التحديد"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "لا يوجد عنوان"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "تم إنشاء طريقة الدفع بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "تم تحديث معلومات العميل"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "فشل تحويل العرض إلى عام"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "أشكال المنتجات"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "المنتجات"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "العروض الترويجية"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "فشل إنشاء خيار المنتج"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "البريد الإلكتروني القديم:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "احفظ العرض كـ\"عام\" لإتاحته لجميع المستخدمين."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "فشل في إنشاء المتغيرات"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "يحدد مستوى المخزون الذي يعتبر عنده هذا الشكل نفد من المخزون. استخدام قيمة سالبة يمكّن دعم الطلب المسبق. يمكن تجاوزه بواسطة أشكال المنتج."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "تدوير المفتاح"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "فشل إنشاء متغيرات المنتج"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "إخفاء كلمة المرور"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "بائع جديد"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "مثل أحمر، كبير، قطن"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "فشل تحديث الملف الشخصي"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "رموز قسائم محذوفة"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "مسح الفلتر"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "المناطق"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "أفلت الملفات هنا للتحميل"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "تبديل جميع المتغيرات المرئية"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "مُتحقق منه"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "مجموعة خيارات جديدة"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "آخر تحديث {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "لم يتم إنشاء عروض عامة بعد."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "فشل تحديث الدور"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "هذه هي المرة الوحيدة التي سيتم فيها عرض مفتاح API الكامل. انسخه أو قم بتنزيله الآن — لا يمكن استرجاعه لاحقًا."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "تم تحديث المجموعة بنجاح"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "تم تحديث طريقة الدفع بنجاح"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "تم حذف العرض بنجاح"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "مجموعة الخيارات {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "أو"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "إدارة العلامات"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "تم حذف رمز القسيمة من الطلب"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "أبدًا"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "فشل تحديث قيمة الخاصية"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "إزالة المجموعة"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "تم تنفيذ الطلب"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "لا يوجد عنوان شحن"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "يحتوي توسيع الاستعلام على صيغة GraphQL غير صالحة"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "خطأ في توسيع الاستعلام"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "خطأ في توسيع الاستعلام:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "توسيع الاستعلام غير صالح: يجب أن يحتوي على حقل واحد على الأقل من المستوى الأعلى"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "عدم تطابق توسيع الاستعلام:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "عام"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "تم تحديث الفئة الضريبية بنجاح"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "نقل"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "تحرير أو حذف العلامات الموجودة"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "شروط فاحص أهلية طريقة الشحن هذه غير مستوفاة للطلب الحالي وعنوان الشحن."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "إضافة رمز قسيمة"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "تم تعيين رمز القسيمة للطلب"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "الحقول المخصصة"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "طريقة شحن جديدة"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "حذف مواقع المخزون"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "أكبر من أو يساوي"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "معاينة"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} من {1} متاح للتنفيذ"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "من بداية الشهر حتى اليوم"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "طلب العميل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "تضرر أثناء الشحن"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "غير متاح"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "أخرى"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "منتج خاطئ"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "ملخص التعديلات"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "الاستردادات ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "آخر تنفيذ"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "تفاصيل الدفع"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "إعادة بناء فهرس البحث"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "قيد التشغيل"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "كل 60 ثانية"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "فشل تحديث مجموعة العملاء"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "البيانات الوصفية للدفع"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "إلغاء التعديل"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "نفس النافذة"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "طبق الفلاتر على الجدول وانقر على \"حفظ العرض\" للبدء."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "الأدوار"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "مطلوب دفع إضافي"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "فشل تحديث الطلب"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "مع المحدد..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "فشل إنشاء موقع المخزون"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "أصغر من أو يساوي"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "أعضاء مجموعة العملاء {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "الحالة"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "عدم التتبع"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "تم إنشاء التنفيذ #{0}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "تشغيل تحديثات فهرس البحث المعلقة"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "هذا دور افتراضي ولا يمكن تعديله"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "عروضي المحفوظة"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "الولاية / المحافظة"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "ممكّن"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "العناصر في الصفحة"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "تحرير الأعضاء"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "المخزون المتاح"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "تصفية حسب {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "المعرف"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "التنبيهات"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "قيم الخيارات"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "معاينة التغييرات"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "فشل في إزالة {entityType} من القناة"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "تم حذف الشكل بنجاح"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "تعديل خصائص الرابط المحدد"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "المبيعات"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "حدد مجموعة وجهة"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "أحدث طلباتك"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "المهام المجدولة"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "هل أنت متأكد من حذف هذا العنصر؟ لا يمكن التراجع عن هذا الإجراء."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "الأشكال"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "البائعون"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "الإعدادات"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "متجر الإعدادات"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "عنوان 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "مرحباً بك في Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "طرق الشحن"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} قابل للاسترداد)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "المعرف"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "فشل تحديث المجموعة"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "السعر والضريبة"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "لم يتم العثور على الطلب"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "خطأ"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "تم تعديل الطلب"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "تم طلب إعادة تعيين كلمة المرور"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "يجب أن يساوي مبلغ الدفع المخصص إجمالي الاسترداد"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "مثل صغير"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "هل أنت متأكد من إزالة {0} {entityType} من القناة الحالية؟"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "إضافة علامات..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "فشل إنشاء مجموعة خيارات المنتج"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} عنصر محدد"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "بحث في اللغات..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "مواقع المخزون"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "الانتقال إلى الصفحة السابقة"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "المحتويات"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "فشل تحويل العرض العام إلى عرض شخصي"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "نتيجة المهمة"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "إضافة دفع ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "النظام"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "اسم المتغير"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "إزالة"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "فشل تحديث العميل"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "إزالة مجموعات الخيارات؟"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "هذه معاينة لمحتويات المجموعة بناءً على إعدادات المرشح الحالية. بمجرد حفظ المجموعة، سيتم تحديث المحتويات لتعكس إعدادات المرشح الجديدة."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {تمت إزالة عميل واحد من المجموعة} two {تمت إزالة عميلين من المجموعة} few {تمت إزالة {count} عملاء من المجموعة} many {تمت إزالة {count} عميلاً من المجموعة} other {تمت إزالة {count} عميل من المجموعة}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "فئات الضرائب"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "معدلات الضرائب"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "فشل في إزالة العملاء من المجموعة"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "فشل تحميل الإعدادات العامة"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "اختر العناصر للاسترداد وإعادتها للمخزون اختياريًا"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "حفظ"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "تم تحديد {selectedRowCount} من {0} صف (صفوف)."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "معاينة تعديلات الطلب"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "تم تحديث مجموعة خيارات المنتج بنجاح"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "ستستمر الصفحة بالاستعلام الافتراضي."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "عنوان الشارع"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "لا توجد فئات أخرى"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "بدأت إعادة بناء فهرس البحث"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "تم تحديث موضع المجموعة"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "اسم مجموعة الخيارات"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "إضافة \"{newOptionInput}\\"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "شكل منتج جديد"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "تم نقل الاسترداد"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "استخدام استراتيجية المصادقة الأصلية"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "فشل في تعيين {entityIdsLength} {entityType} للقناة"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "اللغة الافتراضية"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "الرمز المميز"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "جارٍ التنفيذ..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "إضافة مجموعة خيارات إلى المنتج"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "معاينة {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "تم تحديث البائع بنجاح"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "فشل نقل الطلب إلى الحالة"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "عرض الكل ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "فشل إنشاء معدل الضريبة"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "لقد حفظت مفتاح API هذا"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "تكوين اللغات المتاحة لمتجرك وقنواتك"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "تم إنشاء المنتج بنجاح"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "إضافة شكل منتج"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "اكتب ثم اضغط Enter أو الفاصلة للإضافة."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "تحرير الملاحظة"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "لم يتم العثور على ملفات. حاول تعديل عوامل التصفية."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "إضافة خيار"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "حفظ مجموعة الخيارات"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "إنشاء {createCount} شكل"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "انقر على \"تشغيل الاختبار\" لاختبار طريقة الشحن هذه."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "تم تحديث المسؤول بنجاح"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "مسح الفلاتر"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "التنفيذ #{0} من {1} إلى {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "فشل حذف العرض العام"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "اللغة الافتراضية"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "الحالة"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "لم يتم العثور على خيارات"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "ثنائي"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "تم تحديث مجموعة الخيارات بنجاح"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "طريقة شحن جديدة"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "كل 10 ثوانٍ"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "بدون ضريبة:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "إضافة مخزون إلى الموقع"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "تمت إضافة قيمة الخيار بنجاح"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "تم نقل المجموعة إلى مجموعة أصل جديدة"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "تمت إزالة مجموعة الخيارات"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "الانتقال إلى الحالة المحددة"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "سيكون مطلوبًا دفع إضافي بقيمة {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "تتبع المخزون افتراضيًا"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} من {total} محدد"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "تم إنشاء طريقة الشحن بنجاح"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "مجموعة عملاء جديدة"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "مرئي للعميل"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "تم إنشاء مجموعة الخيارات بنجاح"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "معدلات الضرائب"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "سيتم إنشاء الرابط المختصر تلقائيًا..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "لم يتم العثور على العميل"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "تحديد {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "قيم خصائص جديدة للإضافة:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "فشل في معالجة الاسترداد"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "الاسم الأول"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "يحتوي على"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "لم يتم العثور على مجموعات خيارات"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "لم يتم العثور على عناصر"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "المجموع الفرعي"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "العناصر المنفذة ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "تم تحديث القيمة"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "غير مُتحقق منه"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "الكمية"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "إضافة فلتر"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "الفئة الضريبية"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "الملف الشخصي"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "تم تحديث بيانات الاختبار. انقر على \"تشغيل الاختبار\" لرؤية النتائج المحدثة."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "ليس في"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "تم تحديث بند الطلب"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "طريقة دفع جديدة"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "القيمة المكررة \"{trimmed}\" موجودة بالفعل"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "السبب"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "مجموعات العملاء"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "تمت إزالة {entityType} من القناة بنجاح"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "مجموعات الخيارات"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "إضافة رسوم إضافية"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "قيم الخصائص الحالية"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "صفحة {page} من {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "الشهر الماضي"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "إضافة بلد"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "إزالة العنصر"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "فيديو"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "أصغر من"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "تعذرت إضافة المتغير. تأكد من تفعيل المنتج الأصلي."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "حدث خطأ غير معروف"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "المقاييس"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "اللغة"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "مجموعة جديدة"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "استرداد وإلغاء الطلب"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "تم التحقق من تحديث البريد الإلكتروني"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "بين"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "استرداد وإلغاء"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "جارٍ اختبار طرق الشحن..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "فشل إنشاء طريقة الشحن"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "تم تعيين {entityIdsLength} {entityType} إلى القناة بنجاح"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "اللغات العامة"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "مسؤول جديد"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "حذف المسودة"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "المصدر"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "لا توجد إجراءات متاحة"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "فشل تحديث القناة"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "عام"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "فشل في إزالة المنتج من القناة"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "إضافة عنوان جديد"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "تم تحديث الخاصية بنجاح"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "تم إنشاء المنطقة بنجاح"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "القيمة"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "تم تحديث العميل"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "عامل تحويل السعر"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "طلب البائع"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "خاصية جديدة"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "هل أنت متأكد أنك تريد إزالة مجموعة الخيارات هذه من المنتج؟"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "الوصف (نص بديل)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "لم يتم العثور على علامات"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "العملة الافتراضية"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "لا يلزم دفع أو استرداد لهذه التغييرات."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "إجمالي الإيرادات"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "التنفيذ التالي"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "الملاحظة خاصة"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "تاريخ متوسط"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "رقم غير صالح"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "لم تحفظ أي عروض بعد."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "هل أنت متأكد من حذف هذا العرض؟ لا يمكن التراجع عن هذا الإجراء."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "عرض عملية الطلب"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "فشل نسخ العرض"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "استخدام كعنوان شحن افتراضي"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "تحرير الرابط المختصر يدويًا"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "أضف مرشحات لمعاينة محتويات المجموعة."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "مجموعة خيارات المنتج"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "المجموع الفرعي"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "أصغر من"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "معرف الاسترداد"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "تم تحديث الحقول المخصصة للطلب"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "الحاسبة"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "فشل في إزالة مجموعة الخيارات من القناة: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "عرض بيانات المهمة"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "النقل إلى المستوى الأعلى"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "مسح"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "ملخص الطلبات"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "البحث في الملفات..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "خاصية جديدة"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "تعيين {entityType} إلى القناة"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "متابعة"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "العروض الترويجية"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "رسالة الخطأ"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "إضافة مستوى المخزون لموقع آخر"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "حذف العنوان"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "فشل تحديث الخاصية"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "يجب استخدام useWidgetFilters داخل WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "تحرير العنوان"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "فشل إزالة الخاصية من القناة: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "تعيين الرابط"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "بائع جديد"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "تحرير الصورة"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "إدارة الأشكال"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "مخزون مخصص"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "أكبر من أو يساوي"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "يحدد مستوى المخزون الذي يعتبر عنده هذا الشكل نفد من المخزون. استخدام قيمة سالبة يمكّن دعم الطلب المسبق."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "إنشاء خيارات المنتج"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "جارٍ الحفظ..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "عرض النتيجة"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "صفوف لكل صفحة"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "جارٍ تحميل المجموعات..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "تم تحديث قيمة الخاصية بنجاح"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "إضافة ملف"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "حفظ التغييرات"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "تمت إضافة العميل إلى المجموعة"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "طلبات البائعين"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "فشل إضافة قيمة الخيار"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "إضافة قيمة خيار إلى {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "تم استرداد {totalQuantity} عنصر(عناصر)"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "لم يتم تعريف مجموعات خيارات بعد. أضف مجموعات خيارات لإنشاء أشكال مختلفة من منتجك (مثل الحجم، اللون، المادة)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "البريد الإلكتروني الجديد:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "فشل تحديث طريقة الدفع"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "متاح:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "تم الإنشاء في"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "فشل إنشاء شكل المنتج"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "اللغة: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "ليس لديك إذن لعرض إعدادات اللغة العامة"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "تم إنشاء معدل الضريبة بنجاح"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "عنوان 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "رموز قسائم مضافة"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "نشط"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "أساس الضريبة"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "تحميل المزيد"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "تم تسوية الاسترداد"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "مفتاح API"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "تم نسخ {count} {entityName} بنجاح"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "مجموعة خيارات جديدة"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "لا توجد نتيجة بعد"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "تم تسوية الدفع"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "الشروط المتاحة"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "عوامل التصفية النشطة"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "مسح الكل"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "أكبر من"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "إغلاق"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "إضافة دفع إلى الطلب"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "جارٍ التحميل..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "يُستخدم الرمز المميز لتحديد القناة عند إجراء طلبات API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "لم يتم العثور على عناوين"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "معرف التنفيذ"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "اختر المدفوعات للاسترداد"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "فشل حذف {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "حد نفاد المخزون"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "تمت إزالة المنتج من القناة بنجاح"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "فشل في تحديث القيمة"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "فشل في إنشاء مفتاح API"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "تسوية الاسترداد"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "طريقة الدفع مطلوبة"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "فشل إضافة العميل إلى المجموعة"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "إدارة الأشكال"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "تم تطبيق العرض العام \"{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "تم تسجيل العميل"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "المناطق"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "البحث في البائعين..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "تم إنشاء العرض الترويجي بنجاح"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "الخيار"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "عملية الطلب"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "رقم الهاتف"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "خاص"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "الشكل"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "تم تحديث الإعدادات العامة بنجاح"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "تم تحديث مفتاح API بنجاح"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "ستكون هذه اللغات متاحة لجميع القنوات للاستخدام"

--- a/packages/dashboard/src/i18n/locales/bg.po
+++ b/packages/dashboard/src/i18n/locales/bg.po
@@ -13,1553 +13,1553 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Пълно име"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Изберете елементи"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Виж промените"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Проследяващ код"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Избраните разрешения ще бъдат приложени към тези канали."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Продуктови опции"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Нова данъчна ставка"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Присвоете съществуваща група опции или създайте нова"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Нова роля"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Апартамент, офис и др."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Няма повече елементи"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Редакция на връзката"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Добавете поне един артикул към поръчката"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Добавете продукти, за да създадете тестова поръчка"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Неуспешно създаване на адрес"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Превключване на всички"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Редактиране на JSON стойност"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Използване на външна стратегия за удостоверяване: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Изберете причина..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Заглавие 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Неуспешно добавяне на плащане"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Актуализиран"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Неуспешно актуализиране на глобалните настройки"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Успешно изпълнена поръчка"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Сигурни ли сте, че искате да изтриете {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Глобален праг за изчерпване"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Управление на езици"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Дублиране... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Изтрито успешно"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Премахване от текущия канал"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Изтрити {selectionLength} медийни файла"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Успешно актуализирана данъчна ставка"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Въведете персонализирана причина..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Тип"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Изберете {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Виж стойности"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Изтриване на ред"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Условия"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Текущ"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Без изпълнения"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Неуспешно изтриване на {1} складова локация: {messages}} other {Неуспешно изтриване на {2} складови локации: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Когато това е разрешено, цените, въведени в продуктовия каталог, ще бъдат включени в данъка за данъчната зона по подразбиране."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Създай варианти за вашия продукт"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Проектът на поръчката е завършен"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Автоматично опресняване: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Здравни проверки"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Изтрито {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Здравни проверки"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Продавачи"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Опции"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {Успешно е отменена {fulfilled} задача} other {Успешно са отменени {fulfilled} задачи}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Продавач"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Добавяне на плащане"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Тествайте този метод на доставка, като симулирате поръчка, за да видите дали отговаря на условията и каква ще бъде цената за доставка."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Разгледайте Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Складови местоположения"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Манипулатор на изпълнение"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Поръчки"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Избор на роли"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Успешно създадена роля"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Сигурни ли сте, че искате да изтриете този вариант?"
 
 #~ msgid "Light"
 #~ msgstr "Светло"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Всички ресурси работят"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Неуспешно създаване на администратор"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Не"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Успешно актуализиран вариант на продукта"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Неуспешно изтриване на {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Успешно актуализиран продукт"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Неуспешно актуализиране на държавата"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Въведете поне 2 знака за търсене..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Фамилия"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Заглавие на връзката"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Успешно актуализирана клиентска група"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Персонализираните полета са променени"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Успешно създадено складово местоположение"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Неизвестна грешка"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Общата сума за възстановяване не може да бъде отрицателна"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Виж подробности"
 
 #~ msgid "Month to date"
 #~ msgstr "Месец до днес"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Изберете канал, към който да присвоите {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Успешно създаден клиент"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Последните 7 дни"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Неуспешно създаване на канал"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Режим за разработка"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Нова роля"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Неуспешно изтриване на медийни файлове: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Върни в наличност"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Видимост"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Варианти на продукта"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Нова клиентска група"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Създаване на „{0}“"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Преименуване"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Изберете предпочитания език за показване и регионални настройки"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "Успешно премахнати {successCount} групи опции от канала"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Методът на доставка не отговаря на условията за тази поръчка"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Неуспешно актуализиране на адреса"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Адресът е изтрит успешно"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Данъчна ставка"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Черновата на поръчката не е готова за завършване"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Нова колекция"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Анализи"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Старирай"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Неуспешно актуализиране на данъчната ставка"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Това е съдържанието на колекцията <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "частен"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Успешно създадена продуктова опция"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Основен продукт"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Град"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Администратори"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Цена бруто: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Към следващата страница"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Премахване на връзката"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Това поле е само за четене"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Брой поръчки"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Успешно актуализирана поръчка"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Наследяване на филтри"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Управлявайте глобални запазени изгледи, които са видими за всички потребители"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Търсете начини на плащане..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Адресът за доставка не е зададен за поръчка"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Създаване на {enabledCount} варианта"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Плащане №{0} е прехвърлено на {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Грешка при зареждането на клиентската история: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "Успешно премахна {selectionLength} {entityType} от канала"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Добавете стойност на опцията"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Глобални настройки"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "е след"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Успешно актуализирана продуктова опция"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Редактирайте стойностите на атрибутите"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Добавяне..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Преместване на колекции"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Роли"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Изглед мрежа"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Неуспешно изтриване на адреса"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Няма налични методи за доставка"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Глобалният изглед е преобразуван успешно в личен изглед"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Изпълнението е прехвърлено"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Сигурни ли сте, че искате да изтриете {selectionLength} медийни файла?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Вход"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Изглед списък"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Тестова поръчка"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Изберете клиент, за да продължите"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Групата опции е успешно присвоена"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Изпълнете тест"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Данъчна ставка: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Моля, добавете продукти и попълнете адреса за доставка, за да стартирате теста."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Превключване на заглавния ред"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Изберете адрес"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Проверка на допустимостта на плащанията"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Данъчна зона по подразбиране"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Черновата на поръчката е готова за завършване"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Метаданни"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Филтър..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Нова стойност на атрибут"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Каналът е актуализиран успешно"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Покажи по-малко"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Кратка дата"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Налични валути"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Изберете {0} елементи"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Поставен при"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Ротацията на този ключ незабавно ще обезсили текущия ключ. Всички интеграции, които го използват, ще спрат да работят, докато не бъдат актуализирани с новия ключ."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Данните, които са предадени на заданието"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Потвърдете навигацията"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Цел за връзка"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Приключи черновата"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Име"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Неуспешно изпълнение на поръчката"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Общо"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Въведете ID на транзакцията за това възстановяване"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Вашият API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Сигурни ли сте, че искате да изтриете тази чернова на поръчка?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Създадено изпълнение"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Намерен е {0} отговарящ на условията метод за доставка{1}"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Размери"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Покажи парола"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(макс: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Компания"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Добавете колона след"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Действия"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Отстъпки"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Въведете бележка за възстановяване"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Редът за поръчка е премахнат"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Съдържание:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Ключ"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Потвърдете"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Неуспешно създаване на колекция"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Към първа страница"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Неуспешно създаване на продукт"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Клиент"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Грешка при зареждането на хронологията на поръчките: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Зададен адрес за доставка за поръчка"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Фокусна точка"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Единичен вариант, без опции"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Изберете следващото състояние за поръчката"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Локализация"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Планирани задачи"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Въведете ID на транзакцията"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Обновяване на данните"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Добавяне или премахване на стойности на аспект за {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Това са стойностите на атрибута за атрибута <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Успешно добавено плащане към поръчката"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Адресът за фактуриране е зададен за поръчка"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Неуспешно актуализиране на зоната"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Парола"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Неуспешно изтриване"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Планираната задача ще бъде изпълнена"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Ново складово местоположение"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Разрешения"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Адресът за доставка е променен"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Няма намерени продукти"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Добавете ред преди"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Преход към {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Този месец"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Неуспешно създаване на аспект"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Неуспешно анулиране на артикули от поръчката"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID на транзакцията"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Разпределени"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Добавете друга група опции"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Изберете какво да се направи с останалата наличност"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Разгледайте Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "На всеки 5 секунди"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Успешно създадена колекция"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Цена"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Чернова на поръчка"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Обхват"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Добавяне на условие"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Методът на доставка отговаря на условията за тази поръчка"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Администратори"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Премахнат от групата"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Ширина"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Не се изисква плащане или възстановяване"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Изтегляне като .env файл"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Когато е активирано, в магазина е налична промоция"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Когато се проследяват, нивата на складови наличности на варианти на продукта ще бъдат автоматично коригирани при продажба. Тази настройка може да бъде заменена от отделни варианти на продукта."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Начин на доставка, зададен за поръчка"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Неуспешно актуализиране на промоцията"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Изображения"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Търсене на {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Редакция на актив"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Отказ от плащането"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Опашка от задачи"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Медия"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Имейл адрес"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Регенерирайте slug от изходното поле"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Наследяване от глобалните настройки"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Няма намерени резултати"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Текущо състояние"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Задайте адрес за доставка и изберете метод на доставка"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Изкл"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Настройки на магазина"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Опашка"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Нова данъчна ставка"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Плащането е прехвърлено"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Остават:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Не е намерен дубликатор с код „{duplicatorCode}“ за {entityName}s"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Цените включват данък за данъчна зона по подразбиране"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Общо възстановяване:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Виж резултата от задачата"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Тествайте вашите методи за доставка, като симулирате нова поръчка."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Няма избрани елементи"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} избрани"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Няма намерени държави"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Вариантите са създадени успешно"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Автоматично генериране на slug"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Доплащане"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Начини на плащане"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Наличност"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Няма намерени клиенти"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Използвайте глобалния праг за изчерпване"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Нова група продуктови опции"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Състоянието на плащането е актуализирано успешно"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Създаване на нов"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Общо за възстановяване"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Адресът е изтрит"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Налични са само ролите, присвоени на вашия акаунт."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Артикулът е добавен към поръчката"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Редактиране на фокусната точка"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Няма намерени продавачи"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Ресурс"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Тази група опции се използва от един друг продукт. Промените ще засегнат и него.} other {Тази група опции е споделена между # продукта. Промените ще засегнат всички.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Моите запазени изгледи"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Нов канал"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Неуспешно създаване на продавач"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Конфигуриране на настройките за дублиране на {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Няма варианти, отговарящи на текущия филтър."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Адреси"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Добавяне на нова стойност на опция към групата опции {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Модификация на поръчката №{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Добавете колона преди"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Езици на канала"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Неуспешно създаване на група опции"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Вярно"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Изберете клиент"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Поръчката е прехвърлена"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Този продукт има съществуващи варианти, но няма дефинирани групи опции. Трябва да добавите групи опции, преди да създадете нови варианти."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "е преди"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Изтриване на чернова на поръчка"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Каталог"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Нов начин на плащане"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Успешно актуализирана промоция"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Неуспешно отменяне на {rejected} задача} other {Неуспешно отменяне на {rejected} задачи}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Изберете канал"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Език на дисплея"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Подробности за изпълнението"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Отписване на останалата наличност"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Сега"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Канали"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Изгледът е успешно преобразуван в глобален"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "преди"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Размер"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Няма намерен превод за {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Нов клиент"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Последни поръчки"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ още {leftOver}"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Използвайте като адрес за фактуриране по подразбиране"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Изтриване"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Деактивиране"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Колекции"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Добавяне на вариант"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Неуспешно създаване на държава"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Държави"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Неуспешно създаване на продуктови опции"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Неуспешно преименуване на изглед"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Налично"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Нормално"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Филтри"
 
@@ -1567,3296 +1567,3296 @@ msgstr "Филтри"
 #~ msgstr "Последните 7 дни"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Групи клиенти"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Клиенти"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Примерно форматиране"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Нова опция"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Ограничение за използване"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Глобалните настройки се зареждат..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Адресът е актуализиран успешно"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Създаден"
 
 #~ msgid "System"
 #~ msgstr "Система"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Адресите се зареждат..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Изберете целева колекция, към която да преместите {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Данните за клиента са актуализирани"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "не в"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Приложи"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Опция за нов продукт"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Към последната страница"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Отказ"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Успешно създаден вариант на продукта"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Възстановяване от този метод"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Пощенски код"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Първо добавете опции за продукта"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Нова данъчна категория"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Добавяне на опция"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Частичното възстановяване е завършено"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Задайте потребителски полета"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Колекции"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Изтриване на вариант"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Няма направени модификации"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Зона за доставка по подразбиране"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Причина:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Адрес за доставка"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Преход към {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Данъчни категории"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "В магазина не се виждат частни колекции"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Когато е активирано, даден продукт е наличен в магазина"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Планираната задача не можа да бъде изпълнена"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Групи клиенти"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Забранено"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Нова промоция"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Адрес за доставка по подразбиране"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Изисква се възстановяване"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Изпълнете поръчката"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Нямате разрешение да видите настройките на канала"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Последните 30 дни"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Няма атрибутни стойности"
 
 #~ msgid "Today"
 #~ msgstr "Днес"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Необходима е причина за възстановяването"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Групата опции не може да бъде премахната"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Неуспешно актуализиране на данъчната категория"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Възстановяването е приключено успешно"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Актуализация"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Заглавие 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Поръчката е направена"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Профилът е актуализиран успешно"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "край"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Начин на плащане"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Редакция"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Вариантът е актуализиран успешно"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Филтриране по име на колекция"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Добавена е бележка"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Изберете количества за изпълнение и конфигурирайте манипулатора за изпълнение"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Адресът за фактуриране не е зададен за поръчка"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Започва в"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Дубликат"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Няма резултати"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Настройки на колони"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Неуспешно изтриване на {count} складова локация} other {Неуспешно изтриване на {count} складови локации}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Код"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Неуспешно премахване на групи опции"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Поръчката е доставена"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Прехвърляне към {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Останала наличност"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Премахни от зона"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Изберете от глобално наличните езици за този канал"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Сигурни ли сте, че искате да изтриете този адрес?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Неуспешно присвояване на група опции"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Неуспешно актуализиране на актива"
 
 #~ msgid "Active"
 #~ msgstr "Активен"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Успешно актуализирано складово местоположение"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Потвърдете действие"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Успешно актуализирана държава"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Атрибути"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Неуспешно добавяне на бележка"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Неуспешно изтриване на бележка"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Неуспешно разширяване на документа за заявка"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Актуализирането на бележката не бе успешно"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Възстанови доставка"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Само за четене"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Неуспешно дублиране на глобален изглед"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Показани {shown} от {total} • избрани {selected}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Тестване на метод за доставка"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Атрибутни стойности"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Успешно актуализиран актив"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Тема"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} клиенти"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Изберете език"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Изход"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Опити"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Налични валутни кодове"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Налични езикови кодове"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Навигационни пътеки"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Категория"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Канали"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Дъщерни елементи"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Код"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Код на купон"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Създаден на"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Валутен код"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Клиент"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Група клиенти"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Клиенти"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Потребителски полета"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Данни"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Валутен код по подразбиране"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Езиков код по подразбиране"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Зона за доставка по подразбиране"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Данъчна зона по подразбиране"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Описание"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Продължителност"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Имейл адрес"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Активирано"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Приключва на"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Грешка"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Основно изображение"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Име"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Код на обработчика на изпълнение"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "По подразбиране"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Частен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Приключен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Фамилия"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Име"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Поръчката е направена на"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "Родителско ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Лимит на използване на клиент"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Права"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Позиция"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Цена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Цените включват данък"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Цена с данък"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Варианти"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Напредък"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Име на опашката"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Резултат"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Опити"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Продавач"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Приключено на"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Доставни позиции"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Започнало на"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Започва на"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Състояние"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Нива на наличност"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Токен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Общо"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Общо с данък"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Тип"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Актуализирано на"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Лимит на използване"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Потребител"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Стойност"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Списък със стойности"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Зона"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Метод"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Данъчно резюме"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Задава езиците, които са налични за всички канали. След това отделните канали могат да поддържат подгрупа от тези езици."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Колекциите са преместени успешно"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Регистриран"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Отмени задание"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Завършва в"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Страница {0} от {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Ставка"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Размер, цвят и т.н."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Преглед на атрибути"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Зона"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Отменено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Създадена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Доставено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Изчакващо"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Изпратено"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Запазване на изгледа"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} избрани"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Търсене на групи опции..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Промяна на реда"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Избрани елементи"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Стойности"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Клиентът е настроен за поръчка"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Атрибути"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Сигурни ли сте, че искате да премахнете {count} клиент от тази група?} other {Сигурни ли сте, че искате да премахнете {count} клиенти от тази група?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Склад на ръка"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Възстановяването на индекса за търсене не можа да бъде стартирано"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Адрес за доставка"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Нова зона"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Нов API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Изтриване на колона"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Присвояване на съществуващ"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "е нула"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Това са клиентите в групата клиенти <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Управлявайте глобалните изгледи"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Канал по подразбиране"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Вмъкване на ново изображение с източник, заглавие и размери"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Неуспешно създаване на стойност на аспекта"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Неуспешно актуализиране на опцията за продукта"
 
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Забравена парола?</0><1>Искане за нулиране</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Код на купон"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Проверен от клиента"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Глобални настройки"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "График"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Не може да се премести колекция в собствен наследник"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Нова данъчна категория"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Няма налични складови местоположения за текущия канал"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Успешно създаден канал"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Успешно актуализиран клиент"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Виж данни"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Изтриване на изглед"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Добавете нов адрес към клиента."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Още гледания"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Редактиране на свойствата на избраното изображение"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Приложен изглед „{viewName}“"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Успешно премахнати {successCount} атрибути от канала"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Нов продукт"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Нов актив"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Преизчисляване на доставката"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Изберете кои опции да се прилагат към съществуващия вариант „{0}“"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Медия"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Това ще премахне всички групи опции от този продукт и ще се върне към избора за настройка на варианти."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Адрес за фактуриране"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Добавете стойност на аспекта"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Моля, изберете целева колекция"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Прегледайте промените, преди да ги приложите към поръчката."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Изберете роля"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Поръчката е отменена"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Отстъпка"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Всички типове"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Само черновите на поръчки могат да бъдат завършени"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Неуспешно актуализиране на продукта"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Коригиране на {0} линии"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Добавете стойности на аспекти"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "след"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Канал"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Здравни проверки"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Сума"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Телефонен номер"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Нов клиент"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Изображение"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Успешно създаден администратор"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Опции на продукта"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Изберете държава"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Създава се..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Сигурни ли сте, че искате да изтриете този глобален изглед? Това действие не може да бъде отменено и ще засегне всички потребители."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Принудително премахване на група опции"
 
 #~ msgid "Current"
 #~ msgstr "Текущ"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Добавено"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "История на клиента"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Успешно актуализирани стойности на атрибути за {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Неуспешно премахване на клиент от групата"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Система"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Лимит за използване на клиент"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Адресът за фактуриране е променен"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Изберете опция"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Копиране в лични"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Общата сума за възстановяване надвишава максималната възстановима сума от {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Изтриване на глобалния изглед"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Създай"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "На всеки 30 секунди"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Нова държава"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "От {0} до {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Неуспешно създаване на клиент"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Фокусната точка е актуализирана"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Стойности на опциите"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Адрес за фактуриране по подразбиране"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Няма клиент"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Неуспешно премахване на държави от зоната"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Неуспешно създаване на промоция"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Днес"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Вчера"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Име на опцията"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Сигурни ли сте, че искате да премахнете {0} {1} от тази зона?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Добавяне на {0} надценка(и)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Линк href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Резервна стойност: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "История на поръчките"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Презапиши"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "Изисква се ID на транзакцията"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "съответства на регулярен израз"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Глобалният изглед е преименуван успешно"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Няма избрани етикети"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Назад"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Изгледът е преименуван успешно"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Приложи филтър"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Последен резултат"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Добавен към групата"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Анализи"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Създаване на варианти"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Тестване на метода на доставка..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Тъмен"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Резултати от теста"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Добавете клиент"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Запазване на промените"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Адресът е актуализиран"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Възстановяването е обработено успешно"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Нова зона"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Неуспешно актуализиране на позицията на колекцията"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Възстановяване"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Променете"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Няма конфигурирани глобални езици"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Премахване на {0} елемент(а)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Проследяване"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Създай вариант"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Стойности на аспекти за {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Запазване на оформлението"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Новата парола е потвърдена"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Неуспешно изтриване на изглед"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Сигурни ли сте, че искате да напуснете тази страница? Всички незапазени промени ще бъдат загубени."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Превключване на заглавната колона"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Нова промоция"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Име на стойността на опцията"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Последно използван"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Това е данъчна категория по подразбиране"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug е настроен"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Неуспешно актуализиране на фокусната точка"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Успешно актуализирана зона"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Област/провинция"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Неуспешно актуализиране на група опции"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Стандартни настройки на канала"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Неуспешно създаване на данъчна категория"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Задаване на критерии за филтриране за колона {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Държава"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Прост продукт"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Опашка от задачи"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Моля, потвърдете, че сте запазили API key преди затваряне."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Потвърдете изтриването"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Неуспешна промяна на поръчката"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Включва данък от {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Метрики за поръчка"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Изберете език на дисплея"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Методи за удостоверяване"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "начало"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Неуспешна ротация на API key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "в"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Търсене на роли..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Варианти"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Управление на глобалните изгледи"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Обработка..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "Намерени {totalItems} {0}"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Изберете период от време"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Продукт"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Ротация на API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Категория"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Преместване..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Присвояване"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Успешно създаден продавач"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Методът на доставка бе актуализиран успешно"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Неуспешно актуализиране на варианта на продукта"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Плъзнете, за да пренаредите"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Зони"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Изберете какво да се направи с наличността, останала в {count, plural, one {# складова локация} other {# складови локации}}, които изтривате. Всички избрани локации прехвърлят останалата си наличност в единствената локация, която изберете, или я отписват."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Търсене на стойности на аспекти..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Бележка"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Налични езици"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Зареди още {0} ({remaining} оставащи)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Атрибутни стойности"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Неуспешно пренареждане на артикули"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Общ брой поръчки"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Не са намерени отговарящи на условията методи за доставка за тази поръчка."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Добавете опция за продукт"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Доставка"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions трябва да се използва в рамките на DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Тази група опции се използва от съществуващи варианти. Принудителното й премахване може да ги засегне. Сигурни ли сте?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Изискана е актуализация по имейл"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Грешка при преминаване към състояние"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Успешно създадена клиентска група"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Нов прозорец"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Разрешено плащане"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Успешно актуализирана роля"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Изберете държава"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Неуспешно актуализиране на метода на доставка"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Изтрита е {deleted} складова локация} other {Изтрити са {deleted} складови локации}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Методи за доставка"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Изберете адрес"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Да"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Задаване на фокусна точка"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "край"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Изберете валута"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Актуализирайте съдържанието или видимостта на бележката"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Уиджет за най-нови поръчки"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Съдържание на колекция за {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Методът на доставка е променен"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Описание на данък"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "е по-малко или равно на"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "не е равно на"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Опресняване"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "напр. Размер"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Приклюи плащане"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Канали"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Доставката е възстановена"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Тип на ресурса"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Ново складово местоположение"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} плащане(я) възстановени преди грешката. Проверете историята на поръчката за подробности."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Изберете елемент"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Нов продукт"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Управление на етикети"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Възстановени артикули"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Добавяне на действие"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Присвояване на опции към съществуващ вариант"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Дублиране на {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Премахване от група"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Неуспешно актуализиране на състоянието на изпълнение"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Създаване на нов вариант на продукт с опции, ценообразуване и наличност"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Частните аспекти не се виждат в магазина"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Изберете данъчна категория"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Създадено"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Не работи"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Присвоен"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Заглавие 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Изберете Налични езици"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Добавяне на {0} елемент(а)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Добавете ред след"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Данък общо"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Статус на чернова на поръчка"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Успешно създадени продуктови опции"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Зареждане на локации…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Неуспешно създаване на метод на плащане"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Успешно създадена стойност на аспекта"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Маркетинг"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Черновата на поръчката е изтрита"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "по-голямо от"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Уиджет за показатели"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Търсене на валути..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Премахване от канал"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Заглавие"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Вмъкване на изображение"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Неуспешно актуализиране на продавача"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Успешно създадена държава"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Изберете продавач"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Таговете се зареждат..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Атрибутът е създаден успешно"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} варианта"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Неуспешно плащане"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Няма адрес за фактуриране"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Неуспешно изтриване на {1} складова локация} other {Неуспешно изтриване на {2} складови локации}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Атрибут"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Не може да се премахне от активния канал"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Не е зададено"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Принудително премахване"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Нов канал"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Име на група опции"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "И"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Неуспешно създаване на клиентска група"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Неуспешно създаване на роля"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Име на продукта"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Състоянието на изпълнение е актуализирано успешно"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Продукти"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Адресът е създаден"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "Ротацията на API key е успешна"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Добавете група опции"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Възстановяване {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Въведете slug ръчно"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Няма налични приспособления"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Неуспешно анулиране на плащането"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Плащането е отменено успешно"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Глобалният изглед е дублиран успешно"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Създаден от"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Филтриране на варианти..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Добавете цена в друга валута"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Имейл адрес или идентификатор"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Възстановената сума №{0} е прехвърлена към {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Клиенти"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Заглавие 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Неуспешно актуализиране на складовото местоположение"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Поръчката е изпратена"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Запазване на адреса"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Направи глобален"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Изберете следващо състояние"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Няма сигнали"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Преместване на {0} колекция{1} в {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Тест"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "между"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Бележката е добавена успешно"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Бележката е изтрита успешно"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Бележката е актуализирана успешно"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Неуспешно възстановяване на сумата"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Ниво на склад"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Добавете елемент"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API key е създаден успешно"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Зареждане на прегледа..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Назад към търсенето"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Прегледът е дублиран успешно"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Премахване на група опции"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Описание"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Държави"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Улица 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Глобалният изглед е изтрит успешно"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Редакция на оформлението"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Присвояване на канал"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Тази седмица"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Успешно създадена група продуктови опции"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Добавете ръчно плащане на {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "е в"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "Имейл"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Неуспешно актуализиране на администратора"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Управлявайте личните си запазени изгледи за тази таблица"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Филтриране по тагове"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Влезте за достъп до администраторското табло"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Добавете плащане към поръчката ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Грешно"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Светъл"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Нулиране"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "е равно на"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Създай опции"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Паролата е актуализирана"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "не съдържа"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Група опции"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Редактирайте подробностите за адреса по-долу."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Успешно създадена данъчна категория"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Неуспешно преместване на колекции"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Неуспешно актуализиране на състоянието на плащането"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Резюме на вашите поръчки"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Качване"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Продукт с опции"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Показани са всички {0} резултати"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Идентификатор за търсене"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ още {0}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Групи опции"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Персонализирани полета"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Всички възможни състояния на поръчката и техните преходи. Текущото състояние е маркирано."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Поръчки"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Уиджет за обобщение на поръчките"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Добавяне на артикули"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Уреждане на допълнително плащане"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Уреждане на плащане"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Отменена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Създадена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Доставена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Чернова"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Променя се"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Частично доставена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Частично изпратена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Плащането е разрешено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Плащането е приключено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Изпратена"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Наблюдавани ресурси"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Информация за обекта"
 
 #~ msgid "This month"
 #~ msgstr "Този месец"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Общо за поръчката"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Вижда се само от администратори"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Кол."
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Етикети"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Супер администратор"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Някои ресурси не работят"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Налични действия"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Вмъкване на връзка"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Ако е разрешено, филтрите ще бъдат наследени от родителската колекция и комбинирани с филтрите, зададени в тази колекция."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Изберете зона"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Тестване методите за доставка"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Плащането е приключено успешно"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "Премахнати {0} {1} от зоната"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Активиране"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Начини на плащане"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Разрешено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Отменено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Създадено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Отхвърлено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Грешка"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Неуспешно"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Изчаква"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Приключено"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Средна стойност на поръчката"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Неуспешно създаване на зона"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Нива на склад"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Неуспешно актуализиране на API key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Редове за поръчки"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Неуспешно преименуване на глобалния изглед"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Вмъкване на нова хипервръзка с URL и опции за цел"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Височина"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Изисква се възстановяване на сума от {formattedDiff}. Изберете суми за плащане и въведете бележка, за да продължите."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Единична цена"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Образец на график"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Неуспешно плащане"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Добави канал"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Неуспешно актуализиране на групата опции за продукти"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Търсене на канали..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Добавете групи клиенти"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Налични езици"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Нулиране на избора"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Без адрес"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Успешно създаден начин на плащане"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Информацията за клиента е актуализирана"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Неуспешно преобразуване на изгледа в глобален"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Варианти"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Продукти"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Промоции"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Неуспешно създаване на опция за продукт"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Стар имейл:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Запазете изглед като „Глобален“, за да го направите достъпен за всички потребители."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Неуспешно създаване на варианти"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Задава нивото на наличност, при което този вариант се счита за изчерпан. Използването на отрицателна стойност позволява поддръжка на резервни поръчки. Може да се замени от варианти на продукта."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Ротация на ключ"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Неуспешно създаване на варианти на продукта"
 
 #~ msgid "Dark"
 #~ msgstr "Тъмно"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Скриване на паролата"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Нов продавач"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "напр. Червено, Голямо, Памук"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Неуспешно актуализиране на профила"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Премахнати кодове на купони"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Изчистване на филтъра"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Региони"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Пуснете файлове тук за качване"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Превключване на всички видими варианти"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Проверен"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Нова група опции"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Последна актуализация {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Все още не са създадени глобални изгледи."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Неуспешно актуализиране на ролята"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Това е единственият път, в който пълният API key ще бъде показан. Копирайте го или го изтеглете сега — по-късно няма да може да бъде извлечен."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Успешно актуализирана колекция"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Методът на плащане е актуализиран успешно"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Изгледът е изтрит успешно"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Група опции {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "ИЛИ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Управление на етикети"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Кодът на купона е премахнат от поръчката"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Никога"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Неуспешно актуализиране на стойността на аспекта"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Премахване на групата"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Поръчката е изпълнена"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Няма адрес за доставка"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Разширението на заявката съдържа невалиден синтаксис на GraphQL"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Грешка в разширението на заявката"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Грешка в разширението на заявката:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Разширението на заявката е невалидно: трябва да има поне едно поле от най-високо ниво"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Несъответствие на разширението на заявката:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "публичен"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Успешно актуализирана данъчна категория"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Премести"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Редактирайте или изтрийте съществуващи тагове"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Условията за проверка на допустимостта на този метод на доставка не са изпълнени за текущата поръчка и адрес за доставка."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Добавете код на купон"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Кодът на купона е зададен за поръчка"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Персонализирани полета"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Нов метод на доставка"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Изтриване на складови локации"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "е по-голямо или равно на"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Преглед"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} от {1} налични за изпълнение"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "От началото на месеца"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Заявка от клиент"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Повреден при доставка"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Не е наличен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Друго"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Грешен артикул"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Резюме на модификациите"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Възстановявания на средства ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Последно изпълнено"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Данни за плащане"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Възстановете индекса за търсене"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "В процес"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "На всеки 60 секунди"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Неуспешно актуализиране на клиентска група"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Метаданни за плащане"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Отмяна на модификацията"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Същият прозорец"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Приложете филтри към таблицата и щракнете върху \"Запазване на изгледа\", за да започнете."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Роли"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Изисква се допълнително заплащане"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Неуспешно актуализиране на поръчката"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "С избраните..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Неуспешно създаване на складово местоположение"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "по-малко или равно"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Членове на клиентска група за {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Състояние"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Не проследявайте"
 
@@ -4864,1372 +4864,1372 @@ msgstr "Не проследявайте"
 #~ msgstr "Миналия месец"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Изпълнение №{0} е създадено"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Изпълнение на чакащи актуализации на индекса за търсене"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Това е роля по подразбиране и не може да се променя"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Моите запазени изгледи"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Област / провинция"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Активирано"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Елементи на страница"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Редакция на членове"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Склад на ръка"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Филтриране по {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Известия"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Стойности на опциите"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Преглед на промените"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Неуспешно премахване на {entityType} от канал"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Вариантът е изтрит успешно"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Редактиране на свойствата на избраната връзка"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Продажби"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Изберете целева колекция"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Вашите най-нови поръчки"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Планирани задачи"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Сигурни ли сте, че искате да изтриете този елемент? Това действие не може да бъде отменено."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Варианти"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Продавачи"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Настройки"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Настройки на магазина"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Заглавие 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Добре дошли във Venudre"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Методи за доставка"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} възстановими)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Идентификатор"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Неуспешно актуализиране на колекцията"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Цена и данък"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Поръчката не е намерена"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Грешка"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Поръчката е променена"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Изисква се повторно задаване на парола"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Разпределената сума на плащане трябва да е равна на общата сума за възстановяване"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "напр. малък"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Сигурни ли сте, че искате да премахнете {0} {entityType} от текущия канал?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Добавете тагове..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Неуспешно създаване на група опции за продукти"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} избрани елемента"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Търсене на езици..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Складови местоположения"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Към предишната страница"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Съдържание"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Неуспешно преобразуване на глобален изглед в личен изглед"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Резултатът от задачата"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Добавяне на плащане ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Система"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Име на варианта"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Премахнете"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Неуспешно актуализиране на клиента"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Премахване на групи опции?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Това е визуализация на съдържанието на колекцията въз основа на текущите настройки на филтъра. След като запазите колекцията, съдържанието ще бъде актуализирано, за да отрази новите настройки на филтъра."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {Премахнат {count} клиент от групата} other {Премахнати {count} клиенти от групата}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Данъчни категории"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Данъчни ставки"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Неуспешно премахване на клиенти от групата"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Неуспешно зареждане на глобалните настройки"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Изберете артикули за възстановяване и по желание върнете в наличност"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Запазване"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} от {0} ред(а) избрани."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Преглед на модификациите на поръчката"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Успешно актуализирана група продуктови опции"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Страницата ще продължи със заявката по подразбиране."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Улица"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Без повече аспекти"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Стартира възстановяването на индекса за търсене"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Позицията на колекцията е актуализирана"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Име на група опции"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Добавете „{newOptionInput}“"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Нов вариант на продукта"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Възстановяването е прехвърлено"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Използване на собствена стратегия за удостоверяване"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Неуспешно присвояване на {entityIdsLength} {entityType} към канал"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Език по подразбиране"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Токен"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Изпълнение..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Добавете група опции към продукта"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Преглед на {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Успешно актуализиран продавач"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Неуспешно прехвърляне на поръчка към състояние"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Покажи всички ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Неуспешно създаване на данъчна ставка"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Запазих този API key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Конфигурирайте наличните езици за вашия магазин и канали"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Успешно създаден продукт"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Добавяне на вариант на продукта"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Напишете и натиснете Enter или запетая за добавяне..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Редакция на бележка"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Няма намерени ресурси. Опитайте да промените филтрите."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Добавяне на опция"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Запазете група опции"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Създай {createCount} варианта"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Щракнете върху „Изпълни тест“, за да тествате този метод на доставка."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Успешно актуализиран администратор"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Изчистване на филтрите"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Изпълнение №{0} от {1} до {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Неуспешно изтриване на глобалния изглед"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Език по подразбиране"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Статус"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Не са намерени опции"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Двоичен"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Групата опции е актуализирана успешно"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Нов метод на доставка"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "На всеки 10 секунди"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "пр. данък:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Добавете склад към местоположение"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Успешно добавена стойност на опцията"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Колекцията е преместена в нов родител"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Групата опции е премахната"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Преход към избрано състояние"
 
 #~ msgid "Last 30 days"
 #~ msgstr "Последните 30 дни"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Ще бъде необходимо допълнително плащане от {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Проследяване на инвентара по подразбиране"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "Избрани {selected} от {total}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Методът на доставка е създаден успешно"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Нова клиентска група"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Видимо за клиента"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Успешно създадена група опции"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Данъчни ставки"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug ще се генерира автоматично..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Клиентът не е намерен"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Изберете {0}s"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Нови стойности на аспекти за добавяне:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Неуспешна обработка на възстановяване"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Първо име"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "съдържа"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Няма намерени групи опции"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Няма намерени елементи"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Междинна сума"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Изпълнени елементи ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Стойността е актуализирана"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Непроверено"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Количество"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Добавете филтър"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Данъчна категория"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Профил"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Данните от теста са актуализирани. Щракнете върху „Изпълни тест“, за да видите актуализирани резултати."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "не е в"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Редът за поръчка е актуализиран"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Нов метод на плащане"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Дублираната стойност \"{trimmed}\" вече съществува"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Причина"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Групи клиенти"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} е успешно премахнат от канала"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Групи опции"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Добави надценка"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Текущи атрибутни стойности"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Страница {page} от {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Миналия месец"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Добавете държава"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Премахване на елемент"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Видео"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "по-малко от"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Вариантът не можа да бъде добавен. Уверете се, че родителският продукт е активиран."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Възникна неизвестна грешка"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Метрики"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Език"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Нова колекция"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Възстановяване и анулиране на поръчка"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Имейл актуализацията е потвърдена"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "е между"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Възстановяване и анулиране"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Тестване на методите за доставка..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Неуспешно създаване на метод за доставка"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} успешно присвоен на канал"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Глобални езици"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Нов администратор"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Изтриване на чернова"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Източник"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Няма налични действия"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Неуспешно актуализиране на канала"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Общи"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Неуспешно премахване на продукт от канал"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Добавете нов адрес"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Успешно актуализиран аспект"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Успешно създадена зона"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Стойност"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Клиентът е актуализиран"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Коефициент на преобразуване на цената"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Поръчка на продавача"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Нов аспект"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Сигурни ли сте, че искате да премахнете тази група опции от продукта?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Описание (алт)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Няма намерени етикети"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Валута по подразбиране"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Не се изисква плащане или възстановяване на средства за тези промени."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Общи приходи"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Следващо изпълнение"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Бележката е лична"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Средна дата"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Невалидно число"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Все още не сте запазили изгледи."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Сигурни ли сте, че искате да изтриете този изглед? Това действие не може да бъде отменено."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Преглед на процеса на поръчката"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Неуспешно дублиране на изглед"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Използвайте като адрес за доставка по подразбиране"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Редактирайте slug ръчно"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Добавете филтри, за да прегледате съдържанието на колекцията."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Група продуктови опции"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Междинна сума"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "е по-малко от"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID за възстановяване"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Персонализираните полета на поръчката са актуализирани"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Калкулатор"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Неуспешно премахване на група опции от канал: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Виж данните за задачата"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Преминете към най-горното ниво"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Изчисти"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Резюме на поръчките"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Търсене на ресурси..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Нов аспект"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Присвоете {entityType} към канала"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Продължи"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Промоции"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Съобщение за грешка"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Добавете ниво на наличност за друго местоположение"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Изтриване на адрес"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Неуспешно актуализиране на аспекта"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters трябва да се използва в рамките на WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Редакция на адрес"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Неуспешно премахване на атрибут от канала: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Задайте връзка"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Нов продавач"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Редакция на изображението"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Управление на варианти"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Разпределени запаси"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "по-голямо или равно"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Задава нивото на наличност, при което този вариант се счита за изчерпан. Използването на отрицателна стойност позволява поддръжка на резервни поръчки."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Създай опции за продукти"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Запазва се..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Виж резултата"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Редове на страница"
 
 #~ msgid "Yesterday"
 #~ msgstr "Вчера"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Колекциите се зареждат..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Успешно актуализирана стойност на аспекта"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Добавете актив"
 
 #~ msgid "Save changes"
 #~ msgstr "Запазете промените"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Клиентът е добавен към групата"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Поръчки на продавача"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Неуспешно добавяне на стойност на опцията"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Добавете стойност на опция към {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} артикул(и) възстановен(и)"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Все още няма дефинирани групи опции. Добавете групи опции, за да създадете различни варианти на вашия продукт (напр. Размер, Цвят, Материал)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Нов имейл:"
 
 #~ msgid "This week"
 #~ msgstr "Тази седмица"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Неуспешно актуализиране на начина на плащане"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Наличен:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Създаден на"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Неуспешно създаване на вариант на продукта"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Език: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Нямате разрешение да видите глобалните езикови настройки"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Успешно създадена данъчна ставка"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Заглавие 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Добавени кодове на купони"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Активен"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Данъчна основа"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Зареди още"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Възстановяването е приключено"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "Успешно дублирани {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Нова група опции"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Все още няма резултат"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Плащането е приключено"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Налични условия"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Активни филтри"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Изчисти всички"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "е по-голямо от"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Затваряне"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Добавете плащане към поръчката"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Зареждане..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Токенът се използва за указване на канала, когато се правят заявки за API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Няма намерени адреси"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID на изпълнение"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Изберете плащания за възстановяване"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Неуспешно изтриване на {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Праг за изчерпани количества"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Продуктът е премахнат успешно от канала"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Неуспешно актуализиране на стойност"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Неуспешно създаване на API key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Приключи възстановяване"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Изисква се начин на плащане"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Неуспешно добавяне на клиент към групата"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Управление на варианти"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Приложен е глобален изглед „{viewName}“"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Регистриран клиент"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Зони"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Търсене на продавачи..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Успешно създадена промоция"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Опция"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Процес на поръчката"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Телефонен номер"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Частно"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Вариант"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Успешно актуализирани глобални настройки"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API key е актуализиран успешно"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Тези езици ще бъдат достъпни за използване от всички канали"

--- a/packages/dashboard/src/i18n/locales/cs.po
+++ b/packages/dashboard/src/i18n/locales/cs.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Celé jméno"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Vybrat položky"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Zobrazit změny"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Sledovací kód"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Vybraná oprávnění budou aplikována na tyto kanály."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Volby produktu"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Nová daňová sazba"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Přiřaďte existující skupinu voleb nebo vytvořte novou"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Nová role"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Byt, apartmá apod."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Žádné další položky"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Upravit odkaz"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Přidejte alespoň jednu položku do objednávky"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Přidejte produkty pro vytvoření testovací objednávky"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Nepodařilo se vytvořit adresu"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Přepnout vše"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Upravit hodnotu JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Použití externí autentizační strategie: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Vyberte důvod..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Nadpis 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Nepodařilo se přidat platbu"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Aktualizováno"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Nepodařilo se aktualizovat globální nastavení"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Objednávka úspěšně expedována"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Opravdu chcete smazat {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Globální práh vyprodání"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Spravovat jazyky"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Duplikování... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Úspěšně smazáno"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Odebrat z aktuálního kanálu"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Smazáno {selectionLength} souborů"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Daňová sazba úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Zadejte vlastní důvod..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Typ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Vybrat {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Zobrazit hodnoty"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Smazat řádek"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Podmínky"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Aktuální"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Žádné expedice"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Nepodařilo se smazat {1} skladové místo: {messages}} few {Nepodařilo se smazat {2} skladová místa: {messages}} other {Nepodařilo se smazat {2} skladových míst: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Když je toto povoleno, ceny zadané v katalogu produktů budou zahrnovat DPH pro výchozí daňovou zónu."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Vytvořte varianty pro váš produkt"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Koncept objednávky dokončen"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Automatické obnovení: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr "Úspěšně zrušena {fulfilled} úloha"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Kontroly stavu"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Smazáno {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Kontroly stavu"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Prodejci"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Možnosti"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {Úspěšně zrušena {fulfilled} úloha} few {Úspěšně zrušeny {fulfilled} úlohy} other {Úspěšně zrušeno {fulfilled} úloh}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Prodejce"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Přidat platbu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Otestujte tento způsob dopravy simulací objednávky, abyste viděli, zda je vhodný a jaké jsou náklady na dopravu."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Prozkoumat Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Sklady"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Správce expedice"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Objednávky"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Vybrat role"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Role úspěšně vytvořena"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Opravdu chcete smazat tuto variantu?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Všechny zdroje jsou v provozu"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Vytvoření administrátora se nezdařilo"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Ne"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Varianta produktu úspěšně aktualizována"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Nepodařilo se smazat {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Produkt úspěšně aktualizován"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Nepodařilo se aktualizovat zemi"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Zadejte alespoň 2 znaky pro vyhledávání..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Příjmení"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Nadpis odkazu"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Skupina zákazníků úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Vlastní pole změněna"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Sklad úspěšně vytvořen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Neznámá chyba"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Celková částka k vrácení nemůže být záporná"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Zobrazit podrobnosti"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Vyberte kanál pro přiřazení {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Zákazník úspěšně vytvořen"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Posledních 7 dní"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Nepodařilo se vytvořit kanál"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Vývojový režim"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Nová role"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Nepodařilo se smazat soubory: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Vrátit na sklad"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Viditelnost"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Varianty produktu"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Nová skupina zákazníků"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Vytvořit \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Přejmenovat"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Zvolte preferovaný jazyk zobrazení a regionální nastavení"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "Úspěšně odstraněno {successCount} skupin voleb z kanálu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Způsob dopravy není vhodný pro tuto objednávku"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Nepodařilo se aktualizovat adresu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adresa úspěšně smazána"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Daňová sazba"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr "{fulfilled, plural, one {{0}} other {{1}}}"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Koncept objednávky není připraven k dokončení"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Nová kolekce"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Přehledy"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Spustit"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Nepodařilo se aktualizovat daňovou sazbu"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Toto je obsah kolekce <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "soukromé"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Možnost produktu byla úspěšně vytvořena"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Nadřazený produkt"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Město"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Správci"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Hrubá cena: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Přejít na další stránku"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Odebrat odkaz"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Toto pole je pouze pro čtení"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Počet objednávek"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Objednávka úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Zdědit filtry"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Spravovat globální uložené pohledy viditelné pro všechny uživatele"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Hledat způsoby platby..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Dodací adresa zrušena pro objednávku"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Vytvořit {enabledCount} variant"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Platba #{0} převedena na {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Chyba při načítání historie zákazníka: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "Úspěšně odebráno {selectionLength} {entityType} z kanálu"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Přidat hodnotu volby"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Globální nastavení"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "je po"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Možnost produktu byla úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Upravit hodnoty vlastností"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Přidávání..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Přesunout kolekce"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Role"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Zobrazení mřížky"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Nepodařilo se smazat adresu"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Nejsou k dispozici žádné způsoby dopravy"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Globální pohled úspěšně převeden na osobní pohled"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Expedice převedena"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Opravdu chcete smazat {selectionLength} souborů?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Přihlásit se"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Zobrazení seznamu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Testovací objednávka"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Vyberte zákazníka pro pokračování"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Skupina voleb úspěšně přiřazena"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Spustit test"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Daňová sazba: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Pro spuštění testu přidejte produkty a vyplňte doručovací adresu."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Přepnout řádek hlavičky"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Vybrat adresu"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Kontrola způsobilosti platby"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Výchozí daňová zóna"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Koncept objednávky je připraven k dokončení"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadata"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr "Nepodařilo se nastavit způsob dopravy pro objednávku: {0}"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrovat..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Nová hodnota vlastnosti"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Kanál úspěšně aktualizován"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Zobrazit méně"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Krátké datum"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Dostupné měny"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Vybrat {0} položek"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Vytvořeno"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Rotace tohoto klíče okamžitě zneplatní aktuální klíč. Všechny integrace, které jej používají, přestanou fungovat, dokud nebudou aktualizovány novým klíčem."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Data předaná úloze"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Potvrdit navigaci"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Cíl odkazu"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Dokončit koncept"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Název"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Nepodařilo se expedovat objednávku"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Celkem"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Zadejte ID transakce pro toto vypořádání refundu"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Váš API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Opravdu chcete smazat tento koncept objednávky?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Expedice vytvořena"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Nalezeno {0} vhodných způsobů dopravy"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Rozměry"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Zobrazit heslo"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(max: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Společnost"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Přidat sloupec za"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Akce"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Slevy"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Zadejte poznámku k refundu"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Řádek objednávky odebrán"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Obsah:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Klíč"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Potvrdit"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr "Nepodařilo se dokončit koncept objednávky: {0}"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Nepodařilo se vytvořit kolekci"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Přejít na první stránku"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Nepodařilo se vytvořit produkt"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Zákazník"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Chyba při načítání historie objednávky: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Dodací adresa nastavena pro objednávku"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Ohniskový bod"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Jedna varianta, bez voleb"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Vyberte další stav pro objednávku"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Lokalizace"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Plánované úlohy"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Zadat ID transakce"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Obnovit data"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Přidat nebo odebrat hodnoty vlastností pro {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Toto jsou hodnoty vlastností pro vlastnost <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Platba úspěšně přidána k objednávce"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Fakturační adresa nastavena pro objednávku"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Nepodařilo se aktualizovat zónu"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Heslo"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Nepodařilo se smazat"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Plánovaná úloha bude provedena"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Nový sklad"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Oprávnění"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Doručovací adresa změněna"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Nebyly nalezeny žádné produkty"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Přidat řádek před"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Převést na {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Tento měsíc"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Nepodařilo se vytvořit vlastnost"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Nepodařilo se zrušit položky objednávky"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID transakce"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Alokováno"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Přidat další skupinu voleb"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr "Nepodařilo se nastavit kupónový kód pro objednávku: {0}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Zvolte, co se má stát se zbývajícími zásobami"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Prozkoumat Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Každých 5 sekund"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Kolekce úspěšně vytvořena"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Cena"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Koncept objednávky"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Rozsah"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Přidat podmínku"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Způsob dopravy je vhodný pro tuto objednávku"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Správci"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Odebráno ze skupiny"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Šířka"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Není vyžadována platba ani refund"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Stáhnout jako soubor .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Když je povoleno, akce je dostupná v obchodě"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Když je sledování povoleno, skladové úrovně variant produktů se automaticky upraví při prodeji. Toto nastavení může být přepsáno jednotlivými variantami produktů."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Způsob dopravy nastaven pro objednávku"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Nepodařilo se aktualizovat akci"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Obrázky"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Hledat {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Upravit soubor"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Zrušit platbu"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Fronta úloh"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Soubory"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "E-mailová adresa"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr "Nepodařilo se odebrat kupónový kód z objednávky: {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Obnovit URL segment ze zdrojového pole"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Zdědit z globálních nastavení"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Nenalezeny žádné výsledky"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Aktuální stav"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Nastavte dodací adresu a vyberte způsob dopravy"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Vypnuto"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Nastavení obchodu"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Fronta"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Nová daňová sazba"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Platba převedena"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Zbývá:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Nenalezen žádný duplikátor s kódem \"{duplicatorCode}\" pro {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Ceny zahrnují DPH pro výchozí daňovou zónu"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Celkový refund:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Zobrazit výsledek úlohy"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Otestujte vaše způsoby dopravy simulací nové objednávky."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Nejsou vybrány žádné položky"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} vybráno"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Nenalezeny žádné země"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Varianty úspěšně vytvořeny"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Generovat URL segment automaticky"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Příplatek"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Způsoby platby"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Sklad"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Nenalezeni žádní zákazníci"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Použít globální práh vyprodání"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Nová skupina voleb produktu"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Stav platby úspěšně aktualizován"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Vytvořit nový"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Celková částka k vrácení"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adresa smazána"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "K dispozici jsou pouze role přiřazené k vašemu účtu."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr "{cancellableCount, plural, one {Zrušit {cancellableCount} úlohu} few {Zrušit {cancellableCount} úlohy} other {Zrušit {cancellableCount} úloh}}"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Položka přidána k objednávce"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Upravit ohniskový bod"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Nenalezeni žádní prodejci"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Soubor"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Tato skupina voleb je používána jedním dalším produktem. Změny se projeví i u něj.} other {Tato skupina voleb je sdílena napříč # produkty. Změny se projeví u všech.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Moje uložené pohledy"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Nový kanál"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Nepodařilo se vytvořit prodejce"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Konfigurovat nastavení duplikace pro {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Žádné varianty neodpovídají aktuálnímu filtru."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adresy"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Přidat novou hodnotu volby do skupiny voleb {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Úprava objednávky #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Přidat sloupec před"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Jazyky kanálu"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Nepodařilo se vytvořit skupinu voleb"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Pravda"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Vybrat zákazníka"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Objednávka převedena"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Tento produkt má existující varianty, ale nejsou definovány žádné skupiny voleb. Před vytvořením nových variant musíte přidat skupiny voleb."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "je před"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Smazat koncept objednávky"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Katalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Nový způsob platby"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Akce úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Nepodařilo se zrušit {rejected} úlohu} few {Nepodařilo se zrušit {rejected} úlohy} other {Nepodařilo se zrušit {rejected} úloh}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Vyberte kanál"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Jazyk rozhraní"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Detaily expedice"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Zahodit zbývající zásoby"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Nyní"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Kanály"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Pohled úspěšně převeden na globální"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "před"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr "Nepodařilo se nastavit zákazníka pro objednávku: {0}"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Velikost"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Nenalezen žádný překlad pro {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Nový zákazník"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Poslední objednávky"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} dalších"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Použít jako výchozí fakturační adresu"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Smazat"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Zakázat"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Kolekce"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Přidat variantu"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Nepodařilo se vytvořit zemi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Země"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Nepodařilo se vytvořit volby produktu"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Nepodařilo se přejmenovat pohled"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Dostupné"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normální"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtry"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Skupiny zákazníků"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Zákazníci"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Ukázka formátování"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nová volba"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Limit použití"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Načítání globálních nastavení..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adresa úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Vytvořeno"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Načítání adres..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Vyberte cílovou kolekci pro přesunutí {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr "Nepodařilo se odebrat fakturační adresu z objednávky: {0}"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Údaje zákazníka aktualizovány"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "není v"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Použít"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nová volba produktu"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Přejít na poslední stránku"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Zrušit"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr "Nepodařilo se aktualizovat vlastní pole objednávky: {0}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Varianta produktu úspěšně vytvořena"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Refund z tohoto způsobu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "PSČ"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Nejprve přidejte volby produktu"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Nová daňová kategorie"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Přidat volbu"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Částečné vrácení dokončeno"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Nastavit vlastní pole"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Kolekce"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Smazat variantu"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Nebyly provedeny žádné úpravy"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Výchozí dopravní zóna"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Důvod:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Doručovací adresa"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Převést na {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Daňové kategorie"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Soukromé kolekce nejsou viditelné v obchodě"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Když je povoleno, produkt je dostupný v obchodě"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Plánovaná úloha nemohla být provedena"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Skupiny zákazníků"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Zakázáno"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Nová akce"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Výchozí doručovací adresa"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Vyžadován refund"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Expedovat objednávku"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Nemáte oprávnění k zobrazení nastavení kanálu"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Posledních 30 dní"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Žádné hodnoty vlastností"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Je vyžadován důvod vrácení"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Nepodařilo se odebrat skupinu voleb"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Nepodařilo se aktualizovat daňovou kategorii"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Refund úspěšně vypořádán"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Aktualizovat"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Nadpis 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Objednávka vytvořena"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profil úspěšně aktualizován"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "konec"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Způsob platby"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Upravit"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Varianta úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtrovat podle názvu kolekce"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Poznámka přidána"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Vyberte množství k expedici a nakonfigurujte správce expedice"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Fakturační adresa odebrána z objednávky"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Začíná"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplikovat"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Žádné výsledky"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Nastavení sloupců"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Nepodařilo se smazat {count} skladové místo} few {Nepodařilo se smazat {count} skladová místa} other {Nepodařilo se smazat {count} skladových míst}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Kód"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Nepodařilo se odebrat skupiny voleb"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Objednávka doručena"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Převést na {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Zbývající zásoby"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Odebrat ze zóny"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Vyberte z globálně dostupných jazyků pro tento kanál"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Opravdu chcete smazat tuto adresu?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Nepodařilo se přiřadit skupinu voleb"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Nepodařilo se aktualizovat soubor"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Sklad úspěšně aktualizován"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Potvrdit akci"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Země úspěšně aktualizována"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Vlastnosti"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Nepodařilo se přidat poznámku"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Nepodařilo se smazat poznámku"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Nepodařilo se rozšířit dokument dotazu"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Nepodařilo se aktualizovat poznámku"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Vrátit dopravu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Pouze pro čtení"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Nepodařilo se duplikovat globální pohled"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Zobrazeno {shown} z {total} • vybráno {selected}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Testovat způsob dopravy"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Hodnoty vlastností"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Soubor úspěšně aktualizován"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Téma"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} zákazníků"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Vyberte jazyk"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Odhlásit se"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Pokusy"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Dostupné kódy měn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Dostupné kódy jazyků"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Drobečková navigace"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Kategorie"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Kanály"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Potomci"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Kód"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Kód kupónu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Vytvořeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Kód měny"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Zákazník"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Skupina zákazníků"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Zákazníci"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Vlastní pole"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Data"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Výchozí kód měny"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Výchozí kód jazyka"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Výchozí dopravní zóna"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Výchozí daňová zóna"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Popis"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Délka trvání"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "E-mailová adresa"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Povoleno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Končí"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Chyba"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Hlavní soubor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Jméno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Kód správce expedice"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Je výchozí"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Je soukromé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Je vypořádáno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Příjmení"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Název"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Objednáno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID rodiče"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Limit použití na zákazníka"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Oprávnění"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Pozice"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Cena"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Ceny zahrnují DPH"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Cena s DPH"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Varianty produktů"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Průběh"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Název fronty"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Výsledek"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Opakování"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Prodejce"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Vypořádáno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Řádky dopravy"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "URL segment"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Spuštěno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Začíná"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Stav"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Skladové stavy"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Celkem"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Celkem s DPH"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Typ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Aktualizováno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Limit použití"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Uživatel"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Hodnota"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Seznam hodnot"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zóna"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Metoda"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Souhrn daní"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Nastavuje jazyky dostupné pro všechny kanály. Jednotlivé kanály pak mohou podporovat podmnožinu těchto jazyků."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Kolekce úspěšně přesunuty"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registrovaný"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr "Nepodařilo se nastavit doručovací adresu pro objednávku: {0}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Zrušit úlohu"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Končí"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Stránka {0} z {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Sazba"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Velikost, barva atd."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Procházet fasety"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zóna"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Zrušeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Vytvořeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Doručeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Čekající"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Odesláno"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Uložit zobrazení"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} vybráno"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Hledat skupiny voleb..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Upravit objednávku"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Vybrané položky"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Hodnoty"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Zákazník nastaven pro objednávku"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Vlastnosti"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Opravdu chcete odebrat {count} zákazníka z této skupiny?} few {Opravdu chcete odebrat {count} zákazníky z této skupiny?} other {Opravdu chcete odebrat {count} zákazníků z této skupiny?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Sklad na skladě"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Přebudování vyhledávacího indexu nemohlo být spuštěno"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Doručovací adresa"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Nová zóna"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Nový API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Smazat sloupec"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Přiřadit existující"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "je null"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Toto jsou zákazníci ve skupině zákazníků <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Spravovat globální pohledy"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Výchozí kanál"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Vložit nový obrázek se zdrojem, názvem a rozměry"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Nepodařilo se vytvořit hodnotu vlastnosti"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Nepodařilo se aktualizovat možnost produktu"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Zapomněli jste heslo?</0><1>Požádat o reset</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Kód kupónu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Zákazník ověřen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Globální nastavení"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Plán"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Nelze přesunout kolekci do jejího vlastního potomka"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Nová daňová kategorie"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Na aktuálním kanále nejsou k dispozici žádné sklady"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Kanál úspěšně vytvořen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Zákazník úspěšně aktualizován"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Zobrazit data"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Smazat pohled"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Přidejte novou adresu k zákazníkovi."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Více pohledů"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Upravit vlastnosti vybraného obrázku"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Použit pohled \"{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Úspěšně odebráno {successCount} vlastností z kanálu"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Nový produkt"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Nový soubor"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Přepočítat dopravu"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Vyberte, které volby by se měly vztahovat na existující variantu \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Soubory"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Tímto se odeberou všechny skupiny voleb z tohoto produktu a vrátíte se k výběru nastavení variant."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Fakturační adresa"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Přidat hodnotu vlastnosti"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Prosím vyberte cílovou kolekci"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Zkontrolujte změny před jejich použitím na objednávku."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Vyberte roli"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Objednávka zrušena"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Sleva"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Všechny typy"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Lze dokončit pouze koncepty objednávek"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Nepodařilo se aktualizovat produkt"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Úprava {0} řádků"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Přidat hodnoty vlastností"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "po"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Kanál"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Kontroly stavu"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Částka"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Telefonní číslo"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Nový zákazník"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Obrázek"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administrátor byl úspěšně vytvořen"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Volby produktu"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Vybrat zemi"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Vytváření..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Opravdu chcete smazat tento globální pohled? Tuto akci nelze vrátit zpět a ovlivní všechny uživatele."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Vynutit odebrání skupiny možností"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Přidáno"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Historie zákazníka"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Úspěšně aktualizovány hodnoty vlastností pro {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Nepodařilo se odebrat zákazníka ze skupiny"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Systém"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Limit použití na zákazníka"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Fakturační adresa změněna"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Vyberte volbu"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Zkopírovat do osobních"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Celková částka k vrácení překračuje maximální vratnou částku {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Smazat globální pohled"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Vytvořit"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Každých 30 sekund"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Nová země"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "Z {0} na {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Nepodařilo se vytvořit zákazníka"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Ohniskový bod aktualizován"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Hodnoty voleb"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Výchozí fakturační adresa"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Žádný zákazník"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Nepodařilo se odstranit země ze zóny"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Nepodařilo se vytvořit akci"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Dnes"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Včera"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Název volby"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Opravdu chcete odebrat {0} {1} z této zóny?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Přidávání {0} příplatků"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "URL odkazu"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Náhradní hodnota: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Historie objednávky"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Přepsat"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "ID transakce je povinné"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "odpovídá regulárnímu výrazu"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Globální pohled úspěšně přejmenován"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Nejsou vybrány žádné štítky"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Zpět"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Pohled úspěšně přejmenován"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Použít filtr"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Poslední výsledek"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Přidáno do skupiny"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Přehledy"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Vytvořit varianty"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Testování způsobu dopravy..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Tmavý"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Výsledky testu"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Přidat zákazníka"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Uložit změny"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adresa aktualizována"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Vrácení bylo úspěšně zpracováno"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Nová zóna"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Nepodařilo se aktualizovat pozici kolekce"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Vrácení"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Upravit"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Nejsou nakonfigurovány žádné globální jazyky"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Odebírání {0} položek"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Sledovat"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Vytvořit variantu"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Hodnoty vlastností pro {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Uložit rozložení"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Obnovení hesla ověřeno"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Nepodařilo se smazat pohled"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Opravdu chcete opustit tuto stránku? Všechny neuložené změny budou ztraceny."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Přepnout sloupec hlavičky"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Nová akce"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Název hodnoty volby"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Naposledy použito"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Je výchozí daňová kategorie"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "URL segment je nastaven"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Nepodařilo se aktualizovat ohniskový bod"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zóna úspěšně aktualizována"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Stát/Kraj"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Nepodařilo se aktualizovat skupinu voleb"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Výchozí nastavení kanálu"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Nepodařilo se vytvořit daňovou kategorii"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Nastavit kritéria filtru pro sloupec {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Země"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Jednoduchý produkt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Fronta úloh"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Potvrďte prosím, že jste si API key uložili, než zavřete."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Potvrdit smazání"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Nepodařilo se upravit objednávku"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Včetně daně {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Metriky objednávek"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Vyberte jazyk rozhraní"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Metody ověření"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "začátek"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Nepodařilo se provést rotaci API key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "v"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Hledat role..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr "Úspěšně zrušeno {fulfilled} úloh"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Varianty produktů"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Spravovat globální pohledy"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Zpracování..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "Nalezeno {totalItems} {0}"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Vyberte časové období"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Produkt"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rotace API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Kategorie"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Přesouvání..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Přiřadit"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Prodejce úspěšně vytvořen"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Způsob dopravy byl úspěšně aktualizován"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Nepodařilo se aktualizovat variantu produktu"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Přetažením změnit pořadí"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zóny"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Zvolte, co se má stát se zásobami, které zůstávají na {count, plural, one {# skladovém místě} few {# skladových místech} other {# skladových místech}}, jež mažete. Všechna vybraná místa převedou zbývající zásoby do jednoho místa, které zvolíte, nebo je zahodí."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Hledat hodnoty faset..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Poznámka"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Dostupné jazyky"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Načíst dalších {0} ({remaining} zbývá)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Hodnoty vlastností"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Nepodařilo se přeuspořádat položky"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Celkem objednávek"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Pro tuto objednávku nebyly nalezeny žádné vhodné způsoby dopravy."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Přidat volbu produktu"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Doprava"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions musí být použito v rámci DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Tato skupina možností je používána existujícími variantami. Vynucené odebrání je může ovlivnit. Jste si jisti?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Požadována aktualizace e-mailu"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Chyba při přechodu do stavu"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Skupina zákazníků úspěšně vytvořena"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nové okno"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Platba autorizována"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Role úspěšně aktualizována"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Vyberte zemi"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Nepodařilo se aktualizovat způsob dopravy"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Smazáno {deleted} skladové místo} few {Smazána {deleted} skladová místa} other {Smazáno {deleted} skladových míst}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Způsoby dopravy"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Vyberte adresu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Ano"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "URL segment"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Nastavit ohniskový bod"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "konec"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Vyberte měnu"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Aktualizujte obsah nebo viditelnost poznámky"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget posledních objednávek"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Obsah kolekce {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Způsob dopravy změněn"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Popis daně"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "je menší nebo rovno"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "není rovno"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Obnovit"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "např. Velikost"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Vypořádat platbu"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Kanály"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Doprava vrácena"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Typ souboru"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Nový sklad"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} plateb bylo vráceno před selháním. Podrobnosti najdete v historii objednávky."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Vybrat položku"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Nový produkt"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Spravovat štítky"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Položky vráceny"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Přidat akci"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Přiřadit volby existující variantě"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Duplikovat {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Odebrat ze skupiny"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Nepodařilo se aktualizovat stav expedice"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Vytvořit novou variantu produktu s volbami, cenami a skladem"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Soukromé vlastnosti nejsou viditelné v obchodě"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Vyberte daňovou kategorii"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Vytvořeno"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Neběží"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Přiřazeno"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Nadpis 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Vybrat dostupné jazyky"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Přidávání {0} položek"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Přidat řádek za"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Celková daň"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Stav konceptu objednávky"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Volby produktu úspěšně vytvořeny"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Načítání míst…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Nepodařilo se vytvořit způsob platby"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Hodnota vlastnosti úspěšně vytvořena"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Koncept objednávky smazán"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "větší než"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Widget metrik"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Hledat měny..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Odebrat z kanálu"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Nadpis"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Vložit obrázek"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Nepodařilo se aktualizovat prodejce"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Země úspěšně vytvořena"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Vybrat prodejce"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Načítání štítků..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Vlastnost úspěšně vytvořena"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} variant"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Nepodařilo se vypořádat platbu"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Žádná fakturační adresa"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Nepodařilo se smazat {1} skladové místo} few {Nepodařilo se smazat {2} skladová místa} other {Nepodařilo se smazat {2} skladových míst}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Vlastnost"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr "{rejected, plural, one {{0}} other {{1}}}"
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Nelze odstranit z aktivního kanálu"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Nenastaveno"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Vynutit odebrání"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Nový kanál"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Název skupiny voleb"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "A"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Nepodařilo se vytvořit skupinu zákazníků"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Nepodařilo se vytvořit roli"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Název produktu"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Stav expedice úspěšně aktualizován"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Produkty"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adresa vytvořena"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "Rotace API key proběhla úspěšně"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Přidat skupinu voleb"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Vrátit {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Zadat URL segment ručně"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Žádné widgety nejsou k dispozici"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Nepodařilo se zrušit platbu"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Platba úspěšně zrušena"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Globální pohled úspěšně duplikován"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Vytvořil"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtrovat varianty..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Přidat cenu v jiné měně"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "E-mailová adresa nebo identifikátor"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Refund #{0} převeden na {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Zákazníci"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Nadpis 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Nepodařilo se aktualizovat sklad"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Objednávka odeslána"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Uložit adresu"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Vytvořit globální"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Vyberte další stav"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Žádná upozornění"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Přesouvání {0} kolekce do {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "mezi"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Poznámka úspěšně přidána"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Poznámka úspěšně smazána"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Poznámka úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Nepodařilo se vypořádat refund"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Skladová úroveň"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Přidat položku"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API key úspěšně vytvořen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Načítání náhledu..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Zpět na hledání"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Pohled úspěšně duplikován"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Odebrat skupinu možností"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Popis"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Země"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr "Nepodařilo se odebrat položku objednávky: {0}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Ulice 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Globální pohled úspěšně smazán"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Upravit rozložení"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Přiřadit ke kanálu"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Tento týden"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Skupina možností produktu byla úspěšně vytvořena"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Přidat ruční platbu {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "je v"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-mail"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Aktualizace administrátora se nezdařila"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Spravovat vaše osobní uložené pohledy pro tuto tabulku"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtrovat podle štítků"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Přihlaste se pro přístup k administrátorskému panelu"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Přidat platbu k objednávce ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Nepravda"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Světlý"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Obnovit"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "je rovno"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Vytvořit volby"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Heslo aktualizováno"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "neobsahuje"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Skupina voleb"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Upravte níže uvedené údaje adresy."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Daňová kategorie úspěšně vytvořena"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Nepodařilo se přesunout kolekce"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Nepodařilo se aktualizovat stav platby"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Přehled vašich objednávek"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Nahrát"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Produkt s volbami"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Zobrazeno všech {0} výsledků"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Vyhledávací ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} dalších"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Skupiny voleb"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Vlastní pole"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Všechny možné stavy objednávky a jejich přechody. Aktuální stav je zvýrazněn."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Objednávky"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget souhrnu objednávek"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Přidávání položek"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Zajišťování dodatečné platby"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Příprava platby"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Zrušena"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Vytvořena"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Doručeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Koncept"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Upravování"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Částečně doručeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Částečně odesláno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Platba autorizována"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Platba vypořádána"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Odesláno"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Monitorované zdroje"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Informace o entitě"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Celkem objednávka"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Viditelné pouze pro správce"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Množství"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Štítky"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super Admin"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Některé zdroje nefungují"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Dostupné akce"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr "Nepodařilo se aktualizovat položku objednávky: {0}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Vložit odkaz"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Pokud je povoleno, filtry budou zděděny z nadřazené kolekce a sloučeny s filtry nastavenými pro tuto kolekci."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Vyberte zónu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Testovat způsoby dopravy"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Platba úspěšně vypořádána"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "Odebráno {0} {1} ze zóny"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Povolit"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Způsoby platby"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autorizována"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Zrušena"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Vytvořena"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Odmítnuta"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Chyba"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Neúspěšná"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Čekající"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Vypořádána"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Průměrná hodnota objednávky"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Nepodařilo se vytvořit zónu"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Skladové úrovně"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Nepodařilo se aktualizovat API key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Řádky objednávky"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Nepodařilo se přejmenovat globální pohled"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Vložit nový hypertextový odkaz s URL a možnostmi cíle"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Výška"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Je vyžadován refund ve výši {formattedDiff}. Vyberte částky plateb a zadejte poznámku pro pokračování."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Jednotková cena"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Vzor plánu"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Platba selhala"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Přidat kanál"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Nepodařilo se aktualizovat skupinu možností produktu"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Hledat kanály..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Přidat skupiny zákazníků"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Dostupné jazyky"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Resetovat výběr"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Žádná adresa"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Způsob platby úspěšně vytvořen"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Informace o zákazníkovi aktualizovány"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr "Nepodařilo se smazat koncept objednávky: {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Nepodařilo se převést pohled na globální"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Varianty produktů"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Produkty"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Akce"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Nepodařilo se vytvořit možnost produktu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Starý e-mail:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Uložte pohled jako \"Globální\", aby byl dostupný všem uživatelům."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Nepodařilo se vytvořit varianty"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Nastavuje skladovou úroveň, při které je tato varianta považována za vyprodanou. Použití záporné hodnoty umožňuje podporu předobjednávek. Může být přepsáno variantami produktu."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rotace klíče"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Nepodařilo se vytvořit varianty produktu"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Skrýt heslo"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Nový prodejce"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "např. Červená, Velká, Bavlna"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Nepodařilo se aktualizovat profil"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Odebrané kódy kupónů"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Vymazat filtr"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regiony"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Přetáhněte sem soubory pro nahrání"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Přepnout všechny viditelné varianty"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Ověřený"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Nová skupina voleb"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Naposledy aktualizováno {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Zatím nebyly vytvořeny žádné globální pohledy."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Nepodařilo se aktualizovat roli"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Toto je jediná příležitost, kdy bude celý API key zobrazen. Zkopírujte si jej nebo stáhněte nyní — později jej nebude možné získat."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Kolekce úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Způsob platby úspěšně aktualizován"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Pohled úspěšně smazán"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Skupina voleb {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "NEBO"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Spravovat štítky"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Kód kupónu odebrán z objednávky"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Nikdy"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Nepodařilo se aktualizovat hodnotu vlastnosti"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Odebrat skupinu"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Objednávka expedována"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr "Nepodařilo se nastavit fakturační adresu pro objednávku: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Žádná doručovací adresa"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Rozšíření dotazu obsahuje neplatnou syntaxi GraphQL"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Chyba rozšíření dotazu"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Chyba rozšíření dotazu:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Rozšíření dotazu je neplatné: musí obsahovat alespoň jedno pole nejvyšší úrovně"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Nesoulad rozšíření dotazu:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "veřejné"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Daňová kategorie úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Přesunout"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Upravit nebo smazat existující štítky"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Podmínky kontroly způsobilosti tohoto způsobu dopravy nejsou splněny pro aktuální objednávku a doručovací adresu."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Přidat kód kupónu"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Kód kupónu nastaven pro objednávku"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Vlastní pole"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Nový způsob dopravy"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Smazat skladová místa"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "je větší nebo rovno"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Náhled"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} z {1} k dispozici k vyřízení"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Od začátku měsíce"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Požadavek zákazníka"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Poškozeno při přepravě"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Není k dispozici"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Jiné"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Špatná položka"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Souhrn úprav"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Refundy ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Naposledy provedeno"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Detaily platby"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Přebudovat vyhledávací index"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Běží"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Každých 60 sekund"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Nepodařilo se aktualizovat skupinu zákazníků"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Metadata platby"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Zrušit úpravu"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Stejné okno"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Použijte filtry na tabulku a klikněte na \"Uložit pohled\" pro začátek."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Role"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Vyžadována dodatečná platba"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Nepodařilo se aktualizovat objednávku"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "S vybranými..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Nepodařilo se vytvořit sklad"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "menší nebo rovno"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Členové skupiny zákazníků {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Stav"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Nesledovat"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Expedice #{0} vytvořena"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Spouštění čekajících aktualizací indexu vyhledávání"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Toto je výchozí role a nelze ji upravit"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Moje uložené pohledy"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Stát / Kraj"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Povoleno"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Položek na stránku"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Upravit členy"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Sklad na skladě"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtrovat podle {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Upozornění"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Hodnoty voleb"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Náhled změn"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Nepodařilo se odebrat {entityType} z kanálu"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Varianta úspěšně smazána"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Upravit vlastnosti vybraného odkazu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Prodej"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Vyberte cílovou kolekci"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Vaše poslední objednávky"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Plánované úlohy"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Opravdu chcete smazat tuto položku? Tuto akci nelze vrátit zpět."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Varianty"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Prodejci"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Nastavení"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Nastavení obchodu"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Nadpis 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Vítejte ve Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Způsoby dopravy"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} vratitelných)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identifikátor"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Nepodařilo se aktualizovat kolekci"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Cena a daň"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Objednávka nenalezena"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Chyba"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Objednávka upravena"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Požadováno obnovení hesla"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Přidělená částka platby se musí rovnat celkové částce vrácení"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "např. Malá"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Opravdu chcete odebrat {0} {entityType} z aktuálního kanálu?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Přidat štítky..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Nepodařilo se vytvořit skupinu možností produktu"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} položek vybráno"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Hledat jazyky..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Sklady"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Přejít na předchozí stránku"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Obsah"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr "Nepodařilo se zrušit {rejected} úloh"
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Nepodařilo se převést globální pohled na osobní pohled"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Výsledek úlohy"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Přidat platbu ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Systém"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Název varianty"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Odebrat"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Nepodařilo se aktualizovat zákazníka"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Odebrat skupiny voleb?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Toto je náhled obsahu kolekce na základě aktuálních nastavení filtru. Jakmile kolekci uložíte, obsah bude aktualizován tak, aby odrážel nová nastavení filtru."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {Odebrán {count} zákazník ze skupiny} few {Odebráni {count} zákazníci ze skupiny} other {Odebráno {count} zákazníků ze skupiny}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Daňové kategorie"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Daňové sazby"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Nepodařilo se odebrat zákazníky ze skupiny"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Nepodařilo se načíst globální nastavení"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Vyberte položky k vrácení a volitelně vraťte na sklad"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Uložit"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} z {0} řádků vybráno."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Náhled úprav objednávky"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Skupina možností produktu byla úspěšně aktualizována"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Stránka bude pokračovat s výchozím dotazem."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Ulice"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Žádné další fasety"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Přebudování vyhledávacího indexu spuštěno"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Pozice kolekce aktualizována"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Název skupiny voleb"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Přidat \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Nová varianta produktu"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Refund převeden"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Použití nativní autentizační strategie"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Nepodařilo se přiřadit {entityIdsLength} {entityType} ke kanálu"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Výchozí jazyk"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Expedování..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Přidat skupinu voleb k produktu"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Náhled {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Prodejce úspěšně aktualizován"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Nepodařilo se převést objednávku do stavu"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Zobrazit vše ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Nepodařilo se vytvořit daňovou sazbu"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Uložil jsem si tento API key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Nastavte dostupné jazyky pro váš obchod a kanály"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Produkt úspěšně vytvořen"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Přidat variantu produktu"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Zadejte a stiskněte Enter nebo čárku pro přidání..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Upravit poznámku"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Nebyly nalezeny žádné soubory. Zkuste upravit filtry."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Přidat volbu"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Uložit skupinu voleb"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Vytvořit {createCount} variant"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Klikněte na \"Spustit test\" pro otestování tohoto způsobu dopravy."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administrátor byl úspěšně aktualizován"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Vymazat filtry"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Expedice #{0} z {1} na {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Nepodařilo se smazat globální pohled"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Výchozí jazyk"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Stav"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Nebyly nalezeny žádné možnosti"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binární"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Skupina voleb úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Nový způsob dopravy"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Každých 10 sekund"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "bez DPH:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Přidat zásoby do skladu"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Hodnota volby úspěšně přidána"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Kolekce přesunuta do nového rodiče"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Skupina voleb odebrána"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Převést na vybraný stav"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Bude vyžadována dodatečná platba ve výši {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Sledovat zásoby ve výchozím nastavení"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "Vybráno {selected} z {total}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Způsob dopravy byl úspěšně vytvořen"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nová skupina zákazníků"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Viditelné pro zákazníka"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Skupina voleb úspěšně vytvořena"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Daňové sazby"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "URL segment bude vygenerován automaticky..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Zákazník nenalezen"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Vybrat {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Nové hodnoty vlastností k přidání:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Nepodařilo se zpracovat vrácení"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Jméno"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "obsahuje"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Nebyly nalezeny žádné skupiny voleb"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Nenalezeny žádné položky"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Mezisoučet"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Expedované položky ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Hodnota aktualizována"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Neověřený"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Množství"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Přidat filtr"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Daňová kategorie"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Testovací data byla aktualizována. Klikněte na \"Spustit test\" pro zobrazení aktualizovaných výsledků."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "není v"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Řádek objednávky aktualizován"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Nový způsob platby"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Duplicitní hodnota \"{trimmed}\" již existuje"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Důvod"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Skupiny zákazníků"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} úspěšně odebráno z kanálu"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Skupiny voleb"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Přidat příplatek"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Aktuální hodnoty vlastností"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Stránka {page} z {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr "Nepodařilo se zrušit {rejected} úlohu"
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Minulý měsíc"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Přidat zemi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Odebrat položku"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "menší než"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Variantu nelze přidat. Ujistěte se, že nadřazený produkt je povolen."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Došlo k neznámé chybě"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Metriky"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Jazyk"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Nová kolekce"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Vrátit peníze a zrušit objednávku"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Aktualizace e-mailu ověřena"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "je mezi"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Vrátit a zrušit"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Testování způsobů dopravy..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Nepodařilo se vytvořit způsob dopravy"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "Úspěšně přiřazeno {entityIdsLength} {entityType} ke kanálu"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Globální jazyky"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Nový správce"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Smazat koncept"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Zdroj"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Žádné akce k dispozici"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Nepodařilo se aktualizovat kanál"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Obecné"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Nepodařilo se odstranit produkt z kanálu"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Přidat novou adresu"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Vlastnost úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zóna úspěšně vytvořena"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Hodnota"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Zákazník aktualizován"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Faktor převodu ceny"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Objednávka prodejce"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Nová vlastnost"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Opravdu chcete odebrat tuto skupinu možností z produktu?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Popis (alt)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Nenalezeny žádné štítky"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Výchozí měna"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Pro tyto změny není vyžadována žádná platba ani refund."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr "{cancellableCount, plural, one {Opravdu chcete zrušit {cancellableCount} úlohu? Tuto akci nelze vrátit zpět.} few {Opravdu chcete zrušit {cancellableCount} úlohy? Tuto akci nelze vrátit zpět.} other {Opravdu chcete zrušit {cancellableCount} úloh? Tuto akci nelze vrátit zpět.}}"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Celkové tržby"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Další provedení"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Poznámka je soukromá"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Střední datum"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Neplatné číslo"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Zatím jste neuložili žádné pohledy."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Opravdu chcete smazat tento pohled? Tuto akci nelze vrátit zpět."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Zobrazit proces objednávky"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Nepodařilo se duplikovat pohled"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Použít jako výchozí doručovací adresu"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Upravit URL segment ručně"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Přidejte filtry pro náhled obsahu kolekce."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Skupina voleb produktu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Mezisoučet"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "je menší než"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID refundu"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Vlastní pole objednávky aktualizována"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Kalkulačka"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Nepodařilo se odebrat skupinu voleb z kanálu: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Zobrazit data úlohy"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Přesunout na nejvyšší úroveň"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Vymazat"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Přehled objednávek"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Hledat soubory..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Nová vlastnost"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Přiřadit {entityType} ke kanálu"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Pokračovat"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Akce"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Chybová zpráva"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Přidat úroveň skladu pro jiné místo"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Smazat adresu"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Nepodařilo se aktualizovat vlastnost"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters musí být použito v rámci WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Upravit adresu"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Nepodařilo se odebrat vlastnost z kanálu: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Nastavit odkaz"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Nový prodejce"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Upravit obrázek"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Spravovat varianty"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Sklad alokován"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "větší nebo rovno"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Nastavuje skladovou úroveň, při které je tato varianta považována za vyprodanou. Použití záporné hodnoty umožňuje podporu předobjednávek."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Vytvořit volby produktu"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Ukládání..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Zobrazit výsledek"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Řádků na stránku"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Načítání kolekcí..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Hodnota vlastnosti úspěšně aktualizována"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Přidar soubor"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Uložit změny"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Zákazník přidán do skupiny"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Objednávky prodejců"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Nepodařilo se přidat hodnotu volby"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Přidat hodnotu volby do {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr "Nepodařilo se odebrat doručovací adresu z objednávky: {0}"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} položek vráceno"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Zatím nejsou definovány žádné skupiny voleb. Přidejte skupiny voleb pro vytvoření různých variant vašeho produktu (např. Velikost, Barva, Materiál)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Nový e-mail:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Nepodařilo se aktualizovat způsob platby"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Dostupné:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Vytvořeno"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Nepodařilo se vytvořit variantu produktu"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Jazyk: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Nemáte oprávnění k zobrazení globálních nastavení jazyků"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Daňová sazba úspěšně vytvořena"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Nadpis 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Přidané kódy kupónů"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Aktivní"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Základ daně"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Načíst více"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Refund vypořádán"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "Úspěšně duplikováno {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Nová skupina voleb"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Zatím žádný výsledek"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Platba vypořádána"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Dostupné podmínky"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Aktivní filtry"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Vymazat vše"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "je větší než"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Zavřít"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Přidat platbu k objednávce"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Načítání..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Token se používá k určení kanálu při provádění API požadavků."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Nenalezeny žádné adresy"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID expedice"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Vyberte platby k vrácení"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Nepodařilo se smazat {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Práh vyprodání"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt byl úspěšně odstraněn z kanálu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Nepodařilo se aktualizovat hodnotu"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Nepodařilo se vytvořit API key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Vypořádat refund"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Způsob platby je povinný"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Nepodařilo se přidat zákazníka do skupiny"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Spravovat varianty"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Použit globální pohled \"{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Zákazník registrován"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zóny"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Hledat prodejce..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Akce úspěšně vytvořena"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Volba"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Proces objednávky"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Telefonní číslo"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Soukromé"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Varianta"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Globální nastavení úspěšně aktualizována"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API key úspěšně aktualizován"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Tyto jazyky budou k dispozici pro všechny kanály"

--- a/packages/dashboard/src/i18n/locales/de.po
+++ b/packages/dashboard/src/i18n/locales/de.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Vollständiger Name"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Artikel auswählen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Änderungen anzeigen"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Verfolgungscode"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Die ausgewählten Berechtigungen werden auf diese Kanäle angewendet."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Produktoptionen"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Neuer Steuersatz"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Eine bestehende Optionsgruppe zuweisen oder eine neue erstellen"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Neue Rolle"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Wohnung, Suite, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Keine weiteren Artikel"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Link bearbeiten"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Fügen Sie mindestens einen Artikel zur Bestellung hinzu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Produkte hinzufügen, um eine Testbestellung zu erstellen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Fehler beim Erstellen der Adresse"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Alle umschalten"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "JSON-Wert bearbeiten"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Verwende externe Authentifizierungsstrategie: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Grund auswählen..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Überschrift 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Fehler beim Hinzufügen der Zahlung"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Aktualisiert"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Fehler beim Aktualisieren der globalen Einstellungen"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Bestellung erfolgreich erfüllt"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Möchten Sie wirklich {0} {entityName} löschen?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Globale Grenzwerte für Lagerausfälle"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Sprachen verwalten"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Dupliziere... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Erfolgreich gelöscht"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Aus aktuellem Kanal entfernen"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} Assets gelöscht"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Steuersatz erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Eigenen Grund eingeben..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Typ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "{0} auswählen"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Werte anzeigen"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Zeile löschen"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Bedingungen"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Keine Erfüllungen"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {{1} Lagerort konnte nicht gelöscht werden: {messages}} other {{2} Lagerorte konnten nicht gelöscht werden: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Wenn dies aktiviert ist, sind die im Produktkatalog eingegebenen Preise in der Steuer für die Standard-Steuerzone enthalten."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Varianten für Ihr Produkt erstellen"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Bestellentwurf abgeschlossen"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Automatische Aktualisierung: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Gesundheitsprüfungen"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} gelöscht"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Gesundheitsprüfungen"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Verkäufer"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Optionen"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} Job erfolgreich abgebrochen} other {{fulfilled} Jobs erfolgreich abgebrochen}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Verkäufer"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "Artikelnr.:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Zahlung hinzufügen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Testen Sie diese Versandmethode, indem Sie eine Bestellung simulieren, um zu sehen, ob sie berechtigt ist und wie hoch die Versandkosten wären."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Enterprise Edition erkunden"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Lagerorte"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Erfüllungs-Handler"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Bestellungen"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Rollen auswählen"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Rolle erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Möchten Sie diese Variante wirklich löschen?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Alle Ressourcen sind verfügbar und laufen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Administrator konnte nicht erstellt werden"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Nein"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Produktvariante erfolgreich aktualisiert"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Fehler beim Löschen von {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Produkt erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Fehler beim Aktualisieren des Lands"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Geben Sie mindestens 2 Zeichen ein, um zu suchen..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Nachname"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Link-Titel"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Kundengruppe erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Benutzerdefinierte Felder geändert"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Lagerort erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Unbekannter Fehler"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Der Erstattungsbetrag darf nicht negativ sein"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Details anzeigen"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Kanal auswählen, dem {0} {entityType} zugeordnet werden soll"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Kunde erfolgreich erstellt"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Letzte 7 Tage"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Fehler beim Erstellen des Kanals"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Entwicklermodus"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Neue Rolle"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Fehler beim Löschen der Assets: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Zurück auf Lager"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Produktvarianten"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Neue Kundengruppe"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "\"{0}\" erstellen"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Umbenennen"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Wählen Sie Ihre bevorzugte Anzeigesprache und Gebietsschema-Einstellungen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} Optionsgruppen erfolgreich aus dem Kanal entfernt"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Versandmethode ist für diese Bestellung nicht berechtigt"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Fehler beim Aktualisieren der Adresse"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adresse erfolgreich gelöscht"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Steuersatz"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Bestellentwurf ist nicht bereit zur Fertigstellung"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Neue Sammlung"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Einblicke"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Ausführen"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Fehler beim Aktualisieren des Steuersatzes"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Dies ist der Inhalt der Sammlung <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privat"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Produktoption erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Übergeordnetes Produkt"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Stadt"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administratoren"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Bruttopreis: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Zur nächsten Seite"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Link entfernen"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Dieses Feld ist schreibgeschützt"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Anzahl Bestellungen"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Bestellung erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Filter erben"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Globale gespeicherte Ansichten verwalten, die für alle Benutzer sichtbar sind"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Zahlungsmethoden suchen..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Lieferadresse für Bestellung entfernt"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "{enabledCount} Varianten erstellen"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Zahlung #{0} übertragen an {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Fehler beim Laden des Kundenverlaufs: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} erfolgreich aus Kanal entfernt"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Optionswert hinzufügen"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Globale Einstellungen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "ist nach"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Produktoption erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Facetten-Werte bearbeiten"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Hinzufügen..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Sammlungen verschieben"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Rollen"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Rasteransicht"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Fehler beim Löschen der Adresse"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Keine Versandmethoden verfügbar"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Globale Ansicht erfolgreich in persönliche Ansicht umgewandelt"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Erfüllung übertragen"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Möchten Sie wirklich {selectionLength} Assets löschen?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Anmelden"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Listenansicht"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Testbestellung"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Wählen Sie einen Kunden aus, um fortzufahren"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Optionsgruppe erfolgreich zugewiesen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Test ausführen"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Steuersatz: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Bitte fügen Sie Produkte hinzu und vervollständigen Sie die Versandadresse, um den Test durchzuführen."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Kopfzeile umschalten"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Adresse auswählen"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Zahlungsberechtigungsprüfer"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Standard-Steuerzone"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Bestellentwurf ist bereit zur Fertigstellung"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadaten"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filter..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Neuer Facetten-Wert"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Kanal erfolgreich aktualisiert"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Kurzes Datum"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Verfügbare Währungen"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "{0} Artikel auswählen"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Bestellt am"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Das Rotieren dieses Schlüssels macht den aktuellen Schlüssel sofort ungültig. Alle Integrationen, die ihn verwenden, funktionieren erst wieder, wenn sie mit dem neuen Schlüssel aktualisiert wurden."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Die Daten, die an den Job weitergegeben wurden"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Navigation bestätigen"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Link-Ziel"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Entwurf abschließen"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Name"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Fehler beim Erfüllen der Bestellung"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Gesamt"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Geben Sie die Transaktions-ID für diese Rückerstattungsabrechnung ein"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Ihr API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Möchten Sie diesen Bestellentwurf wirklich löschen?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Erfüllung erstellt"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "{0} geeignete Versandmethode{1} gefunden"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Abmessungen"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Passwort anzeigen"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(max: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Unternehmen"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Spalte danach hinzufügen"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Aktionen"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Rabatte"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Rückerstattungsnotiz eingeben"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Bestellzeile entfernt"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Inhalt:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Schlüssel"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Bestätigen"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Fehler beim Erstellen der Sammlung"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Zur ersten Seite"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Fehler beim Erstellen des Produkts"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Kunde"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Fehler beim Laden des Bestellverlaufs: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Lieferadresse für Bestellung festgelegt"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Fokuspunkt"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Einzelvariante, keine Optionen"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Nächsten Status für die Bestellung auswählen"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Gebietsschema"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Geplante Aufgaben"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Transaktions-ID eingeben"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Daten aktualisieren"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Facettenwerte für {0} {entityType} hinzufügen oder entfernen"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Dies sind die Facetten-Werte für die Facette <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Zahlung erfolgreich zur Bestellung hinzugefügt"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Rechnungsadresse für Bestellung festgelegt"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Fehler beim Aktualisieren der Zone"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Passwort"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Fehler beim Löschen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Geplante Aufgabe wird ausgeführt"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Neuer Lagerort"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Berechtigungen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Versandadresse geändert"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Keine Produkte gefunden"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Zeile davor hinzufügen"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Übergang zu {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Dieser Monat"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Fehler beim Erstellen der Facette"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Fehler beim Stornieren der Bestellpositionen"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "Transaktions-ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Zugewiesen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Weitere Optionsgruppe hinzufügen"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Wählen Sie, was mit dem verbleibenden Bestand geschehen soll"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Platform & Cloud entdecken"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Alle 5 Sekunden"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Sammlung erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Preis"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Entwurfsbestellung"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Geltungsbereich"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Bedingung hinzufügen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Versandmethode ist für diese Bestellung berechtigt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administratoren"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Aus Gruppe entfernt"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Breite"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Keine Zahlung oder Rückerstattung erforderlich"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Als .env-Datei herunterladen"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Wenn aktiviert, ist eine Aktion im Shop verfügbar"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Bei Verfolgung werden die Lagerbestände der Produktvarianten beim Verkauf automatisch angepasst. Diese Einstellung kann von einzelnen Produktvarianten überschrieben werden."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Versandmethode für Bestellung festgelegt"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Fehler beim Aktualisieren der Aktion"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Bilder"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "{name} suchen..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Asset bearbeiten"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Zahlung stornieren"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Job-Warteschlange"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Assets"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Slug aus Quellfeld regenerieren"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Von globalen Einstellungen übernehmen"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Aktueller Status"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Legen Sie eine Lieferadresse fest und wählen Sie eine Versandmethode"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Aus"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Einstellungsspeicher"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Warteschlange"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Neuer Steuersatz"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Zahlung übertragen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Verbleibend:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Kein Duplikator mit Code \"{duplicatorCode}\" für {entityName} gefunden"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Preise enthalten Steuern für Standard-Steuerzone"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Gesamtrückerstattung:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Job-Ergebnis anzeigen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Testen Sie Ihre Versandmethoden, indem Sie eine neue Bestellung simulieren."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Keine Artikel ausgewählt"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} ausgewählt"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Keine Länder gefunden"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Varianten erfolgreich erstellt"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Slug automatisch generieren"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Aufschlag"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Zahlungsmethoden"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Lager"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Keine Kunden gefunden"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Globale Grenzwerte für Lagerausfälle verwenden"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Neue Produktoptionsgruppe"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Zahlungsstatus erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Neu erstellen"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Erstattungsbetrag"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adresse gelöscht"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Es stehen nur Rollen zur Verfügung, die Ihrem Konto zugewiesen sind."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Element zur Bestellung hinzugefügt"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Fokuspunkt bearbeiten"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Keine Verkäufer gefunden"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Asset"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Diese Optionsgruppe wird von einem anderen Produkt verwendet. Änderungen wirken sich auch darauf aus.} other {Diese Optionsgruppe wird von # Produkten gemeinsam genutzt. Änderungen wirken sich auf alle aus.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Meine gespeicherten Ansichten"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Neuer Kanal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Fehler beim Erstellen des Verkäufers"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Duplizierungseinstellungen für {0}s konfigurieren"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Keine Varianten entsprechen dem aktuellen Filter."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adressen"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Einen neuen Optionswert zur Optionsgruppe {groupName} hinzufügen"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Bestellungsmodifikation #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Spalte davor hinzufügen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Kanal-Sprachen"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Fehler beim Erstellen der Optionsgruppe"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Wahr"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Kunde auswählen"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Bestellung übertragen"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Dieses Produkt hat bereits Varianten, aber keine Optionsgruppen definiert. Sie müssen Optionsgruppen hinzufügen, bevor Sie neue Varianten erstellen."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "ist vor"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Bestellentwurf löschen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Katalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Neue Zahlungsmethode"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Aktion erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {{rejected} Job konnte nicht abgebrochen werden} other {{rejected} Jobs konnten nicht abgebrochen werden}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Kanal auswählen"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Anzeigesprache"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Erfüllungsdetails"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Verbleibenden Bestand verwerfen"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Jetzt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Kanäle"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Ansicht erfolgreich in globale Ansicht umgewandelt"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "vor"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Größe"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Keine Übersetzung für {0} gefunden"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Neuer Kunde"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Neueste Bestellungen"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} weitere"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Als Standard-Rechnungsadresse verwenden"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Löschen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Deaktivieren"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Sammlungen"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Variante hinzufügen"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Fehler beim Erstellen des Lands"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Länder"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Fehler beim Erstellen der Produktoptionen"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Fehler beim Umbenennen der Ansicht"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Verfügbar"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filter"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Kundengruppen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Kunden"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Beispielformatierung"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Neue Option"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Nutzungslimit"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Lade globale Einstellungen..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adresse erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Erstellt"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Lade Adressen..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Zielsammlung auswählen, um {0} dorthin zu verschieben."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Kundendetails aktualisiert"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "nicht in"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Anwenden"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Neue Produktoption"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Zur letzten Seite"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Abbrechen"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Produktvariante erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Rückerstattung von dieser Methode"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Zuerst Produktoptionen hinzufügen"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Neue Steuerkategorie"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Option hinzufügen"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Teilerstattung abgeschlossen"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Benutzerdefinierte Felder setzen"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Sammlungen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Variante löschen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Keine Änderungen vorgenommen"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Standard-Versandzone"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Grund:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Versandadresse"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Übergang zu {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Steuerkategorien"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Private Sammlungen sind im Shop nicht sichtbar"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Wenn aktiviert, ist ein Produkt im Shop verfügbar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Geplante Aufgabe konnte nicht ausgeführt werden"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Kundengruppen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Neue Aktion"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Standard-Versandadresse"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Rückerstattung erforderlich"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Bestellung erfüllen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Sie haben keine Berechtigung, die Kanaleinstellungen anzuzeigen"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Keine Facetten-Werte"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Ein Grund für die Erstattung ist erforderlich"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Optionsgruppe konnte nicht entfernt werden"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Fehler beim Aktualisieren der Steuerkategorie"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Rückerstattung erfolgreich abgewickelt"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Bestellung aufgegeben"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profil erfolgreich aktualisiert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "Ende"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Zahlungsmethode"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variante erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Nach Sammlungsname filtern"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Notiz hinzugefügt"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Mengen zum Erfüllen auswählen und Erfüllungs-Handler konfigurieren"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Rechnungsadresse für Bestellung entfernt"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Beginnt am"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplizieren"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Keine Ergebnisse"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Spalteneinstellungen"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {{count} Lagerort konnte nicht gelöscht werden} other {{count} Lagerorte konnten nicht gelöscht werden}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Code"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Optionsgruppen konnten nicht entfernt werden"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Bestellung zugestellt"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Übertragen an {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Verbleibender Bestand"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Aus Zone entfernen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Aus global verfügbaren Sprachen für diesen Kanal auswählen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Möchten Sie diese Adresse wirklich löschen?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Optionsgruppe konnte nicht zugewiesen werden"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Fehler beim Aktualisieren des Assets"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Lagerort erfolgreich aktualisiert"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Aktion bestätigen"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Land erfolgreich aktualisiert"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Facetten"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Fehler beim Hinzufügen der Notiz"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Fehler beim Löschen der Notiz"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Fehler beim Erweitern des Abfragedokuments"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Fehler beim Aktualisieren der Notiz"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Versand erstatten"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Schreibgeschützt"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Fehler beim Duplizieren der globalen Ansicht"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "{shown} von {total} werden angezeigt • {selected} ausgewählt"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Versandmethode testen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Facetten-Werte"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Asset erfolgreich aktualisiert"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Theme"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} Kunden"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Sprache auswählen"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Abmelden"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Versuche"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Verfügbare Währungscodes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Verfügbare Sprachcodes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Brotkrümel"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Kategorie"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Kanäle"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Kinder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Gutscheincode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Erstellt am"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Währungscode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Kunde"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Kundengruppe"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Kunden"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Benutzerdefinierte Felder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Daten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Standard-Währungscode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Standard-Sprachcode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Standard-Versandzone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Standard-Steuerzone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Beschreibung"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Dauer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "E-Mail-Adresse"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Aktiviert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Endet am"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Fehler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Haupt-Asset"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Vorname"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Erfüllungshandler-Code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Ist Standard"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Ist privat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Ist abgewickelt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Nachname"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Name"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Bestellung aufgegeben am"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "Eltern-ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Verwendungslimit pro Kunde"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Berechtigungen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Position"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Preis"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Preise inklusive Steuer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Preis mit Steuer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Produktvarianten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Fortschritt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Warteschlangenname"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Ergebnis"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Wiederholungen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Verkäufer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Abgewickelt am"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Versandlinien"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Gestartet am"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Startet am"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Status"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Lagerbestände"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Gesamt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Gesamt mit Steuer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Typ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Aktualisiert am"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Verwendungslimit"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Benutzer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Wert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Werteliste"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Methode"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Steuerübersicht"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Legt die Sprachen fest, die für alle Kanäle verfügbar sind. Einzelne Kanäle können dann eine Teilmenge dieser Sprachen unterstützen."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Sammlungen erfolgreich verschoben"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registriert"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Job abbrechen"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Endet am"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Seite {0} von {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Satz"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Größe, Farbe usw."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Facetten durchsuchen"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Storniert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Erstellt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Geliefert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Ausstehend"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Versandt"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Ansicht speichern"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} ausgewählt"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Optionsgruppen suchen..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Bestellung ändern"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Ausgewählte Artikel"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Werte"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Kunde für Bestellung festgelegt"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Facetten"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Möchten Sie wirklich {count} Kunden aus dieser Gruppe entfernen?} other {Möchten Sie wirklich {count} Kunden aus dieser Gruppe entfernen?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Lagerbestand"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Suchindex-Neuerstellung konnte nicht gestartet werden"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Versandadresse"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Neue Zone"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Neuer API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Spalte löschen"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Bestehende zuweisen"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "ist null"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Dies sind die Kunden in der Kundengruppe <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Globale Ansichten verwalten"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Standardkanal"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Ein neues Bild mit Quelle, Titel und Abmessungen einfügen"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Fehler beim Erstellen des Facettenwerts"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Produktoption konnte nicht aktualisiert werden"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Passwort vergessen?</0><1>Zurücksetzen anfordern</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Gutscheincode"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Kunde verifiziert"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Globale Einstellungen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Zeitplan"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Eine Sammlung kann nicht in einen eigenen Unterordner verschoben werden"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Neue Steuerkategorie"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Keine Lagerorte im aktuellen Kanal verfügbar"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Kanal erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Kunde erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Daten anzeigen"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Ansicht löschen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Neue Adresse zum Kunden hinzufügen."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Weitere Ansichten"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Die ausgewählten Bildeigenschaften bearbeiten"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Ansicht „{viewName}\" angewendet"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} Facetten erfolgreich aus Kanal entfernt"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Neues Produkt"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Neues Asset"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Versand neu berechnen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Wählen Sie aus, welche Optionen für die vorhandene Variante \"{0}\" gelten sollen"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Assets"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Dadurch werden alle Optionsgruppen von diesem Produkt entfernt und Sie kehren zur Varianteneinrichtung zurück."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Rechnungsadresse"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Facettenwert hinzufügen"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Bitte wählen Sie eine Zielsammlung aus"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Überprüfen Sie die Änderungen, bevor Sie sie auf die Bestellung anwenden."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Rolle auswählen"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Bestellung storniert"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Rabatt"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Alle Typen"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Nur Bestellentwürfe können abgeschlossen werden"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Fehler beim Aktualisieren des Produkts"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "{0} Positionen anpassen"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Facettenwerte hinzufügen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "nach"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Kanal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Gesundheitsprüfungen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Betrag"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Neuer Kunde"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Bild"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administrator erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Produktoptionen"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Land auswählen"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Erstelle..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Möchten Sie diese globale Ansicht wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden und betrifft alle Benutzer."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Optionsgruppe erzwungen entfernen"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Hinzugefügt"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Kundenverlauf"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Facettenwerte für {entityIdsLength} {entityType} erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Fehler beim Entfernen des Kunden aus der Gruppe"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Nutzungslimit pro Kunde"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Rechnungsadresse geändert"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Eine Option auswählen"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "In persönlich kopieren"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Der Erstattungsbetrag übersteigt den maximal erstattungsfähigen Betrag von {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Globale Ansicht löschen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Erstellen"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Alle 30 Sekunden"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Neues Land"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "Von {0} zu {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Fehler beim Erstellen des Kunden"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Fokuspunkt aktualisiert"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Optionswerte"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Standard-Rechnungsadresse"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Kein Kunde"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Fehler beim Entfernen der Länder aus der Zone"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Fehler beim Erstellen der Aktion"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Heute"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Gestern"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Optionsname"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Sind Sie sicher, dass Sie {0} {1} aus dieser Zone entfernen möchten?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "{0} Zuschlag/Zuschläge werden hinzugefügt"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Link-URL"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Fallback: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Bestellverlauf"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Überschreiben"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "Transaktions-ID ist erforderlich"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "entspricht regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Globale Ansicht erfolgreich umbenannt"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Keine Tags ausgewählt"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Zurück"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Ansicht erfolgreich umbenannt"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Filter anwenden"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Letztes Ergebnis"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Zur Gruppe hinzugefügt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Erkenntnisse"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Varianten erstellen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Teste Versandmethode..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Dunkel"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Testergebnisse"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Kunde hinzufügen"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adresse aktualisiert"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Erstattung erfolgreich verarbeitet"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Neue Zone"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Fehler beim Aktualisieren der Sammlungsposition"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Erstattung"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Ändern"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Keine globalen Sprachen konfiguriert"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Entferne {0} Artikel"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Verfolgen"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Variante erstellen"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Facetten-Werte für {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Layout speichern"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Passwort-Zurücksetzung verifiziert"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Fehler beim Löschen der Ansicht"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Möchten Sie diese Seite wirklich verlassen? Alle nicht gespeicherten Änderungen gehen verloren."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Kopfzeile-Spalte umschalten"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Neue Aktion"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Name des Optionswerts"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Zuletzt verwendet"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Ist Standard-Steuerkategorie"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug ist festgelegt"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Fokuspunkt konnte nicht aktualisiert werden"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zone erfolgreich aktualisiert"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Bundesland/Provinz"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Optionsgruppe konnte nicht aktualisiert werden"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Kanal-Standards"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Fehler beim Erstellen der Steuerkategorie"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Filterkriterien für die Spalte {columnId} festlegen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Land"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Einfaches Produkt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Job-Warteschlange"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Bitte bestätigen Sie, dass Sie den API Key gespeichert haben, bevor Sie schließen."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Löschung bestätigen"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Fehler beim Ändern der Bestellung"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Inkl. {taxRate}% MwSt."
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Bestellmetriken"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Anzeigesprache auswählen"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Authentifizierungsmethoden"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "Anfang"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "API Key konnte nicht rotiert werden"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "in"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Rollen suchen..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Produktvarianten"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Globale Ansichten verwalten"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Wird verarbeitet..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} gefunden"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Datumsbereich auswählen"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Produkt"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "API Key rotieren"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Kategorie"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Verschiebe..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Zuweisen"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Verkäufer erfolgreich erstellt"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Versandmethode erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Fehler beim Aktualisieren der Produktvariante"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Zum Sortieren ziehen"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zonen"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Wählen Sie, was mit dem verbleibenden Bestand in {count, plural, one {# Lagerort} other {# Lagerorten}} geschehen soll, den Sie löschen. Alle ausgewählten Lagerorte übertragen ihren verbleibenden Bestand an den einen von Ihnen gewählten Lagerort oder verwerfen ihn."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Facettenwerte suchen..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Hinweis"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Verfügbare Sprachen"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "{0} weitere laden ({remaining} verbleibend)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Facetten-Werte"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Fehler beim Neuanordnen der Artikel"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Bestellungen gesamt"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Keine geeigneten Versandmethoden für diese Bestellung gefunden."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Produktoption hinzufügen"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Versand"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions muss innerhalb eines DashboardBaseWidget verwendet werden"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Diese Optionsgruppe wird von bestehenden Varianten verwendet. Das erzwungene Entfernen kann diese Varianten beeinträchtigen. Sind Sie sicher?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "E-Mail-Aktualisierung angefordert"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Fehler beim Übergang zum Status"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Kundengruppe erfolgreich erstellt"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Neues Fenster"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Zahlung autorisiert"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Rolle erfolgreich aktualisiert"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Land auswählen"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Versandmethode konnte nicht aktualisiert werden"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} Lagerort gelöscht} other {{deleted} Lagerorte gelöscht}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Versandmethoden"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Eine Adresse auswählen"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Ja"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Fokuspunkt setzen"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "Ende"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Währung auswählen"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Notizinhalt oder Sichtbarkeit aktualisieren"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Neueste Bestellungen Widget"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Sammlungsinhalte für {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Versandmethode geändert"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Steuerbeschreibung"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "ist kleiner oder gleich"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "ist nicht gleich"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Aktualisieren"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "z.B. Größe"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Zahlung abwickeln"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Kanäle"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Versand erstattet"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Asset-Typ"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Neuer Lagerort"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} Zahlung(en) wurden vor dem Fehler erstattet. Details finden Sie in der Bestellhistorie."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Artikel auswählen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Neues Produkt"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Tags verwalten"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Artikel erstattet"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Aktion hinzufügen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Optionen zu bestehender Variante zuweisen"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "{0} duplizieren"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Aus Gruppe entfernen"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Fehler beim Aktualisieren des Erfüllungsstatus"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Eine neue Produktvariante mit Optionen, Preisen und Bestand erstellen"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Private Facetten sind im Shop nicht sichtbar"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Steuerkategorie auswählen"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Erstellt"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Läuft nicht"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Zugewiesen"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Verfügbare Sprachen auswählen"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "{0} Artikel werden hinzugefügt"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Zeile danach hinzufügen"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Steuersumme"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Status des Bestellentwurfs"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Produktoptionen erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Lagerorte werden geladen…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Fehler beim Erstellen der Zahlungsmethode"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Facettenwert erfolgreich erstellt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Bestellentwurf gelöscht"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "größer als"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Metriken-Widget"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Währungen suchen..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Aus Kanal entfernen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Titel"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Fehler beim Aktualisieren des Verkäufers"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Land erfolgreich erstellt"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Verkäufer auswählen"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Lade Tags..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Facette erfolgreich erstellt"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} Varianten"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Fehler beim Abwickeln der Zahlung"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Keine Rechnungsadresse"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {{1} Lagerort konnte nicht gelöscht werden} other {{2} Lagerorte konnten nicht gelöscht werden}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Facette"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Kann nicht aus aktivem Kanal entfernt werden"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Nicht gesetzt"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Erzwungenes Entfernen"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Neuer Kanal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Name der Optionsgruppe"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "UND"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Fehler beim Erstellen der Kundengruppe"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Fehler beim Erstellen der Rolle"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Produktname"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Erfüllungsstatus erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Produkte"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adresse erstellt"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key erfolgreich rotiert"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Optionsgruppe hinzufügen"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "{0} erstatten"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Slug manuell eingeben"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Keine Widgets verfügbar"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Fehler beim Stornieren der Zahlung"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Zahlung erfolgreich storniert"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Globale Ansicht erfolgreich dupliziert"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Erstellt von"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Varianten filtern..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Preis in einer anderen Währung hinzufügen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "E-Mail-Adresse oder Bezeichner"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Rückerstattung #{0} übertragen zu {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Kunden"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Überschrift 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Fehler beim Aktualisieren des Lagerorts"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Bestellung versandt"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Adresse speichern"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Global machen"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Nächsten Status auswählen"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Keine Benachrichtigungen"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Verschiebe {0} Sammlung{1} nach {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "zwischen"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Notiz erfolgreich hinzugefügt"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Notiz erfolgreich gelöscht"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Notiz erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Fehler beim Abwickeln der Rückerstattung"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Lagerbestand"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Element hinzufügen"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Lade Vorschau..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Zurück zur Suche"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Ansicht erfolgreich dupliziert"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Optionsgruppe entfernen"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Länder"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Straßenadresse 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Globale Ansicht erfolgreich gelöscht"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Layout bearbeiten"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Zu Kanal zuweisen"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Diese Woche"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Produktoptionsgruppe erfolgreich erstellt"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Manuelle Zahlung von {0} hinzufügen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "ist in"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-Mail"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Administrator konnte nicht aktualisiert werden"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Ihre persönlichen gespeicherten Ansichten für diese Tabelle verwalten"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Nach Tags filtern"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Melden Sie sich an, um auf das Admin-Dashboard zuzugreifen"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Zahlung zur Bestellung hinzufügen ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Falsch"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Hell"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "ist gleich"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Optionen erstellen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Passwort aktualisiert"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "enthält nicht"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Optionsgruppe"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Bearbeiten Sie die Adressdaten unten."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Steuerkategorie erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Fehler beim Verschieben der Sammlungen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Fehler beim Aktualisieren des Zahlungsstatus"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Ihre Bestellübersicht"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Hochladen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Produkt mit Optionen"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Zeige alle {0} Ergebnisse"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Lookup-ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} weitere"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Optionsgruppen"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Benutzerdefinierte Felder"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Alle möglichen Bestellstatus und deren Übergänge. Der aktuelle Status ist hervorgehoben."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Bestellungen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Bestellungsübersicht Widget"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Artikel hinzufügen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Zusätzliche Zahlung einrichten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Zahlung einrichten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Storniert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Erstellt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Geliefert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Entwurf"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Wird geändert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Teilweise geliefert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Teilweise versandt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Zahlung autorisiert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Zahlung abgewickelt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Versandt"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Überwachte Ressourcen"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Entitätsinformationen"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Bestellsumme"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Nur für Administratoren sichtbar"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Menge"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Tags"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super Admin"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Einige Ressourcen sind nicht verfügbar"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Verfügbare Aktionen"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Link einfügen"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Falls aktiviert, werden die Filter von der übergeordneten Sammlung übernommen und mit den Filtern dieser Sammlung kombiniert."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Zone auswählen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Versandmethoden testen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Zahlung erfolgreich abgewickelt"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} aus Zone entfernt"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Aktivieren"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Zahlungsmethoden"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autorisiert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Storniert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Erstellt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Abgelehnt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Fehler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Fehlgeschlagen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Ausstehend"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Abgewickelt"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Durchschnittlicher Bestellwert"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Fehler beim Erstellen der Zone"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Lagerbestände"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "API Key konnte nicht aktualisiert werden"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Bestellpositionen"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Fehler beim Umbenennen der globalen Ansicht"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Einen neuen Hyperlink mit URL und Zieloptionen einfügen"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Höhe"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Eine Rückerstattung von {formattedDiff} ist erforderlich. Wählen Sie Zahlungsbeträge und geben Sie eine Notiz ein, um fortzufahren."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Stückpreis"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Zeitplan-Muster"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Zahlung fehlgeschlagen"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Kanal hinzufügen"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Aktualisierung der Produktoptionsgruppe fehlgeschlagen"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Kanäle suchen..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Kundengruppen hinzufügen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Verfügbare Sprachen"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Auswahl zurücksetzen"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Keine Adresse"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Zahlungsmethode erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Kundeninformationen aktualisiert"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Fehler beim Umwandeln der Ansicht in globale Ansicht"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Produktvarianten"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Produkte"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Aktionen"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Produktoption konnte nicht erstellt werden"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Alte E-Mail:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Speichern Sie eine Ansicht als \"Global\", um sie für alle Benutzer verfügbar zu machen."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Varianten konnten nicht erstellt werden"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Legt den Lagerbestand fest, bei dem diese Variante als nicht vorrätig gilt. Ein negativer Wert ermöglicht die Unterstützung von Nachbestellungen. Kann von Produktvarianten überschrieben werden."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Schlüssel rotieren"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Produktvarianten konnten nicht erstellt werden"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Passwort verbergen"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Neuer Verkäufer"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "z.B. Rot, Groß, Baumwolle"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Fehler beim Aktualisieren des Profils"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Entfernte Gutscheincodes"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Filter löschen"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regionen"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Dateien zum Hochladen hier ablegen"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Alle sichtbaren Varianten umschalten"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verifiziert"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Neue Optionsgruppe"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Zuletzt aktualisiert {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Es wurden noch keine globalen Ansichten erstellt."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Fehler beim Aktualisieren der Rolle"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Der vollständige API Key wird nur dieses eine Mal angezeigt. Kopieren oder laden Sie ihn jetzt herunter — er kann später nicht mehr abgerufen werden."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Sammlung erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Zahlungsmethode erfolgreich aktualisiert"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Ansicht erfolgreich gelöscht"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Optionsgruppe {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "ODER"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Tags verwalten"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Gutscheincode aus Bestellung entfernt"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Niemals"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Fehler beim Aktualisieren des Facettenwerts"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Gruppe entfernen"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Bestellung erfüllt"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Keine Versandadresse"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Abfrageerweiterung enthält ungültige GraphQL-Syntax"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Abfrageerweiterungsfehler"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Abfrageerweiterungsfehler: "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Abfrageerweiterung ist ungültig: muss mindestens ein Top-Level-Feld haben"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Abfrageerweiterung stimmt nicht überein: "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "öffentlich"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Steuerkategorie erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Verschieben"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Vorhandene Tags bearbeiten oder löschen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Die Berechtigungsprüferbedingungen dieser Versandmethode sind für die aktuelle Bestellung und Versandadresse nicht erfüllt."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Gutscheincode hinzufügen"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Gutscheincode für Bestellung festgelegt"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Benutzerdefinierte Felder"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Neue Versandmethode"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Lagerorte löschen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "ist größer oder gleich"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Vorschau"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} von {1} verfügbar zur Erfüllung"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Monat bis heute"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Kundenanfrage"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Beim Versand beschädigt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Nicht verfügbar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Sonstiges"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Falscher Artikel"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Zusammenfassung der Änderungen"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Rückerstattungen ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Zuletzt ausgeführt"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Zahlungsdetails"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Suchindex neu erstellen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Läuft"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Alle 60 Sekunden"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Fehler beim Aktualisieren der Kundengruppe"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Zahlungsmetadaten"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Änderung abbrechen"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Gleiches Fenster"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Filter auf die Tabelle anwenden und \"Ansicht speichern\" klicken, um loszulegen."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Rollen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Zusätzliche Zahlung erforderlich"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Fehler beim Aktualisieren der Bestellung"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Mit ausgewählten..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Fehler beim Erstellen des Lagerorts"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "kleiner oder gleich"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Kundengruppenmitglieder für {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Status"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Nicht verfolgen"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Erfüllung #{0} erstellt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Ausstehende Suchindex-Aktualisierungen werden ausgeführt"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Dies ist eine Standardrolle und kann nicht geändert werden"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Meine gespeicherten Ansichten"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Bundesland / Provinz"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Einträge pro Seite"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Mitglieder bearbeiten"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Lagerbestand"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Nach {columnId} filtern"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Benachrichtigungen"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Optionswerte"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Änderungen vorschauen"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "{entityType} konnte nicht aus dem Kanal entfernt werden"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variante erfolgreich gelöscht"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Die ausgewählten Link-Eigenschaften bearbeiten"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Verkäufe"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Zielsammlung auswählen"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Ihre neuesten Bestellungen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Geplante Aufgaben"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Möchten Sie dieses Element wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Varianten"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Verkäufer"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Einstellungen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Einstellungsspeicher"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Überschrift 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Willkommen bei Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Versandmethoden"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} erstattungsfähig)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Bezeichner"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Fehler beim Aktualisieren der Sammlung"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Preis und Steuer"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Bestellung nicht gefunden"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Fehler"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Bestellung geändert"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Passwort-Zurücksetzung angefordert"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Der zugewiesene Zahlungsbetrag muss dem Erstattungsbetrag entsprechen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "z.B. Klein"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Möchten Sie wirklich {0} {entityType} aus dem aktuellen Kanal entfernen?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Tags hinzufügen..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Erstellen der Produktoptionsgruppe fehlgeschlagen"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} Elemente ausgewählt"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Sprachen suchen..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Lagerorte"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Zur vorherigen Seite"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Inhalte"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Fehler beim Umwandeln der globalen Ansicht in persönliche Ansicht"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Das Ergebnis des Jobs"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Zahlung hinzufügen ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Variantenname"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Entfernen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Fehler beim Aktualisieren des Kunden"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Optionsgruppen entfernen?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Dies ist eine Vorschau der Sammlungsinhalte basierend auf den aktuellen Filtereinstellungen. Sobald Sie die Sammlung speichern, werden die Inhalte aktualisiert, um die neuen Filtereinstellungen widerzuspiegeln."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} Kunde aus der Gruppe entfernt} other {{count} Kunden aus der Gruppe entfernt}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Steuerkategorien"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Steuersätze"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Kunden konnten nicht aus der Gruppe entfernt werden"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Fehler beim Laden der globalen Einstellungen"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Artikel zur Erstattung auswählen und optional wieder einlagern"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Speichern"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} von {0} Zeile(n) ausgewählt."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Bestelländerungen vorschauen"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Produktoptionsgruppe erfolgreich aktualisiert"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Die Seite wird mit der Standardabfrage fortfahren."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Straßenadresse"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Keine weiteren Facetten"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Suchindex-Neuerstellung gestartet"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Sammlungsposition aktualisiert"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Name der Optionsgruppe"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "\"{newOptionInput}\" hinzufügen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Neue Produktvariante"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Rückerstattung übertragen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Verwende native Authentifizierungsstrategie"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Fehler beim Zuweisen von {entityIdsLength} {entityType} zum Kanal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Standardsprache"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Erfülle..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Optionsgruppe zum Produkt hinzufügen"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Vorschau von {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Verkäufer erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Fehler beim Übergang der Bestellung zum Status"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Alle anzeigen ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Fehler beim Erstellen des Steuersatzes"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Ich habe diesen API Key gespeichert"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Verfügbare Sprachen für Ihren Shop und Ihre Kanäle konfigurieren"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Produkt erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Produktvariante hinzufügen"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Tippen und Enter oder Komma drücken zum Hinzufügen..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Notiz bearbeiten"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Keine Assets gefunden. Versuchen Sie, Ihre Filter anzupassen."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Option hinzufügen"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Optionsgruppe speichern"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "{createCount} Varianten erstellen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Klicken Sie auf \"Test ausführen\", um diese Versandmethode zu testen."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administrator erfolgreich aktualisiert"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Filter löschen"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Erfüllung #{0} von {1} zu {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Fehler beim Löschen der globalen Ansicht"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Standardsprache"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Keine Optionen gefunden"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binär"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Optionsgruppe erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Neue Versandmethode"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Alle 10 Sekunden"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "exkl. Steuer:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Bestand zum Standort hinzufügen"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Optionswert erfolgreich hinzugefügt"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Sammlung in neuen übergeordneten Ordner verschoben"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Optionsgruppe entfernt"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Zum ausgewählten Status übergehen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Eine zusätzliche Zahlung von {formattedDiff} wird erforderlich sein."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Inventar standardmäßig verfolgen"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} von {total} ausgewählt"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Versandmethode erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Neue Kundengruppe"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Für Kunden sichtbar"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Optionsgruppe erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Steuersätze"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug wird automatisch generiert..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Kunde nicht gefunden"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "{0} auswählen"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Neue Facetten-Werte hinzufügen:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Fehler bei der Verarbeitung der Erstattung"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Vorname"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "enthält"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Keine Optionsgruppen gefunden"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Keine Artikel gefunden"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Zwischensumme"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Erfüllte Artikel ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Wert aktualisiert"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Nicht verifiziert"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Menge"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Steuerkategorie"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Testdaten wurden aktualisiert. Klicken Sie auf \"Test ausführen\", um aktualisierte Ergebnisse zu sehen."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "ist nicht in"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Bestellzeile aktualisiert"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Neue Zahlungsmethode"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Der doppelte Wert \"{trimmed}\" existiert bereits"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Grund"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Kundengruppen"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} erfolgreich aus dem Kanal entfernt"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Optionsgruppen"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Zuschlag hinzufügen"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Aktuelle Facetten-Werte"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Seite {page} von {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Letzter Monat"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Land hinzufügen"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Element entfernen"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "kleiner als"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Die Variante konnte nicht hinzugefügt werden. Stellen Sie sicher, dass das übergeordnete Produkt aktiviert ist."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Ein unbekannter Fehler ist aufgetreten"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Metriken"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Sprache"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Neue Sammlung"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Erstattung und Bestellung stornieren"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "E-Mail-Aktualisierung verifiziert"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "ist zwischen"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Erstatten & Stornieren"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Teste Versandmethoden..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Versandmethode konnte nicht erstellt werden"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} erfolgreich zu Kanal zugewiesen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Globale Sprachen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Neuer Administrator"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Entwurf löschen"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Quelle"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Fehler beim Aktualisieren des Kanals"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Allgemein"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Fehler beim Entfernen des Produkts aus dem Kanal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Neue Adresse hinzufügen"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Facette erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zone erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Wert"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Kunde aktualisiert"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Preisumrechnungsfaktor"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Verkäuferbestellung"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Neue Facette"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Sind Sie sicher, dass Sie diese Optionsgruppe vom Produkt entfernen möchten?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Beschreibung (Alt-Text)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Keine Tags gefunden"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Standardwährung"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Für diese Änderungen ist keine Zahlung oder Rückerstattung erforderlich."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Gesamtumsatz"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Nächste Ausführung"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Notiz ist privat"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Mittleres Datum"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Ungültige Zahl"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Sie haben noch keine Ansichten gespeichert."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Möchten Sie diese Ansicht wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Bestellprozess anzeigen"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Fehler beim Duplizieren der Ansicht"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Als Standard-Versandadresse verwenden"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Slug manuell bearbeiten"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Filter hinzufügen, um die Sammlungsinhalte in der Vorschau anzuzeigen."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Produktoptionsgruppe"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Zwischensumme"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "ist kleiner als"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "Rückerstattungs-ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Benutzerdefinierte Bestellfelder aktualisiert"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Rechner"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Optionsgruppe konnte nicht aus dem Kanal entfernt werden: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Job-Daten anzeigen"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "An die oberste Ebene verschieben"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Leeren"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Bestellübersicht"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Assets suchen..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Neue Facette"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "{entityType} zu Kanal zuweisen"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Fortfahren"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Aktionen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Fehlermeldung"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Lagerbestand für einen anderen Standort hinzufügen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Adresse löschen"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Fehler beim Aktualisieren der Facette"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters muss innerhalb eines WidgetFiltersProvider verwendet werden"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Adresse bearbeiten"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Fehler beim Entfernen der Facette aus dem Kanal: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Link setzen"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Neuer Verkäufer"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Bild bearbeiten"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Varianten verwalten"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Zugewiesener Bestand"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "größer oder gleich"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Legt den Lagerbestand fest, bei dem diese Variante als nicht vorrätig gilt. Ein negativer Wert ermöglicht die Unterstützung von Nachbestellungen."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Produktoptionen erstellen"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Speichere..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Ergebnis anzeigen"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Zeilen pro Seite"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Lade Sammlungen..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Facettenwert erfolgreich aktualisiert"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Asset hinzufügen"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Änderungen speichern"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Kunde zur Gruppe hinzugefügt"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Verkäuferbestellungen"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Fehler beim Hinzufügen des Optionswerts"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Optionswert zu {groupName} hinzufügen"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} Artikel erstattet"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Noch keine Optionsgruppen definiert. Fügen Sie Optionsgruppen hinzu, um verschiedene Varianten Ihres Produkts zu erstellen (z.B. Größe, Farbe, Material)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Neue E-Mail:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Fehler beim Aktualisieren der Zahlungsmethode"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Verfügbar:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Erstellt am"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Fehler beim Erstellen der Produktvariante"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Sprache: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Sie haben keine Berechtigung, die globalen Spracheinstellungen anzuzeigen"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Steuersatz erfolgreich erstellt"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Überschrift 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Gutscheincodes hinzugefügt"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Aktiv"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Steuerbasis"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Mehr laden"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Rückerstattung abgerechnet"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} erfolgreich dupliziert"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Neue Optionsgruppe"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Noch kein Ergebnis"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Zahlung abgerechnet"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Verfügbare Bedingungen"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Aktive Filter"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "ist größer als"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Schließen"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Zahlung zur Bestellung hinzufügen"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Lade..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Das Token wird verwendet, um den Kanal bei API-Anfragen zu spezifizieren."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Keine Adressen gefunden"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "Erfüllungs-ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Zahlungen zur Erstattung auswählen"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Fehler beim Löschen von {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Grenzwert für Lagerausfall"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt erfolgreich aus Kanal entfernt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Wert konnte nicht aktualisiert werden"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "API Key konnte nicht erstellt werden"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Rückerstattung abrechnen"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Zahlungsmethode ist erforderlich"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Fehler beim Hinzufügen des Kunden zur Gruppe"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Varianten verwalten"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Globale Ansicht „{viewName}\" angewendet"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Kunde registriert"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zonen"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Verkäufer suchen..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Aktion erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Option"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Bestellprozess"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privat"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variante"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Globale Einstellungen erfolgreich aktualisiert"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key erfolgreich aktualisiert"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Diese Sprachen stehen allen Kanälen zur Verfügung"

--- a/packages/dashboard/src/i18n/locales/en.po
+++ b/packages/dashboard/src/i18n/locales/en.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Full Name"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Select items"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "View changes"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Tracking code"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "The selected permissions will be applied to the these channels."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Product options"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "New Tax Rate"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Assign an existing option group or create a new one"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "New role"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Apartment, suite, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "No more items"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Edit link"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Add at least one item to the order"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Add products to create a test order"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Failed to create address"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Toggle all"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Edit JSON value"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Using external authentication strategy: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Select a reason..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Heading 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Failed to add payment"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Updated"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Failed to update global settings"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Successfully fulfilled order"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Are you sure you want to delete {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Global out of stock threshold"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Manage Languages"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Duplicating... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Deleted successfully"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Remove from current channel"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Deleted {selectionLength} assets"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Successfully updated tax rate"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Enter custom reason..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Type"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr "The default currency is chosen from this list."
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Select {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr "Add more ({0} selected)"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "View values"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Delete row"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Conditions"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Current"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "No fulfillments"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Create variants for your product"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Draft order completed"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Auto refresh: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr "Successfully cancelled {fulfilled} job"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Health checks"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Deleted {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr "File Size"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Healthchecks"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Sellers"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Options"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Seller"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Add payment"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Explore Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Stock Locations"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Fulfillment handler"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Orders"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Select roles"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Successfully created role"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Are you sure you want to delete this variant?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "All resources are up and running"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Failed to create administrator"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "No"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Successfully updated product variant"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Failed to delete {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Successfully updated product"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Failed to update country"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Type at least 2 characters to search..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Last name"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Link title"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Successfully updated customer group"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Custom fields changed"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Successfully created stock location"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Unknown error"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Refund total cannot be negative"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "View details"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Select a channel to assign {0} {entityType} to"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Successfully created customer"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Last 7 days"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Failed to create channel"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Dev Mode"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "New Role"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Failed to delete assets: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Return to stock"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Visibility"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Product variants"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "New customer group"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Create \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Rename"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Choose your preferred display language and locale settings"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr "← Back"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "Successfully removed {successCount} option groups from channel"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Shipping method is not eligible for this order"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Failed to update address"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Address deleted successfully"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Tax rate"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr "{fulfilled, plural, one {{0}} other {{1}}}"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Order draft isn't ready to be completed"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "New collection"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Insights"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Run"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Failed to update tax rate"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "This is the contents of the <0>{collectionName}</0> collection."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "private"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Successfully created product option"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Parent product"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "City"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administrators"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Gross price: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Go to next page"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Remove link"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "This field is readonly"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Order Count"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr "You must first select an available currency to set a default currency"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Successfully updated order"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Inherit filters"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Manage global saved views that are visible to all users"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Search payment methods..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Shipping address unset for order"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Create {enabledCount} variants"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Payment #{0} transitioned to {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Error loading customer history: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "Successfully removed {selectionLength} {entityType} from channel"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Add option value"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Global Settings"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "is after"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Successfully updated product option"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Edit facet values"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Adding..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Move Collections"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Roles"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Grid view"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Failed to delete address"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "No shipping methods available"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Global view converted to personal view successfully"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Fulfillment transitioned"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Are you sure you want to delete {selectionLength} assets?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "List view"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Test Order"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Select a customer to continue"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Successfully assigned option group"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Run Test"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Tax rate: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Please add products and complete the shipping address to run the test."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Toggle header row"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Select address"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Payment eligibility checker"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Default tax zone"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Order draft is ready to be completed"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadata"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr "Failed to set shipping method for order: {0}"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filter..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "New facet value"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Successfully updated channel"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Show less"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Short date"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Available currencies"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Select {0} Items"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Placed At"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "The data that has been passed to the job"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Confirm navigation"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Link target"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Complete draft"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Name"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Failed to fulfill order"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Total"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Enter the transaction ID for this refund settlement"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Your API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Are you sure you want to delete this draft order?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Fulfillment created"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Found {0} eligible shipping method{1}"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Dimensions"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Show password"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(max: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Company"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Add column after"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Actions"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Discounts"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Enter refund note"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Order line removed"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Content:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Key"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Confirm"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr "Failed to complete draft order: {0}"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Failed to create collection"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Go to first page"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr "Defaults to the default currency."
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Failed to create product"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Customer"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Error loading order history: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Shipping address set for order"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Focal Point"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Single variant, no options"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Select the next state for the order"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Locale"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Scheduled Tasks"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Enter transaction ID"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Refresh data"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Add or remove facet values for {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "These are the facet values for the <0>{facetName}</0> facet."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Successfully added payment to order"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Billing address set for order"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Failed to update zone"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Password"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Failed to delete"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Scheduled task will be executed"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "New stock location"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Permissions"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Shipping address changed"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "No products found"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Add row before"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Transition to {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "This month"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Failed to create facet"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Failed to cancel order items"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "Transaction ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Allocated"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Add another option group"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr "Failed to set coupon code for order: {0}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Select what to do with remaining stock"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Explore Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Every 5 seconds"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Successfully created collection"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Price"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Draft order"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Scope"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Add condition"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Shipping method is eligible for this order"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administrators"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Removed from group"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Width"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "No payment or refund required"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Download as .env file"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "When enabled, a promotion is available in the shop"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Shipping method set for order"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Failed to update promotion"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Images"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Search {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Edit asset"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Cancel payment"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Job Queue"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Assets"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Email address"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr "Failed to remove coupon code from order: {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Regenerate slug from source field"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Inherit from global settings"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "No results found"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Current status"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Set a shipping address and select a shipping method"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Off"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Settings Store"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Queue"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "New tax rate"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Payment transitioned"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Remaining:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Prices include tax for default tax zone"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr "This field is required"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Total refund:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "View job result"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Test your shipping methods by simulating a new order."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "No items selected"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} selected"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "No countries found"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Successfully created variants"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Generate slug automatically"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Surcharge"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Payment Methods"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Stock"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "No customers found"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Use global out-of-stock threshold"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "New product option group"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Payment state updated successfully"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Create new"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Refund total"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Address deleted"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Only roles assigned to your account are available."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Item added to order"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Edit focal point"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "No sellers found"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Asset"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "My Saved Views"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "New channel"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Failed to create seller"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Configure duplication settings for {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "No variants match the current filter."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Addresses"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Add a new option value to the {groupName} option group"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Order modification #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Add column before"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Channel Languages"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Failed to create option group"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "True"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Select customer"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Order transitioned"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "is before"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Delete draft order"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Catalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "New payment method"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Successfully updated promotion"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Select a channel"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Display language"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Fulfillment details"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Discard remaining stock"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Now"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Channels"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "View converted to global successfully"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "before"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr "Failed to set customer for order: {0}"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Size"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "No translation found for {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "New Customer"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Latest Orders"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} more"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Use as the default billing address"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Delete"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Disable"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Collections"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Add variant"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Failed to create country"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Countries"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Failed to create product options"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Failed to rename view"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Available"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filters"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Customer Groups"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Customers"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr "Select Shipping Calculator"
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Sample Formatting"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "New option"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Usage limit"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Loading global settings..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Address updated successfully"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Created"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Loading addresses..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Select a target collection to move {0} to."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr "Failed to unset billing address for order: {0}"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Customer details updated"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "not in"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Apply"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "New product option"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Go to last page"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Cancel"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr "Failed to update order custom fields: {0}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Successfully created product variant"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Refund from this method"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Postal Code"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Add product options first"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "New tax category"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Add option"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Partial refund completed"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Set custom fields"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Collections"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr "Select Shipping Eligibility Checker"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Delete variant"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "No modifications made"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Default shipping zone"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Reason:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Shipping address"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Transition to {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Tax Categories"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Private collections are not visible in the shop"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "When enabled, a product is available in the shop"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Scheduled task could not be executed"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Customer Groups"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Disabled"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "New promotion"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Default Shipping Address"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Refund required"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Fulfill order"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "You don't have permission to view channel settings"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Last 30 days"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "No facet values"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "A reason for the refund is required"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Could not remove option group"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Failed to update tax category"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Refund settled successfully"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Update"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Heading 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Order placed"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Successfully updated profile"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "end"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Payment method"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Edit"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variant updated successfully"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filter by collection name"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Note added"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Select quantities to fulfill and configure the fulfillment handler"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Billing address unset for order"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Starts at"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "No results"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Column settings"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Code"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Failed to remove option groups"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Order delivered"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Transfer to {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Remaining stock"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Remove from zone"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Select from globally available languages for this channel"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Are you sure you want to delete this address?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Failed to assign option group"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Failed to update asset"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Successfully updated stock location"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Confirm Action"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Successfully updated country"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Facets"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Failed to add note"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Failed to delete note"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Failed to extend query document"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Failed to update note"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Refund shipping"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Readonly"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Failed to duplicate global view"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Showing {shown} of {total} • {selected} selected"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Test Shipping Method"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Facet Values"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Successfully updated asset"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Theme"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr "You must select at least one available currency"
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} customers"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Select a language"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Log out"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Attempts"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Available currency codes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Available language codes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Breadcrumbs"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Category"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Channels"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Children"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Coupon code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Created at"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Currency code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Customer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Customer group"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Customers"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Custom fields"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Data"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Default currency code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Default language code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Default shipping zone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Default tax zone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Description"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Duration"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Email address"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Enabled"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Ends at"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Error"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Featured asset"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "First name"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Fulfillment handler code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Is default"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Is private"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Is settled"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Last name"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Name"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Order placed at"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "Parent ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Per customer usage limit"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Permissions"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Position"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Price"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Prices include tax"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Price with tax"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Product variants"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Progress"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Queue name"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Result"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Retries"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Seller"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Settled at"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Shipping lines"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Started at"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Starts at"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "State"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Stock levels"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Total"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Total with tax"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Type"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Updated at"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Usage limit"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "User"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Value"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Value list"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Method"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Tax summary"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Collections moved successfully"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr "Change selection"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registered"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr "Failed to set shipping address for order: {0}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Cancel Job"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Ends at"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Page {0} of {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Rate"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Size, colour, etc."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Browse facets"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Cancelled"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "fulfillmentState.Created"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Delivered"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Pending"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Shipped"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Save View"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} selected"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Search option groups..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Modify order"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Selected Items"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Values"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Customer set for order"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Facets"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Stock on Hand"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Search index rebuild could not be started"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Shipping Address"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "New zone"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "New API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Delete column"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Assign existing"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "is null"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "These are the customers in the <0>{customerGroupName}</0> customer group."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Manage global views"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Default channel"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Insert a new image with source, title, and dimensions"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Failed to create facet value"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Failed to update product option"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Forgot password?</0><1>Request reset</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Coupon code"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Customer verified"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Global Settings"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Schedule"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Cannot move a collection into its own descendant"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "New Tax Category"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "No stock locations available on current channel"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Successfully created channel"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Successfully updated customer"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "View data"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Delete View"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Add a new address to the customer."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "More views"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Edit the selected image properties"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Applied view \"{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Successfully removed {successCount} facets from channel"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "New Product"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "New asset"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Recalculate shipping"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Select which options should apply to the existing variant \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Assets"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "This will remove all option groups from this product and return to the variant setup choice."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Billing address"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Add facet value"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Please select a target collection"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Review the changes before applying them to the order."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Select a role"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Order cancelled"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Discount"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "All types"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr "Select channels to assign {0} {entityType} to"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Only draft orders can be completed"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Failed to update product"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr "Add collection filter"
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Adjusting {0} lines"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Add facet values"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "after"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Channel"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Healthchecks"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Amount"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Phone Number"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "New customer"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Image"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Successfully created administrator"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Product Options"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Select country"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Creating..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Force remove option group"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Added"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Customer history"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Successfully updated facet values for {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Failed to remove customer from group"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Per customer usage limit"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Billing address changed"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Select an option"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Copy to Personal"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Refund total exceeds maximum refundable amount of {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Delete Global View"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Create"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Every 30 seconds"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "New country"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "From {0} to {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Failed to create customer"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Focal point updated"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Option values"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Default Billing Address"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "No customer"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Failed to remove countries from zone"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Failed to create promotion"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Today"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Yesterday"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Option name"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Are you sure you want to remove {0} {1} from this zone?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Adding {0} surcharge(s)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Link href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Fallback: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Order history"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Override"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "Transaction ID is required"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "matches regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Global view renamed successfully"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "No tags selected"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Back"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr "Select at least one currency"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "View renamed successfully"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Apply filter"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Last Result"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Added to group"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Insights"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Create Variants"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Testing shipping method..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Dark"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Test Results"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Add customer"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Save Changes"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Address updated"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Refund processed successfully"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr "Select value"
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "New Zone"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Failed to update collection position"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Refund"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Modify"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "No global languages configured"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Removing {0} item(s)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Track"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Create variant"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Facet values for {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Save Layout"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Password reset verified"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Failed to delete view"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Toggle header column"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "New Promotion"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Option value name"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Last used"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Is default tax category"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug is set"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Failed to update focal point"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Successfully updated zone"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "State/Province"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Failed to update option group"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Channel defaults"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Failed to create tax category"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Set filter criteria for the {columnId} column"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Country"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Simple product"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Job Queue"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Please confirm you have saved the API key before closing."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Confirm deletion"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Failed to modify order"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Includes tax at {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Order metrics"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Select display language"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr "Select Payment Handler"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Authentication methods"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "start"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Failed to rotate API key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "in"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Search roles..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr "Successfully cancelled {fulfilled} jobs"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Product Variants"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Manage Global Views"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Processing..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} found"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Select date range"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Product"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rotate API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Category"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Moving..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Assign"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Successfully created seller"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Successfully updated shipping method"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Failed to update product variant"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Drag to reorder"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zones"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Search facet values..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Note"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Available languages"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Load {0} more ({remaining} remaining)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Facet values"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Failed to reorder items"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Total Orders"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "No eligible shipping methods found for this order."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Add product option"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Shipping"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions must be used within a DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Email update requested"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Error transitioning to state"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Successfully created customer group"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "New window"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Payment authorized"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Successfully updated role"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Select a country"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Failed to update shipping method"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Shipping Methods"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Select an address"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Yes"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Set Focal Point"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "end"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Select a currency"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Update the note content or visibility"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Latest Orders Widget"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Collection contents for {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Shipping method changed"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Tax description"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "is less than or equal to"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "is not equal to"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Refresh"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "e.g. Size"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr "No checkers found"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Settle payment"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Channels"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Shipping refunded"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Asset type"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "New Stock Location"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Select item"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "New product"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Manage Tags"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Items refunded"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Add action"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Assign options to existing variant"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Duplicate {0}s"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Remove from group"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Failed to update fulfillment state"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Create a new product variant with options, pricing, and stock"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Private facets are not visible in the shop"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Select a tax category"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Created"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Not Running"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Assigned"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Heading 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Select Available Languages"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Adding {0} item(s)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Add row after"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Tax total"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Draft order status"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Successfully created product options"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Loading locations…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Failed to create payment method"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Successfully created facet value"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Draft order deleted"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "greater than"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Metrics Widget"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Search currencies..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Remove from channel"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Title"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Insert image"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Failed to update seller"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Successfully created country"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Select seller"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Loading tags..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Successfully created facet"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} variants"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Failed to settle payment"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "No billing address"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Facet"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr "{rejected, plural, one {{0}} other {{1}}}"
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Cannot remove from active channel"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Not set"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Force remove"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "New Channel"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Option Group Name"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "AND"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Failed to create customer group"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Failed to create role"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Product name"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Fulfillment state updated successfully"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Products"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Address created"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr "Add an option group to get started with variants."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API key rotated successfully"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Add option group"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Refund {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Enter slug manually"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "No widgets available"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Failed to cancel payment"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Payment cancelled successfully"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Global view duplicated successfully"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Created by"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filter variants..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Add a price in another currency"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Email Address or identifier"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Refund #{0} transitioned to {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Customers"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Heading 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Failed to update stock location"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Order shipped"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Save Address"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Make Global"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Select next state"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "No alerts"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Moving {0} collection{1} into {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "between"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Note added successfully"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Note deleted successfully"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Note updated successfully"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Failed to settle refund"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Stock level"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Add item"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "Successfully created API key"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Loading preview…"
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Back to search"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "View duplicated successfully"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Remove option group"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Description"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Countries"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr "Failed to remove order line: {0}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Street Address 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Global view deleted successfully"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Edit Layout"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Assign to channel"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "This week"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Successfully created product option group"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Add a manual payment of {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "is in"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "Email"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Failed to update administrator"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Manage your personal saved views for this table"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filter by tags"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Sign in to access the admin dashboard"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Add payment to order ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "False"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Light"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Reset"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "is equal to"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr "Source File"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Create options"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Password updated"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "does not contain"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Option Group"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Edit the address details below."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Successfully created tax category"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Failed to move collections"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Failed to update payment state"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Your orders summary"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Upload"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Product with options"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Showing all {0} results"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Lookup ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} more"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Option Groups"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Custom fields"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "All possible order states and their transitions. The current state is highlighted."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Orders"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Orders Summary Widget"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Adding items"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Arranging additional payment"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Arranging payment"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Cancelled"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Created"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Delivered"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Draft"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Modifying"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Partially delivered"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Partially shipped"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Payment authorized"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Payment settled"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Shipped"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Monitored Resources"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Entity Information"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Order Total"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Visible to admins only"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Qty"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Tags"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super Admin"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Some resources are down"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Available Actions"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr "Failed to update order line: {0}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Insert link"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Select a zone"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Test shipping methods"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Payment settled successfully"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "Removed {0} {1} from zone"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Enable"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Payment Methods"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Authorized"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Cancelled"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Created"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Declined"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Error"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Failed"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Pending"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Settled"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Average Order Value"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Failed to create zone"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Stock levels"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Failed to update API key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Order lines"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Failed to rename global view"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Insert a new hyperlink with URL and target options"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Height"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr "Assign {entityType} to channels"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Unit price"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Schedule Pattern"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Payment failed"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Add channel"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Failed to update product option group"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Search channels..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Add customer groups"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Available Languages"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Reset selection"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "No address"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Successfully created payment method"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Customer information updated"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr "Failed to delete draft order: {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Failed to convert view to global"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr "Select Payment Eligibility Checker"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr "Select one or more channels"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr "Select operator"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Product Variants"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Products"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promotions"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Failed to create product option"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Old email:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Save a view as \"Global\" to make it available to all users."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Failed to create variants"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rotate Key"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Failed to create product variants"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Hide password"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "New seller"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "e.g., Red, Large, Cotton"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Failed to update profile"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Removed coupon codes"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Clear filter"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regions"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Drop files here to upload"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Toggle all visible variants"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verified"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "New option group"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Last updated {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "No global views have been created yet."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Failed to update role"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Successfully updated collection"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Successfully updated payment method"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "View deleted successfully"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Option group {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "OR"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr "You must select a default currency from the list of available currencies"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Manage tags"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Coupon code removed from order"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Never"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Failed to update facet value"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Remove group"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Order fulfilled"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr "Loading selected items..."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr "Failed to set billing address for order: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "No shipping address"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Query extension contains invalid GraphQL syntax"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Query extension error"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Query extension error: "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Query extension is invalid: must have at least one top-level field"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Query extension mismatch: "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "public"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Successfully updated tax category"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Move"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Edit or delete existing tags"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Add coupon code"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Coupon code set for order"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Custom Fields"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "New Shipping Method"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Delete stock locations"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "is greater than or equal to"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Preview"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} of {1} available to fulfill"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Month to date"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Customer request"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Damaged in shipping"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Item not available"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Other"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Wrong item shipped"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Summary of modifications"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Refunds ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Last Executed"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Payment details"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Rebuild search index"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Running"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Every 60 seconds"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Failed to update customer group"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Payment metadata"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Cancel modification"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Same window"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Apply filters to the table and click \"Save View\" to get started."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Roles"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Additional payment required"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Failed to update order"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "With selected..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Failed to create stock location"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "less than or equal"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Customer group members for {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr "Failed to set address for order: {0}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "State"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Do not track"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Fulfillment #{0} created"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Running pending search index updates"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "This is a default Role and cannot be modified"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "My saved views"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "State / Province"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Enabled"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Items per page"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Edit members"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Stock on hand"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filter by {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Alerts"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Option Values"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Preview changes"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Failed to remove {entityType} from channel"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variant deleted successfully"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Edit the selected link properties"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Sales"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Select a destination collection"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Your latest orders"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Scheduled Tasks"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Are you sure you want to delete this item? This action cannot be undone."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Variants"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Sellers"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Settings"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Settings Store"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Heading 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Welcome to Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Shipping Methods"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} refundable)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identifier"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr "Select a fulfillment handler"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Failed to update collection"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Price and tax"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Order not found"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Error"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Order modified"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Password reset requested"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Allocated payment amount must equal refund total"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "e.g. Small"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Are you sure you want to remove {0} {entityType} from the current channel?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Add tags..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Failed to create product option group"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} items selected"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Search languages..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Stock Locations"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Go to previous page"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Contents"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr "Failed to cancel {rejected} jobs"
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Failed to convert global view to personal view"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "The result of the job"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Add payment ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Variant name"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Remove"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Failed to update customer"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Remove option groups?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Tax Categories"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Tax Rates"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Failed to remove customers from group"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Failed to load global settings"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Select items to refund and optionally return to stock"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Save"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} of {0} row(s) selected."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Preview order modifications"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Successfully updated product option group"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "The page will continue with the default query."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Street Address"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "No more facets"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Search index rebuild started"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Collection position updated"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Option group name"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Add \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "New product variant"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Refund transitioned"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Using native authentication strategy"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Failed to assign {entityIdsLength} {entityType} to channel"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Default Language"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Fulfilling..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Add option group to product"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Preview of {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Successfully updated seller"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Failed to transition order to state"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Show all ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Failed to create tax rate"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "I have saved this API key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Configure available languages for your store and channels"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Successfully created product"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Add product variant"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Type and press Enter or comma to add..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Edit Note"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "No assets found. Try adjusting your filters."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Add Option"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Save option group"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Create {createCount} variants"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Click \"Run Test\" to test this shipping method."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Successfully updated administrator"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Clear filters"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Fulfillment #{0} from {1} to {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Failed to delete global view"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Default language"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "No options found"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binary"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Successfully updated option group"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "New shipping method"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Every 10 seconds"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "ex. tax:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Add Stock to Location"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Successfully added option value"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Collection moved to new parent"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Option group removed"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Transition to selected state"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "An additional payment of {formattedDiff} will be required."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Track inventory by default"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} of {total} selected"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Successfully created shipping method"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "New Customer Group"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Visible to customer"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Successfully created option group"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Tax Rates"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug will be generated automatically..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Customer not found"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Select {0}s"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "New facet values to add:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Failed to process refund"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "First name"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr "Add item to order"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "contains"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "No option groups found"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "No items found"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr "Failed to remove option group"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Sub total"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Fulfilled items ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Value updated"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Unverified"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Quantity"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Add filter"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Tax category"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profile"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Test data has been updated. Click \"Run Test\" to see updated results."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "is not in"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Order line updated"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "New Payment Method"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Duplicate value \"{trimmed}\" already exists"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Reason"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Customer groups"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "Successfully removed {entityType} from channel"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Option Groups"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Add surcharge"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Current facet values"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Page {page} of {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr "Failed to cancel {rejected} job"
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Last month"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Add Country"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr "Defaults to the default language."
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Remove item"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "less than"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "The variant could not be added. Ensure the parent product is enabled."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "An unknown error occurred"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Metrics"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Language"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "New Collection"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Refund and cancel order"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Email update verified"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "is between"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Refund & Cancel"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Testing shipping methods..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Failed to create shipping method"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "Successfully assigned {entityIdsLength} {entityType} to channel"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Global Languages"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "New administrator"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Delete draft"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Source"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "No actions available"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Failed to update channel"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "General"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Failed to remove product from channel"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Add new address"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Successfully updated facet"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Successfully created zone"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Value"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Customer updated"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Price conversion factor"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Seller order"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "New facet"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Are you sure you want to remove this option group from the product?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Description (alt)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "No tags found"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Default currency"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "No payment or refund is required for these changes."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Total Revenue"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Next Execution"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Note is private"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Medium date"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Invalid number"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "You haven't saved any views yet."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Are you sure you want to delete this view? This action cannot be undone."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "View order process"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Failed to duplicate view"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Use as the default shipping address"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Edit slug manually"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Add filters to preview the collection contents."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Product Option Group"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "is less than"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "Refund ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Order custom fields updated"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Calculator"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Failed to remove option group from channel: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "View job data"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Move to the top level"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Clear"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Orders Summary"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Search assets..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "New Facet"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Assign {entityType} to channel"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Continue"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promotions"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Error message"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Add stock level for another location"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Delete Address"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Failed to update facet"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters must be used within a WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Edit Address"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Failed to remove facet from channel: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Set link"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "New Seller"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Edit image"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Manage Variants"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Stock allocated"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "greater than or equal"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Create product options"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Saving..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "View result"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Rows per page"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Loading collections..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Successfully updated facet value"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Add asset"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Save changes"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Customer added to group"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Seller orders"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Failed to add option value"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Add option value to {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr "Failed to unset shipping address for order: {0}"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} item(s) refunded"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "New email:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Failed to update payment method"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Available:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Created at"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Failed to create product variant"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr "Search..."
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Language: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "You don't have permission to view global language settings"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Successfully created tax rate"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Heading 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Added coupon codes"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Active"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Tax base"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Load more"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Refund settled"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "Successfully duplicated {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "New Option Group"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "No result yet"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Payment settled"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Available Conditions"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Active filters"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Clear all"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "is greater than"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Close"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Add payment to order"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Loading..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "The token is used to specify the channel when making API requests."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "No addresses found"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "Fulfillment ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Select payments to refund"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Failed to delete {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Out-of-stock threshold"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Successfully removed product from channel"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Failed to update value"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Failed to create API key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Settle refund"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Payment method is required"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Failed to add customer to group"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Manage variants"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Applied global view \"{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Customer registered"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zones"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Search sellers..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Successfully created promotion"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Option"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Order process"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Phone number"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Private"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variant"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Successfully updated global settings"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "Successfully updated API key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "These languages will be available for all channels to use"

--- a/packages/dashboard/src/i18n/locales/es.po
+++ b/packages/dashboard/src/i18n/locales/es.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Nombre Completo"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Seleccionar elementos"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Ver cambios"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Código de seguimiento"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Los permisos seleccionados se aplicarán a estos canales."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Opciones del producto"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Nueva Tasa de Impuesto"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Asignar un grupo de opciones existente o crear uno nuevo"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Nuevo rol"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Apartamento, suite, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "No hay más elementos"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Editar enlace"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Añade al menos un artículo al pedido"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Agregar productos para crear un pedido de prueba"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Error al crear dirección"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Alternar todo"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Editar valor JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Usando estrategia de autenticación externa: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Selecciona un motivo..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Encabezado 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Error al agregar pago"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Actualizado"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Error al actualizar configuración global"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Pedido cumplido exitosamente"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "¿Está seguro de que desea eliminar {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Umbral global de agotamiento"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Gestionar Idiomas"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Duplicando... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Eliminado exitosamente"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Eliminar del canal actual"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Eliminados {selectionLength} recursos"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Tasa de impuesto actualizada exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Introduce un motivo personalizado..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Tipo"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Seleccionar {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Ver valores"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Eliminar fila"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Condiciones"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Actual"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Sin cumplimientos"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {No se pudo eliminar {1} ubicación de stock: {messages}} other {No se pudieron eliminar {2} ubicaciones de stock: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Cuando esto está habilitado, los precios ingresados en el catálogo de productos incluirán el impuesto para la zona fiscal predeterminada."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Crear variantes para su producto"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Pedido borrador completado"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Actualización automática: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Verificaciones de salud"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Eliminado {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Comprobaciones de salud"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Vendedores"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Opciones"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} tarea cancelada correctamente} other {{fulfilled} tareas canceladas correctamente}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Vendedor"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Agregar pago"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Pruebe este método de envío simulando un pedido para ver si es elegible y cuál sería el costo de envío."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Explorar Edición Enterprise"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Ubicaciones de stock"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Controlador de cumplimiento"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Pedidos"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Seleccionar roles"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Rol creado exitosamente"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "¿Está seguro de que desea eliminar esta variante?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Todos los recursos están funcionando"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Error al crear el administrador"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "No"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Variante de producto actualizada exitosamente"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Error al eliminar {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Producto actualizado exitosamente"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Error al actualizar país"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Escriba al menos 2 caracteres para buscar..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Apellido"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Título del enlace"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Grupo de clientes actualizado exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Campos personalizados cambiados"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Ubicación de stock creada exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Error desconocido"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "El total a reembolsar no puede ser negativo"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Ver detalles"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Seleccione un canal al que asignar {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Cliente creado exitosamente"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Últimos 7 días"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Error al crear canal"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Modo Dev"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Nuevo Rol"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Error al eliminar recursos: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Devolver al stock"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Visibilidad"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Variantes de producto"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Nuevo grupo de clientes"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Crear \\\"{0}\\\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Renombrar"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Elija su idioma de visualización y configuración regional preferidos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} grupos de opciones eliminados del canal correctamente"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "El método de envío no es elegible para este pedido"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Error al actualizar dirección"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Dirección eliminada exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Tasa de impuestos"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "El borrador del pedido no está listo para completarse"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Nueva colección"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Información"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Ejecutar"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Error al actualizar tasa de impuesto"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Este es el contenido de la colección <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privado"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Opción de producto creada correctamente"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Producto principal"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Ciudad"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administradores"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Precio bruto: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Ir a la página siguiente"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Eliminar enlace"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Este campo es de solo lectura"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Cantidad de pedidos"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Pedido actualizado exitosamente"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Heredar filtros"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Gestionar vistas guardadas globales que son visibles para todos los usuarios"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Buscar métodos de pago..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Dirección de envío removida del pedido"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Crear {enabledCount} variantes"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Pago #{0} transicionado a {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Error al cargar historial del cliente: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "Removido exitosamente {selectionLength} {entityType} del canal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Agregar valor de opción"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Configuración global"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "es después"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Opción de producto actualizada correctamente"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Editar valores de faceta"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Agregando..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Mover Colecciones"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Roles"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Vista de cuadrícula"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Error al eliminar dirección"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Sin métodos de envío disponibles"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Vista global convertida a vista personal exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Cumplimiento transicionado"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "¿Está seguro de que desea eliminar {selectionLength} recursos?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Vista de lista"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Pedido de Prueba"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Selecciona un cliente para continuar"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Grupo de opciones asignado correctamente"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Ejecutar prueba"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Tasa de impuesto: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Por favor agregue productos y complete la dirección de envío para ejecutar la prueba."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Alternar fila de encabezado"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Seleccionar dirección"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Verificador de elegibilidad de pago"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Zona fiscal predeterminada"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "El borrador del pedido está listo para completarse"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadatos"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrar..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Nuevo valor de faceta"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Canal actualizado exitosamente"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Mostrar menos"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Fecha corta"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Monedas disponibles"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Seleccionar {0} elementos"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Realizado el"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "La rotación de esta clave invalidará inmediatamente la clave actual. Todas las integraciones que la utilicen dejarán de funcionar hasta que se actualicen con la nueva clave."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Los datos que se han pasado al trabajo"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Confirmar navegación"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Destino del enlace"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Completar borrador"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Nombre"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Error al cumplir pedido"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Total"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Ingrese el ID de transacción para esta liquidación de reembolso"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Su API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "¿Está seguro de que desea eliminar este borrador de pedido?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Cumplimiento creado"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Se encontraron {0} método{1} de envío elegible{1}"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Dimensiones"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Mostrar contraseña"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(máx: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Empresa"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Agregar columna después"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Acciones"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Descuentos"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Ingrese nota de reembolso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Línea de pedido eliminada"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Contenido:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Clave"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Confirmar"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Error al crear colección"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Ir a la primera página"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Error al crear producto"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Cliente"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Error al cargar historial del pedido: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Dirección de envío establecida para el pedido"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Punto Focal"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Variante única, sin opciones"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Seleccione el siguiente estado del pedido"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Configuración regional"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Tareas programadas"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Ingrese ID de transacción"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Actualizar datos"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Agregar o quitar valores de faceta para {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Estos son los valores de la faceta <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Pago agregado al pedido exitosamente"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Dirección de facturación establecida para el pedido"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Error al actualizar zona"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Error al eliminar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Se ejecutará la tarea programada"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Nueva ubicación de stock"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Permisos"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Dirección de envío cambiada"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "No se encontraron productos"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Agregar fila antes"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Transición a {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Este mes"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Error al crear faceta"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Error al cancelar los artículos del pedido"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID de transacción"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Asignado"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Agregar otro grupo de opciones"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Seleccione qué hacer con el stock restante"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Explorar Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Cada 5 segundos"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Colección creada exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Precio"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Pedido borrador"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Alcance"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Añadir condición"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "El método de envío es elegible para este pedido"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administradores"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Eliminado del grupo"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Ancho"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "No se requiere pago o reembolso"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Descargar como archivo .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Cuando está habilitada, una promoción está disponible en la tienda"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Cuando se rastrea, los niveles de stock de las variantes de producto se ajustarán automáticamente al venderse. Esta configuración puede ser anulada por las variantes de producto individuales."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Método de envío establecido para el pedido"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Error al actualizar promoción"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Imágenes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Buscar {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Editar recurso"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Cancelar pago"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Cola de trabajos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Recursos"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Regenerar slug del campo fuente"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Heredar de configuración global"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "No se encontraron resultados"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Estado actual"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Establece una dirección de envío y selecciona un método de envío"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Desactivado"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Almacén de configuración"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Cola"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Nueva tasa de impuesto"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Pago transicionado"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Restante:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "No se encontró duplicador con código \\\"{duplicatorCode}\\\" para {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Los precios incluyen impuesto para la zona fiscal predeterminada"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Reembolso total:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Ver resultado del trabajo"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Pruebe sus métodos de envío simulando un nuevo pedido."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Ningún elemento seleccionado"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} seleccionado(s)"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "No se encontraron países"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Variantes creadas correctamente"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Generar slug automáticamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Recargo"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Métodos de pago"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Stock"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "No se encontraron clientes"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Usar umbral de agotamiento global"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Nuevo grupo de opciones de producto"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Estado de pago actualizado exitosamente"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Crear nuevo"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Total a reembolsar"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Dirección eliminada"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Solo están disponibles los roles asignados a su cuenta."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Elemento agregado al pedido"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Editar punto focal"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "No se encontraron vendedores"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Recurso"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Este grupo de opciones es utilizado por otro producto. Los cambios también lo afectarán.} other {Este grupo de opciones es compartido por # productos. Los cambios los afectarán a todos.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Mis Vistas Guardadas"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Nuevo canal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Error al crear vendedor"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Configurar ajustes de duplicación para {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Ninguna variante coincide con el filtro actual."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Direcciones"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Agregar un nuevo valor de opción al grupo de opciones {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Modificación de pedido #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Agregar columna antes"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Idiomas del Canal"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Error al crear grupo de opciones"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Verdadero"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Seleccionar cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Pedido transicionado"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Este producto tiene variantes existentes pero no tiene grupos de opciones definidos. Debe agregar grupos de opciones antes de crear nuevas variantes."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "es antes"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Eliminar pedido borrador"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Catálogo"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Nuevo método de pago"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promoción actualizada exitosamente"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {No se pudo cancelar {rejected} tarea} other {No se pudieron cancelar {rejected} tareas}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Seleccione un canal"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Idioma de visualización"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Detalles de cumplimiento"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Descartar el stock restante"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Ahora"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Canales"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Vista convertida a global correctamente"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "antes"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Tamaño"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "No se encontró traducción para {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Nuevo Cliente"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Últimos pedidos"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} más"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Usar como dirección de facturación predeterminada"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Deshabilitar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Colecciones"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Agregar variante"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Error al crear país"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Países"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Error al crear opciones de producto"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Error al renombrar vista"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Disponible"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtros"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Grupos de clientes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Clientes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Formato de ejemplo"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nueva opción"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Límite de uso"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Cargando configuración global..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Dirección actualizada exitosamente"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Creado"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Cargando direcciones..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Seleccione una colección de destino a la que mover {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Detalles del cliente actualizados"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "no en"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Aplicar"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nueva opción de producto"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Ir a la última página"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Variante de producto creada exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Reembolso de este método"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Código Postal"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Agregar opciones de producto primero"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Nueva categoría de impuesto"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Agregar opción"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Reembolso parcial completado"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Establecer campos personalizados"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Colecciones"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Eliminar variante"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Sin modificaciones realizadas"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Zona de envío predeterminada"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Motivo:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Dirección de envío"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Transición a {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Categorías de impuestos"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Las colecciones privadas no son visibles en la tienda"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Cuando está habilitado, un producto está disponible en la tienda"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "No se pudo ejecutar la tarea programada"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Grupos de clientes"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Deshabilitado"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Nueva promoción"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Dirección de Envío Predeterminada"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Reembolso requerido"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Cumplir pedido"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "No tiene permiso para ver la configuración del canal"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Últimos 30 días"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Sin valores de faceta"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Se requiere un motivo para el reembolso"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "No se pudo eliminar el grupo de opciones"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Error al actualizar categoría de impuesto"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Reembolso liquidado exitosamente"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Actualizar"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Encabezado 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Pedido realizado"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Perfil actualizado exitosamente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "fin"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Método de pago"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Editar"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variante actualizada correctamente"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtrar por nombre de colección"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Nota agregada"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Seleccione las cantidades a cumplir y configure el gestor de cumplimiento"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Dirección de facturación eliminada del pedido"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Comienza en"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Sin resultados"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Configuración de columnas"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {No se pudo eliminar {count} ubicación de stock} other {No se pudieron eliminar {count} ubicaciones de stock}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Código"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Error al eliminar los grupos de opciones"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Pedido entregado"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Transferir a {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Stock restante"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Eliminar de la zona"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Seleccione entre los idiomas disponibles globalmente para este canal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "¿Está seguro de que desea eliminar esta dirección?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Error al asignar el grupo de opciones"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Error al actualizar recurso"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Ubicación de stock actualizada exitosamente"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Confirmar Acción"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "País actualizado exitosamente"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Facetas"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Error al agregar nota"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Error al eliminar nota"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Error al extender el documento de consulta"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Error al actualizar nota"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Reembolsar envío"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Solo lectura"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Error al duplicar vista global"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Mostrando {shown} de {total} • {selected} seleccionadas"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Probar método de envío"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Valores de Faceta"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Recurso actualizado exitosamente"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Tema"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} clientes"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Seleccione un idioma"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Cerrar sesión"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Intentos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Códigos de monedas disponibles"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Códigos de idiomas disponibles"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Navegación"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Categoría"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Canales"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Elementos secundarios"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Código"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Código de cupón"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Creado en"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Código de moneda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Grupo de clientes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Clientes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Campos personalizados"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Datos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Código de moneda predeterminado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Código de idioma predeterminado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Zona de envío predeterminada"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Zona fiscal predeterminada"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Descripción"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Duración"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Dirección de correo electrónico"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Habilitado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Termina en"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Error"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Recurso destacado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Nombre"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Código de controlador de cumplimiento"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Es predeterminado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Es privado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Está liquidado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Apellido"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Nombre"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Pedido realizado en"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID del elemento principal"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Límite de uso por cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Permisos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Posición"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Precio"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Los precios incluyen impuestos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Precio con impuestos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Variantes de producto"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Progreso"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Nombre de cola"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Resultado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Reintentos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Vendedor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Liquidado en"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Líneas de envío"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Iniciado en"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Comienza en"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Estado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Niveles de stock"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Total"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Total con impuestos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Tipo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Actualizado en"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Límite de uso"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Usuario"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Valor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Lista de valores"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zona"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Método"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Resumen de impuestos"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Establece los idiomas disponibles para todos los canales. Los canales individuales pueden admitir un subconjunto de estos idiomas."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Colecciones movidas exitosamente"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registrado"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Cancelar Trabajo"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Termina en"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Página {0} de {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Tasa"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Tamaño, color, etc."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Explorar facetas"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Cancelado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Creado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Entregado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Pendiente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Enviado"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Guardar vista"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} seleccionado(s)"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Buscar grupos de opciones..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Modificar pedido"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Elementos seleccionados"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Valores"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Cliente establecido para el pedido"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Facetas"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {¿Está seguro de que desea eliminar {count} cliente de este grupo?} other {¿Está seguro de que desea eliminar {count} clientes de este grupo?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Stock Disponible"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "No se pudo iniciar la reconstrucción del índice de búsqueda"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Dirección de Envío"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Nueva zona"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Nuevo API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Eliminar columna"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Asignar existente"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "es nulo"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Estos son los clientes del grupo de clientes <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Gestionar vistas globales"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Canal predeterminado"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Insertar una nueva imagen con origen, título y dimensiones"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Error al crear valor de faceta"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Error al actualizar la opción de producto"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>¿Olvidaste tu contraseña?</0><1>Solicitar restablecimiento</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Código de cupón"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Cliente verificado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Configuración global"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Programación"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "No se puede mover una colección a su propio descendiente"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Nueva Categoría de Impuesto"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Sin ubicaciones de stock disponibles en el canal actual"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Canal creado exitosamente"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Cliente actualizado exitosamente"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Ver datos"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Eliminar Vista"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Agregar una nueva dirección al cliente."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Más vistas"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Editar las propiedades de la imagen seleccionada"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Vista „{viewName}\" aplicada"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Removido exitosamente {successCount} facetas del canal"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Nuevo Producto"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Nuevo recurso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Recalcular envío"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Seleccione qué opciones deben aplicarse a la variante existente \\\"{0}\\\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Recursos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Esto eliminará todos los grupos de opciones de este producto y volverá a la selección de configuración de variantes."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Dirección de facturación"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Agregar valor de faceta"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Por favor seleccione una colección objetivo"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Revise los cambios antes de aplicarlos al pedido."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Seleccionar un rol"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Pedido cancelado"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Descuento"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Todos los tipos"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Solo los borradores de pedidos pueden completarse"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Error al actualizar producto"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Ajustando {0} líneas"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Agregar valores de faceta"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "después"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Canal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Comprobaciones de salud"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Cantidad"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Número de Teléfono"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Nuevo cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Imagen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administrador creado correctamente"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Opciones de Producto"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Seleccionar país"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Creando..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "¿Está seguro de que desea eliminar esta vista global? Esta acción no se puede deshacer y afectará a todos los usuarios."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Forzar eliminación del grupo de opciones"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Añadido"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Historial del cliente"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Valores de faceta actualizados exitosamente para {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Error al quitar cliente del grupo"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Sistema"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Límite de uso por cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Dirección de facturación cambiada"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Seleccione una opción"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Copiar a Personal"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "El total a reembolsar excede el importe máximo reembolsable de {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Eliminar Vista Global"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Crear"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Cada 30 segundos"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Nuevo país"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "De {0} a {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Error al crear cliente"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Punto focal actualizado"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Valores de opción"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Dirección de Facturación Predeterminada"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Sin cliente"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Error al eliminar países de la zona"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Error al crear promoción"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Hoy"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Ayer"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Nombre de la opción"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "¿Está seguro de que desea eliminar {0} {1} de esta zona?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Añadiendo {0} recargo(s)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Enlace href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Fallback: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Historial de pedidos"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Sobrescribir"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "Se requiere ID de transacción"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "coincide con regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Vista global renombrada exitosamente"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Ninguna etiqueta seleccionada"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Volver"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Vista renombrada correctamente"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Aplicar filtro"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Último Resultado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Agregado al grupo"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Perspectivas"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Crear Variantes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Probando método de envío..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Oscuro"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Resultados de Prueba"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Agregar cliente"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Guardar cambios"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Dirección actualizada"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Reembolso procesado correctamente"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Nueva Zona"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Error al actualizar la posición de la colección"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Reembolso"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Modificar"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Sin idiomas globales configurados"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Eliminando {0} elemento(s)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Rastrear"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Crear variante"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Valores de faceta para {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Guardar diseño"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Restablecimiento de contraseña verificado"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Error al eliminar vista"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "¿Está seguro de que desea salir de esta página? Se perderán los cambios no guardados."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Alternar columna de encabezado"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Nueva Promoción"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Nombre del valor de opción"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Último uso"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Es categoría de impuesto predeterminada"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug está establecido"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "No se pudo actualizar el punto focal"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zona actualizada exitosamente"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Estado/Provincia"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Error al actualizar el grupo de opciones"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Valores predeterminados del canal"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Error al crear categoría de impuesto"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Establecer criterios de filtro para la columna {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "País"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Producto simple"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Cola de trabajos"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Confirme que ha guardado el API Key antes de cerrar."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Confirmar eliminación"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Error al modificar pedido"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Incluye impuesto del {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Métricas de pedidos"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Seleccione el idioma de visualización"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Métodos de autenticación"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "inicio"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Error al rotar el API Key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "en"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Buscar roles..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Variantes de producto"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Gestionar Vistas Globales"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Procesando..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} encontrado(s)"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Seleccionar rango de fechas"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Producto"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rotar API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Categoría"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Moviendo..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Asignar"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Vendedor creado exitosamente"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Método de envío actualizado correctamente"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Error al actualizar variante de producto"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Arrastrar para reordenar"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zonas"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Elija qué hacer con el stock restante en {count, plural, one {# ubicación de stock} other {# ubicaciones de stock}} que va a eliminar. Todas las ubicaciones seleccionadas transfieren su stock restante a la única ubicación que elija, o lo descartan."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Buscar valores de facetas..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Nota"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Idiomas disponibles"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Cargar {0} más ({remaining} restantes)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Valores de faceta"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Error al reordenar los artículos"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Total de pedidos"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "No se encontraron métodos de envío elegibles para este pedido."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Agregar opción de producto"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Envío"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions debe usarse dentro de un DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Este grupo de opciones está en uso por variantes existentes. Forzar su eliminación puede afectar a esas variantes. ¿Está seguro?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Actualización de correo electrónico solicitada"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Error al transicionar al estado"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Grupo de clientes creado exitosamente"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nueva ventana"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Pago autorizado"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Rol actualizado exitosamente"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Seleccione un país"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Error al actualizar el método de envío"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Se eliminó {deleted} ubicación de stock} other {Se eliminaron {deleted} ubicaciones de stock}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Métodos de envío"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Seleccione una dirección"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Sí"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Establecer punto focal"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "fin"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Seleccione una moneda"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Actualizar el contenido o la visibilidad de la nota"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget de últimos pedidos"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Contenido de la colección para {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Método de envío cambiado"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Descripción del impuesto"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "es menor o igual que"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "no es igual a"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Actualizar"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "ej. Tamaño"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Liquidar pago"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Canales"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Envío reembolsado"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Tipo de asset"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Nueva Ubicación de Stock"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} pago(s) reembolsado(s) antes del fallo. Consulta el historial del pedido para más detalles."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Seleccionar elemento"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Nuevo producto"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gestionar Etiquetas"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Artículos reembolsados"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Añadir acción"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Asignar opciones a variante existente"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Duplicar {0}s"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Eliminar del grupo"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Error al actualizar estado de cumplimiento"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Crear una nueva variante de producto con opciones, precios y stock"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Las facetas privadas no son visibles en la tienda"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Seleccionar una categoría de impuesto"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Creado"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "No Ejecutándose"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Asignado"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Encabezado 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Seleccionar idiomas disponibles"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Agregando {0} elemento(s)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Agregar fila después"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Total de impuestos"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Estado del borrador del pedido"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Opciones de producto creadas exitosamente"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Cargando ubicaciones…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Error al crear método de pago"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Valor de faceta creado exitosamente"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Pedido borrador eliminado"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "mayor que"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Widget de métricas"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Buscar monedas..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Eliminar del canal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Título"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Insertar imagen"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Error al actualizar vendedor"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "País creado exitosamente"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Seleccionar vendedor"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Cargando etiquetas..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Faceta creada exitosamente"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} variantes"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Error al liquidar pago"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Sin dirección de facturación"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {No se pudo eliminar {1} ubicación de stock} other {No se pudieron eliminar {2} ubicaciones de stock}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Faceta"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "No se puede eliminar del canal activo"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "No establecido"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Forzar eliminación"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Nuevo Canal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Nombre del Grupo de Opciones"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "Y"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Error al crear grupo de clientes"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Error al crear rol"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Nombre del producto"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Estado de cumplimiento actualizado exitosamente"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Productos"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Dirección creada"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key rotado correctamente"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Agregar grupo de opciones"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Reembolsar {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Ingrese slug manualmente"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "No hay widgets disponibles"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Error al cancelar pago"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Pago cancelado exitosamente"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Vista global duplicada exitosamente"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Creado por"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtrar variantes..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Añadir un precio en otra moneda"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Dirección de correo electrónico o identificador"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Reembolso #{0} transicionado a {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Clientes"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Encabezado 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Error al actualizar ubicación de stock"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Pedido enviado"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Guardar dirección"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Hacer Global"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Seleccionar siguiente estado"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Sin alertas"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Moviendo {0} colección{1} a {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Prueba"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "entre"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Nota agregada exitosamente"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Nota eliminada exitosamente"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Nota actualizada exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Error al liquidar reembolso"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Nivel de stock"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Agregar elemento"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key creado correctamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Cargando vista previa…"
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Volver a la búsqueda"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Vista duplicada correctamente"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Eliminar grupo de opciones"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Descripción"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Países"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Dirección 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Vista global eliminada exitosamente"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Editar diseño"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Asignar al canal"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Esta semana"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Grupo de opciones de producto creado correctamente"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Agregar un pago manual de {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "está en"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Error al actualizar el administrador"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Gestionar sus vistas guardadas personales para esta tabla"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtrar por etiquetas"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Inicia sesión para acceder al panel de administración"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Agregar pago al pedido ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Falso"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Claro"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Restablecer"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "es igual a"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Crear opciones"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Contraseña actualizada"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "no contiene"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Grupo de opciones"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Editar los detalles de la dirección a continuación."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Categoría de impuesto creada exitosamente"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Error al mover colecciones"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Error al actualizar estado de pago"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Resumen de sus pedidos"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Subir"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Producto con opciones"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Mostrando todos los {0} resultados"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "ID de búsqueda"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} más"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Grupos de opciones"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Campos personalizados"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Todos los estados de pedido posibles y sus transiciones. El estado actual está resaltado."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Pedidos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget de resumen de pedidos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Agregando artículos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Organizando pago adicional"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Organizando pago"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Cancelado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Creado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Entregado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Borrador"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Modificando"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Parcialmente entregado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Parcialmente enviado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Pago autorizado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Pago liquidado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Enviado"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Recursos Monitoreados"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Información de Entidad"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Total del pedido"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Visible solo para administradores"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Cant."
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super Administrador"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Algunos recursos están inactivos"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Acciones disponibles"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Insertar enlace"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Si está habilitado, los filtros se heredarán de la colección padre y se combinarán con los filtros establecidos en esta colección."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Seleccionar una zona"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Probar métodos de envío"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Pago liquidado exitosamente"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} eliminados de la zona"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Habilitar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Métodos de pago"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autorizado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Cancelado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Creado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Rechazado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Error"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Fallido"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Pendiente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Liquidado"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Valor promedio del pedido"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Error al crear zona"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Niveles de stock"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Error al actualizar el API Key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Líneas de pedido"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Error al renombrar vista global"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Insertar un nuevo hipervínculo con URL y opciones de destino"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Altura"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Se requiere un reembolso de {formattedDiff}. Seleccione los importes de pago e ingrese una nota para continuar."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Precio unitario"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Patrón de programación"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Pago falló"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Añadir canal"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Error al actualizar el grupo de opciones de producto"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Buscar canales..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Agregar grupos de clientes"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Idiomas Disponibles"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Restablecer selección"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Sin dirección"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Método de pago creado exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Información del cliente actualizada"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Error al convertir vista a global"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Variantes de producto"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Productos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promociones"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Error al crear la opción de producto"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Correo anterior:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Guarde una vista como \\\"Global\\\" para que esté disponible para todos los usuarios."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Error al crear las variantes"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Establece el nivel de stock en el que esta variante se considera agotada. El uso de un valor negativo habilita el soporte de pedidos pendientes. Puede ser anulado por las variantes de producto."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rotar clave"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Error al crear variantes del producto"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Ocultar contraseña"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Nuevo vendedor"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "ej., Rojo, Grande, Algodón"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Error al actualizar perfil"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Códigos de cupón eliminados"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Limpiar filtro"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regiones"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Suelte los archivos aquí para cargarlos"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Alternar todas las variantes visibles"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verificado"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Nuevo grupo de opciones"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Última actualización {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Aún no se han creado vistas globales."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Error al actualizar rol"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Esta es la única vez que se mostrará el API Key completo. Cópielo o descárguelo ahora — no se podrá recuperar más adelante."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Colección actualizada exitosamente"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Método de pago actualizado exitosamente"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Vista eliminada correctamente"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Grupo de opciones {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "O"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Gestionar etiquetas"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Código de cupón eliminado del pedido"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Nunca"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Error al actualizar valor de faceta"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Eliminar grupo"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Pedido cumplido"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Sin dirección de envío"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "La extensión de consulta contiene sintaxis GraphQL no válida"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Error de extensión de consulta"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Error de extensión de consulta: "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "La extensión de consulta no es válida: debe tener al menos un campo de nivel superior"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Incompatibilidad de extensión de consulta: "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "público"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Categoría de impuesto actualizada exitosamente"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Mover"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Editar o eliminar etiquetas existentes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Las condiciones de verificación de elegibilidad de este método de envío no se cumplen para el pedido y la dirección de envío actuales."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Agregar código de cupón"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Código de cupón establecido para el pedido"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Campos Personalizados"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Nuevo Método de Envío"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Eliminar ubicaciones de stock"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "es mayor o igual que"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Vista previa"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} de {1} disponibles para cumplir"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Mes hasta la fecha"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Solicitud del cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Dañado en el envío"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "No disponible"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Otro"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Artículo incorrecto"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Resumen de modificaciones"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Reembolsos ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Última Ejecución"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Detalles del pago"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Reconstruir índice de búsqueda"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Ejecutándose"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Cada 60 segundos"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Error al actualizar grupo de clientes"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Metadatos del pago"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Cancelar modificación"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Misma ventana"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Aplique filtros a la tabla y haga clic en \\\"Guardar vista\\\" para comenzar."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Roles"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Pago adicional requerido"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Error al actualizar pedido"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Con seleccionados..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Error al crear ubicación de stock"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "menor o igual que"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Miembros del grupo de clientes para {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Estado"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "No rastrear"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Cumplimiento #{0} creado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Ejecutando actualizaciones pendientes del índice de búsqueda"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Este es un rol predeterminado y no se puede modificar"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Mis vistas guardadas"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Estado / Provincia"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Elementos por página"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Editar miembros"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Stock disponible"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtrar por {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Alertas"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Valores de Opción"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Previsualizar cambios"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Error al eliminar {entityType} del canal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variante eliminada correctamente"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Editar las propiedades del enlace seleccionado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Ventas"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Seleccione una colección de destino"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Sus últimos pedidos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Tareas programadas"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "¿Está seguro de que desea eliminar este elemento? Esta acción no se puede deshacer."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Variantes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Vendedores"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Configuración"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Almacén de configuración"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Encabezado 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Bienvenido a Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Métodos de envío"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} reembolsable)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identificador"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Error al actualizar colección"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Precio e impuesto"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Pedido no encontrado"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Error"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Pedido modificado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Restablecimiento de contraseña solicitado"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "El importe de pago asignado debe ser igual al total del reembolso"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "ej. Pequeño"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "¿Está seguro de que desea quitar {0} {entityType} del canal actual?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Agregar etiquetas..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Error al crear el grupo de opciones de producto"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} elementos seleccionados"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Buscar idiomas..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Ubicaciones de stock"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Ir a la página anterior"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Contenidos"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Error al convertir vista global a vista personal"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "El resultado del trabajo"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Agregar pago ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Sistema"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Nombre de la variante"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Quitar"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Error al actualizar cliente"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "¿Eliminar grupos de opciones?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Esta es una vista previa del contenido de la colección basada en la configuración de filtros actual. Una vez que guarde la colección, el contenido se actualizará para reflejar la nueva configuración de filtros."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {Se eliminó {count} cliente del grupo} other {Se eliminaron {count} clientes del grupo}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Categorías de impuestos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Tasas de impuestos"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Error al eliminar clientes del grupo"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Error al cargar configuración global"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Selecciona los artículos a reembolsar y opcionalmente devolver al stock"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Guardar"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} de {0} fila(s) seleccionada(s)."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Previsualizar modificaciones del pedido"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Grupo de opciones de producto actualizado correctamente"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "La página continuará con la consulta predeterminada."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Dirección"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "No hay más facetas"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Reconstrucción del índice de búsqueda iniciada"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Posición de la colección actualizada"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Nombre del grupo de opciones"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Agregar \\\"{newOptionInput}\\\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Nueva variante de producto"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Reembolso transicionado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Usando estrategia de autenticación nativa"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Error al asignar {entityIdsLength} {entityType} al canal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Idioma Predeterminado"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Cumpliendo..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Agregar grupo de opciones al producto"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Vista previa de {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Vendedor actualizado exitosamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Error al transicionar pedido al estado"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Mostrar todo ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Error al crear tasa de impuesto"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "He guardado este API Key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Configurar idiomas disponibles para su tienda y canales"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Producto creado exitosamente"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Agregar variante de producto"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Escribe y presiona Enter o coma para añadir..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Editar Nota"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "No se encontraron assets. Intente ajustar sus filtros."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Agregar Opción"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Guardar grupo de opciones"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Crear {createCount} variantes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Haga clic en \\\"Ejecutar prueba\\\" para probar este método de envío."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administrador actualizado correctamente"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Limpiar filtros"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Cumplimiento #{0} de {1} a {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Error al eliminar vista global"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Idioma predeterminado"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Estado"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "No se encontraron opciones"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binario"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Grupo de opciones actualizado correctamente"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Nuevo método de envío"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Cada 10 segundos"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "ej. impuesto:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Agregar Stock a Ubicación"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Valor de opción agregado exitosamente"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Colección movida al nuevo padre"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Grupo de opciones eliminado"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Transición al estado seleccionado"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Se requerirá un pago adicional de {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Rastrear inventario por defecto"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} de {total} seleccionadas"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Método de envío creado correctamente"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nuevo Grupo de Clientes"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Visible para el cliente"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Grupo de opciones creado exitosamente"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Tasas de impuestos"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "El slug se generará automáticamente..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Cliente no encontrado"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Seleccionar {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Nuevos valores de faceta a agregar:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Error al procesar el reembolso"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Nombre"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "contiene"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "No se encontraron grupos de opciones"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "No se encontraron elementos"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Subtotal"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Elementos cumplidos ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Valor actualizado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "No verificado"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Cantidad"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Agregar filtro"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Categoría de impuesto"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Perfil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Los datos de prueba se han actualizado. Haga clic en \\\"Ejecutar prueba\\\" para ver los resultados actualizados."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "no está en"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Línea de pedido actualizada"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Nuevo Método de Pago"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "El valor duplicado \"{trimmed}\" ya existe"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Motivo"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Grupos de clientes"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} eliminado del canal correctamente"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Grupos de Opciones"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Añadir recargo"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Valores de faceta actuales"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Página {page} de {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Mes pasado"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Agregar país"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Quitar elemento"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Vídeo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "menor que"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "No se pudo añadir la variante. Asegúrese de que el producto principal esté habilitado."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Se produjo un error desconocido"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Métricas"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Idioma"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Nueva Colección"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Reembolsar y cancelar pedido"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Actualización de correo electrónico verificada"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "está entre"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Reembolsar y cancelar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Probando métodos de envío..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Error al crear el método de envío"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "Asignado exitosamente {entityIdsLength} {entityType} al canal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Idiomas Globales"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Nuevo administrador"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Eliminar borrador"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Fuente"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Sin acciones disponibles"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Error al actualizar canal"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "General"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Error al eliminar el producto del canal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Agregar nueva dirección"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Faceta actualizada exitosamente"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zona creada exitosamente"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Valor"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Cliente actualizado"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Factor de conversión de precio"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Pedido del vendedor"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Nueva faceta"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "¿Está seguro de que desea eliminar este grupo de opciones del producto?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Descripción (alt)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "No se encontraron etiquetas"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Moneda predeterminada"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "No se requiere pago o reembolso para estos cambios."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Ingresos totales"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Próxima Ejecución"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "La nota es privada"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Fecha media"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Número inválido"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Aún no ha guardado ninguna vista."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "¿Está seguro de que desea eliminar esta vista? Esta acción no se puede deshacer."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Ver proceso de pedido"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Error al duplicar vista"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Usar como dirección de envío predeterminada"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Editar slug manualmente"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Agregar filtros para previsualizar el contenido de la colección."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Grupo de Opciones de Producto"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "es menor que"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID de Reembolso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Campos personalizados del pedido actualizados"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Calculadora"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Error al eliminar el grupo de opciones del canal: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Ver datos del trabajo"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Mover al nivel superior"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Limpiar"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Resumen de pedidos"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Buscar assets..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Nueva Faceta"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Asignar {entityType} al canal"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Continuar"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promociones"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Mensaje de error"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Añadir nivel de stock para otra ubicación"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Eliminar Dirección"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Error al actualizar faceta"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters debe usarse dentro de un WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Editar Dirección"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Error al quitar faceta del canal: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Establecer enlace"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Nuevo Vendedor"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Editar imagen"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Gestionar Variantes"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Stock asignado"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "mayor o igual que"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Establece el nivel de stock en el que esta variante se considera agotada. El uso de un valor negativo habilita el soporte de pedidos pendientes."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Crear opciones de producto"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Guardando..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Ver resultado"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Filas por página"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Cargando colecciones..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Valor de faceta actualizado exitosamente"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Agregar recurso"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Guardar cambios"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Cliente agregado al grupo"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Pedidos del vendedor"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Error al agregar valor de opción"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Agregar valor de opción a {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} artículo(s) reembolsado(s)"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Aún no hay grupos de opciones definidos. Agregue grupos de opciones para crear diferentes variantes de su producto (ej. Tamaño, Color, Material)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Nuevo correo:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Error al actualizar método de pago"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Disponible:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Creado en"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Error al crear variante de producto"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Idioma: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "No tiene permiso para ver la configuración de idioma global"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Tasa de impuesto creada exitosamente"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Encabezado 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Códigos de cupón agregados"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Activo"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Base imponible"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Cargar más"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Reembolso liquidado"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "Duplicado exitosamente {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Nuevo grupo de opciones"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Aún sin resultado"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Pago liquidado"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Condiciones disponibles"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Filtros activos"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Limpiar todo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "es mayor que"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Agregar pago al pedido"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Cargando..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "El token se utiliza para especificar el canal al realizar solicitudes de API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "No se encontraron direcciones"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID de Cumplimiento"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Selecciona los pagos a reembolsar"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Error al eliminar {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Umbral de agotamiento"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Producto eliminado del canal correctamente"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Error al actualizar el valor"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Error al crear el API Key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Liquidar reembolso"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "El método de pago es requerido"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Error al agregar cliente al grupo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Gestionar variantes"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Vista global „{viewName}\" aplicada"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Cliente registrado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zonas"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Buscar vendedores..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Promoción creada exitosamente"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Opción"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Proceso de pedido"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Número de teléfono"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privado"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variante"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Configuración global actualizada exitosamente"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key actualizado correctamente"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Estos idiomas estarán disponibles para que los usen todos los canales"

--- a/packages/dashboard/src/i18n/locales/fa.po
+++ b/packages/dashboard/src/i18n/locales/fa.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "نام کامل"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "انتخاب موارد"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "مشاهده تغییرات"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "کد پیگیری"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "مجوزهای انتخاب شده به این کانال‌ها اعمال خواهد شد."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "گزینه‌های محصول"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "نرخ مالیات جدید"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "تخصیص یک گروه گزینه موجود یا ایجاد گروه جدید"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "نقش جدید"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "آپارتمان، سوئیت و غیره"
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "موردی دیگر وجود ندارد"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "ویرایش پیوند"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "حداقل یک کالا به سفارش اضافه کنید"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "برای ایجاد سفارش آزمایشی محصولات اضافه کنید"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "ایجاد آدرس ناموفق بود"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "تغییر وضعیت همه"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "ویرایش مقدار JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "استفاده از استراتژی احراز هویت خارجی: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "یک دلیل انتخاب کنید..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "سرفصل ۵"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "افزودن پرداخت ناموفق بود"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "به‌روزرسانی تنظیمات عمومی ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "سفارش با موفقیت تحویل داده شد"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "آیا مطمئن هستید که می‌خواهید {0} {entityName} را حذف کنید؟"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "آستانه عمومی اتمام موجودی"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "مدیریت زبان‌ها"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "در حال تکثیر... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "با موفقیت حذف شد"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "حذف از کانال فعلی"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} فایل حذف شد"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "نرخ مالیات با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "دلیل سفارشی را وارد کنید..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "نوع"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "انتخاب {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "مشاهده مقادیر"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "حذف سطر"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "شرایط"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "فعلی"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "هیچ تحویلی وجود ندارد"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {حذف {1} مکان موجودی ناموفق بود: {messages}} other {حذف {2} مکان موجودی ناموفق بود: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "وقتی این فعال باشد، قیمت‌های وارد شده در کاتالوگ محصول شامل مالیات برای منطقه مالیاتی پیش‌فرض خواهد بود."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "انواع را برای محصول خود ایجاد کنید"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "سفارش پیش‌نویس تکمیل شد"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "تازه‌سازی خودکار: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "بررسی‌های سلامت"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} حذف شد"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "بررسی سلامت"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "فروشندگان"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "گزینه‌ها"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} کار با موفقیت لغو شد} other {{fulfilled} کار با موفقیت لغو شد}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "فروشنده"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "کد کالا:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "افزودن پرداخت"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "این روش ارسال را با شبیه‌سازی یک سفارش آزمایش کنید تا ببینید آیا واجد شرایط است و هزینه ارسال چقدر خواهد بود."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "کاوش نسخه سازمانی"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "محل‌های انبار"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "مدیریت تحویل"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "سفارش‌ها"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "انتخاب نقش‌ها"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "نقش با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "آیا مطمئن هستید که می‌خواهید این نوع را حذف کنید؟"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "تمام منابع در حال اجرا هستند"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "ایجاد مدیر ناموفق بود"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "خیر"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "نوع محصول با موفقیت به‌روزرسانی شد"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "حذف {failed} {entityName} ناموفق بود: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "محصول با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "به‌روزرسانی کشور ناموفق بود"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "حداقل ۲ حرف برای جستجو تایپ کنید..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "نام خانوادگی"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "عنوان پیوند"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "گروه مشتری با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "فیلدهای سفارشی تغییر کرد"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "محل انبار با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "خطای ناشناخته"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "کل بازپرداخت نمی‌تواند منفی باشد"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "مشاهده جزئیات"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "یک کانال برای اختصاص {0} {entityType} انتخاب کنید"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "مشتری با موفقیت ایجاد شد"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "7 روز گذشته"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "ایجاد کانال ناموفق بود"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "حالت توسعه"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "نقش جدید"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "حذف فایل‌ها ناموفق بود: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "بازگشت به انبار"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "قابلیت مشاهده"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "گونه‌های محصول"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "گروه مشتری جدید"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "ایجاد \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "تغییر نام"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "زبان نمایش و تنظیمات منطقه‌ای مورد نظر خود را انتخاب کنید"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} گروه گزینه با موفقیت از کانال حذف شد"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "روش ارسال برای این سفارش واجد شرایط نیست"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "به‌روزرسانی آدرس ناموفق بود"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "آدرس با موفقیت حذف شد"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "نرخ مالیات"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "پیش‌نویس سفارش آماده تکمیل نیست"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "مجموعه جدید"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "بینش‌ها"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "اجرا"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "به‌روزرسانی نرخ مالیات ناموفق بود"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "این محتویات مجموعه <0>{collectionName}</0> است."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "خصوصی"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "گزینه محصول با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "محصول والد"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "شهر"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "مدیران"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "قیمت ناخالص: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "رفتن به صفحه بعدی"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "حذف پیوند"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "این فیلد فقط خواندنی است"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "تعداد سفارش"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "سفارش با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "وراثت فیلترها"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "مدیریت نماهای ذخیره شده عمومی که برای همه کاربران قابل مشاهده است"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "جستجوی روش‌های پرداخت..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "آدرس حمل و نقل برای سفارش لغو شد"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "ایجاد {enabledCount} گونه"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "پرداخت شماره {0} به {1} منتقل شد"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "خطا در بارگذاری تاریخچه مشتری: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} با موفقیت از کانال حذف شد"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "افزودن مقدار گزینه"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "تنظیمات عمومی"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "بعد از است"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "گزینه محصول با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "ویرایش مقادیر ویژگی"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "در حال افزودن..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "جابجایی مجموعه‌ها"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "نقش‌ها"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "نمای شبکه‌ای"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "حذف آدرس ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "روش ارسالی موجود نیست"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "نمای عمومی با موفقیت به نمای شخصی تبدیل شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "تحویل منتقل شد"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "آیا مطمئن هستید که می‌خواهید {selectionLength} فایل را حذف کنید؟"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "ورود"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "نمای فهرست"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "سفارش آزمایشی"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "یک مشتری انتخاب کنید تا ادامه دهید"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "گروه گزینه با موفقیت تخصیص داده شد"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "اجرای آزمون"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "نرخ مالیات: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "لطفا برای اجرای آزمون محصولات اضافه کنید و آدرس ارسال را تکمیل کنید."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "تغییر وضعیت سطر سرفصل"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "انتخاب آدرس"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "بررسی صلاحیت پرداخت"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "منطقه مالیاتی پیش‌فرض"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "پیش‌نویس سفارش آماده تکمیل است"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "فراداده"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "فیلتر..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "مقدار ویژگی جدید"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "کانال با موفقیت به‌روزرسانی شد"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "نمایش کمتر"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "تاریخ کوتاه"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "ارزهای موجود"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "انتخاب {0} مورد"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "ثبت شده در"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "چرخش این کلید بلافاصله کلید فعلی را باطل می‌کند. هرگونه یکپارچه‌سازی که از آن استفاده می‌کند تا زمان به‌روزرسانی با کلید جدید از کار می‌افتد."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "داده‌ای که به کار ارسال شده است"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "تایید پیمایش"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "هدف پیوند"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "تکمیل پیش‌نویس"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "نام"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "تحویل سفارش ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "مجموع"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "شناسه تراکنش را برای این تسویه بازپرداخت وارد کنید"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "کلید API شما"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "آیا مطمئن هستید که می‌خواهید این سفارش پیش‌نویس را حذف کنید؟"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "تحویل ایجاد شد"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "{0} روش ارسال واجد شرایط یافت شد"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "ابعاد"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "نمایش رمز عبور"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(حداکثر: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "شرکت"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "افزودن ستون بعد از"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "اقدامات"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "تخفیف‌ها"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "یادداشت بازپرداخت را وارد کنید"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "خط سفارش حذف شد"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "محتوا:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "کلید"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "تایید"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "ایجاد مجموعه ناموفق بود"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "رفتن به صفحه اول"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "ایجاد محصول ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "مشتری"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "خطا در بارگذاری تاریخچه سفارش: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "آدرس حمل و نقل برای سفارش تنظیم شد"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "نقطه کانونی"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "یک گونه، بدون گزینه"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "وضعیت بعدی را برای سفارش انتخاب کنید"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "محلی‌سازی"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "وظایف زمان‌بندی شده"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "شناسه تراکنش را وارد کنید"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "تازه‌سازی داده‌ها"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "افزودن یا حذف مقادیر ویژگی برای {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "اینها مقادیر ویژگی برای ویژگی <0>{facetName}</0> هستند."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "پرداخت با موفقیت به سفارش اضافه شد"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "آدرس صورتحساب برای سفارش تنظیم شد"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "به‌روزرسانی منطقه ناموفق بود"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "رمز عبور"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "حذف ناموفق بود"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "وظیفه زمان‌بندی شده اجرا خواهد شد"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "محل انبار جدید"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "مجوزها"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "آدرس ارسال تغییر کرد"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "محصولی یافت نشد"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "افزودن سطر قبل از"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "انتقال به {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "این ماه"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "ایجاد ویژگی ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "لغو اقلام سفارش ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "شناسه تراکنش"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "تخصیص داده شده"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "افزودن گروه گزینه دیگر"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "انتخاب کنید با موجودی باقی‌مانده چه کاری انجام شود"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "کاوش پلتفرم و ابر"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "هر ۵ ثانیه"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "مجموعه با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "قیمت"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "سفارش پیش‌نویس"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "دامنه"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "افزودن شرط"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "روش ارسال برای این سفارش واجد شرایط است"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "مدیران"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "از گروه حذف شد"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "عرض"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "پرداخت یا بازپرداخت لازم نیست"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "دانلود به عنوان فایل .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "وقتی فعال باشد، تبلیغات در فروشگاه موجود است"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "وقتی دنبال می‌شود، سطوح موجودی نوع محصول هنگام فروش به طور خودکار تنظیم می‌شود. این تنظیم می‌تواند توسط انواع محصول منفرد لغو شود."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "روش حمل و نقل برای سفارش تنظیم شد"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "به‌روزرسانی تبلیغات ناموفق بود"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "تصاویر"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "کلیدهای API"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "جستجوی {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "ویرایش فایل"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "لغو پرداخت"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "صف کارها"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "فایل‌ها"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "آدرس ایمیل"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "بازسازی نامک از فیلد منبع"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "وراثت از تنظیمات عمومی"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "هیچ نتیجه‌ای یافت نشد"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "وضعیت فعلی"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "آدرس ارسال را تنظیم کنید و روش ارسال را انتخاب کنید"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "خاموش"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "فروشگاه تنظیمات"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "صف"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "نرخ مالیات جدید"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "پرداخت منتقل شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "باقیمانده:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "هیچ تکثیرکننده‌ای با کد \"{duplicatorCode}\" برای {entityName} یافت نشد"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "قیمت‌ها شامل مالیات برای منطقه مالیاتی پیش‌فرض است"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "مجموع بازپرداخت:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "مشاهده نتیجه کار"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "روش‌های ارسال خود را با شبیه‌سازی یک سفارش جدید آزمایش کنید."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "هیچ موردی انتخاب نشده است"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr "، {0} انتخاب شده"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "هیچ کشوری یافت نشد"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "گونه‌ها با موفقیت ایجاد شدند"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "ایجاد خودکار نامک"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "هزینه اضافی"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "روش‌های پرداخت"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "موجودی"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "هیچ مشتری یافت نشد"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "استفاده از آستانه عمومی اتمام موجودی"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "گروه گزینه محصول جدید"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "وضعیت پرداخت با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "ایجاد جدید"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "کل بازپرداخت"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "آدرس حذف شد"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "فقط نقش‌های تخصیص داده شده به حساب شما در دسترس هستند."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "مورد به سفارش اضافه شد"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "ویرایش نقطه کانونی"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "هیچ فروشنده‌ای یافت نشد"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "فایل"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {این گروه گزینه توسط یک محصول دیگر استفاده می‌شود. تغییرات بر آن نیز تأثیر خواهد گذاشت.} other {این گروه گزینه در # محصول مشترک است. تغییرات بر همه آنها تأثیر خواهد گذاشت.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "نماهای ذخیره شده من"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "کانال جدید"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "ایجاد فروشنده ناموفق بود"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "پیکربندی تنظیمات تکرار برای {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "هیچ گونه‌ای با فیلتر فعلی مطابقت ندارد."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "آدرس‌ها"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "افزودن مقدار گزینه جدید به گروه گزینه {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "تغییر سفارش شماره {0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "افزودن ستون قبل از"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "زبان‌های کانال"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "ایجاد گروه گزینه ناموفق بود"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "درست"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "انتخاب مشتری"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "سفارش منتقل شد"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "این محصول دارای انواع موجود است اما هیچ گروه گزینه‌ای تعریف نشده است. قبل از ایجاد انواع جدید باید گروه‌های گزینه اضافه کنید."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "قبل از است"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "حذف سفارش پیش‌نویس"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "کاتالوگ"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "روش پرداخت جدید"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "تبلیغات با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {لغو {rejected} کار ناموفق بود} other {لغو {rejected} کار ناموفق بود}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "یک کانال انتخاب کنید"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "زبان نمایش"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "جزئیات تحویل"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "کنار گذاشتن موجودی باقی‌مانده"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "اکنون"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "کانال‌ها"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "نما با موفقیت به عمومی تبدیل شد"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "قبل از"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "اندازه"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "هیچ ترجمه‌ای برای {0} یافت نشد"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "مشتری جدید"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "آخرین سفارش‌ها"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} بیشتر"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "استفاده به عنوان آدرس صورتحساب پیش‌فرض"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "حذف"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "غیرفعال کردن"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "مجموعه‌ها"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "افزودن نوع"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "ایجاد کشور ناموفق بود"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "کشورها"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "ایجاد گزینه‌های محصول ناموفق بود"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "تغییر نام نما ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "موجود"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "عادی"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "فیلترها"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "گروه‌های مشتری"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "مشتریان"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "نمونه قالب‌بندی"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "گزینه جدید"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "محدودیت استفاده"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "در حال بارگذاری تنظیمات عمومی..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "آدرس با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "ایجاد شد"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "در حال بارگذاری آدرس‌ها..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "یک مجموعه هدف برای جابجایی {0} انتخاب کنید."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "جزئیات مشتری به‌روزرسانی شد"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "در نیست"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "اعمال"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "گزینه محصول جدید"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "رفتن به صفحه آخر"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "لغو"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "نوع محصول با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "بازپرداخت از این روش"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "کد پستی"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "ابتدا گزینه‌های محصول را اضافه کنید"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "دسته‌بندی مالیاتی جدید"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "افزودن گزینه"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "بازپرداخت جزئی تکمیل شد"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "تنظیم فیلدهای سفارشی"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "مجموعه‌ها"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "حذف گونه"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "هیچ تغییری انجام نشد"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "منطقه ارسال پیش‌فرض"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "دلیل:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "آدرس ارسال"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "انتقال به {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "دسته‌بندی‌های مالیاتی"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "مجموعه‌های خصوصی در فروشگاه قابل مشاهده نیستند"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "وقتی فعال باشد، محصول در فروشگاه موجود است"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "وظیفه زمان‌بندی شده نتوانست اجرا شود"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "گروه‌های مشتری"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "غیرفعال"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "تبلیغات جدید"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "آدرس ارسال پیش‌فرض"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "بازپرداخت مورد نیاز است"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "تحویل سفارش"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "شما مجوز مشاهده تنظیمات کانال را ندارید"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "30 روز گذشته"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "هیچ مقدار ویژگی وجود ندارد"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "دلیل بازپرداخت الزامی است"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "حذف گروه گزینه امکان‌پذیر نبود"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "به‌روزرسانی دسته‌بندی مالیاتی ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "بازپرداخت با موفقیت تسویه شد"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "به‌روزرسانی"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "سرفصل ۲"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "سفارش ثبت شد"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "پروفایل با موفقیت به‌روزرسانی شد"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "پایان"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "روش پرداخت"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "ویرایش"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "نوع با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "فیلتر بر اساس نام مجموعه"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "یادداشت اضافه شد"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "تعداد را برای تحویل انتخاب کنید و مدیریت تحویل را پیکربندی کنید"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "آدرس صورتحساب از سفارش حذف شد"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "شروع در"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "تکثیر"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "نتیجه‌ای وجود ندارد"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "تنظیمات ستون"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {حذف {count} مکان موجودی ناموفق بود} other {حذف {count} مکان موجودی ناموفق بود}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "کد"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "حذف گروه‌های گزینه ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "سفارش تحویل داده شد"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "انتقال به {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "موجودی باقی‌مانده"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "حذف از منطقه"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "از زبان‌های موجود سراسری برای این کانال انتخاب کنید"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "آیا مطمئن هستید که می‌خواهید این آدرس را حذف کنید؟"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "تخصیص گروه گزینه ناموفق بود"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "به‌روزرسانی فایل ناموفق بود"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "محل انبار با موفقیت به‌روزرسانی شد"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "تایید عملیات"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "کشور با موفقیت به‌روزرسانی شد"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "ویژگی‌ها"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "افزودن یادداشت ناموفق بود"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "حذف یادداشت ناموفق بود"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "گسترش سند پرس‌وجو ناموفق بود"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "به‌روزرسانی یادداشت ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "بازپرداخت هزینه ارسال"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "فقط خواندنی"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "تکثیر نمای عمومی ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "نمایش {shown} از {total} • {selected} انتخاب‌شده"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "آزمون روش ارسال"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "مقادیر ویژگی"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "فایل با موفقیت به‌روزرسانی شد"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "تم"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} مشتری"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "کلیدهای API"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "یک زبان انتخاب کنید"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "خروج"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "تلاش‌ها"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "کدهای ارز موجود"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "کدهای زبان‌های موجود"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "مسیر پیمایش"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "دسته‌بندی"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "کانال‌ها"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "فرزندان"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "کد"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "کد کوپن"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "ایجاد شده در"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "کد ارز"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "مشتری"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "گروه مشتری"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "مشتریان"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "فیلدهای سفارشی"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "داده‌ها"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "کد ارز پیش‌فرض"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "کد زبان پیش‌فرض"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "منطقه ارسال پیش‌فرض"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "منطقه مالیاتی پیش‌فرض"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "توضیحات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "مدت زمان"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "آدرس ایمیل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "فعال"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "پایان در"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "خطا"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "فایل برجسته"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "نام"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "کد مدیریت تحویل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "شناسه"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "پیش‌فرض است"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "خصوصی است"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "تسویه شده است"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "نام خانوادگی"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "نام"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "زمان ثبت سفارش"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "شناسه والد"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "محدودیت استفاده به ازای هر مشتری"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "مجوزها"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "موقعیت"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "قیمت"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "قیمت‌ها شامل مالیات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "قیمت با مالیات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "انواع محصول"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "پیشرفت"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "نام صف"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "نتیجه"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "تلاش‌های مجدد"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "فروشنده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "تسویه شده در"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "خطوط ارسال"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "نامک"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "شروع شده در"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "شروع در"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "وضعیت"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "سطوح موجودی"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "توکن"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "مجموع"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "مجموع با مالیات"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "نوع"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "به‌روزرسانی شده در"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "محدودیت استفاده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "کاربر"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "مقدار"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "لیست مقادیر"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "منطقه"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "روش"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "خلاصه مالیات"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "زبان‌هایی را که برای همه کانال‌ها موجود است تنظیم می‌کند. کانال‌های منفرد سپس می‌توانند زیرمجموعه‌ای از این زبان‌ها را پشتیبانی کنند."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "مجموعه‌ها با موفقیت منتقل شدند"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "ثبت‌نام شده"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "لغو کار"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "پایان در"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "صفحه {0} از {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "نرخ"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "اندازه، رنگ و غیره"
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "مرور فاست‌ها"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "منطقه"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "لغو شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "ایجاد شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "تحویل داده شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "در انتظار"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "ارسال شده"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "ذخیره نما"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} انتخاب شده"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "جستجوی گروه‌های گزینه..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "تغییر سفارش"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "موارد انتخاب شده"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "مقادیر"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "مشتری برای سفارش تنظیم شد"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "ویژگی‌ها"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {آیا مطمئن هستید که می‌خواهید {count} مشتری را از این گروه حذف کنید؟} other {آیا مطمئن هستید که می‌خواهید {count} مشتری را از این گروه حذف کنید؟}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "موجودی در دست"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "بازسازی فهرست جستجو نتوانست شروع شود"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "آدرس ارسال"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "منطقه جدید"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "کلید API جدید"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "حذف ستون"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "تخصیص موجود"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "خالی است"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "اینها مشتریان در گروه مشتری <0>{customerGroupName}</0> هستند."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "مدیریت نماهای عمومی"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "کانال پیش‌فرض"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "درج تصویر جدید با منبع، عنوان و ابعاد"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "ایجاد مقدار ویژگی ناموفق بود"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "به‌روزرسانی گزینه محصول ناموفق بود"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>رمز عبور را فراموش کرده‌اید؟</0><1>درخواست بازنشانی</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "کد کوپن"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "مشتری تایید شد"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "تنظیمات عمومی"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "برنامه"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "نمی‌توان یک مجموعه را به زیرمجموعه خودش منتقل کرد"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "دسته‌بندی مالیاتی جدید"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "محل انباری در کانال فعلی موجود نیست"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "کانال با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "مشتری با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "مشاهده داده‌ها"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "حذف نما"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "یک آدرس جدید به مشتری اضافه کنید."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "نماهای بیشتر"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "ویرایش ویژگی‌های تصویر انتخاب شده"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "نمای \"{viewName}\" اعمال شد"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} ویژگی با موفقیت از کانال حذف شد"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "محصول جدید"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "فایل جدید"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "محاسبه مجدد هزینه ارسال"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "انتخاب کنید که کدام گزینه‌ها باید برای نوع موجود \"{0}\" اعمال شود"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "فایل‌ها"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "این عمل تمام گروه‌های گزینه را از این محصول حذف کرده و به انتخاب تنظیم گونه بازمی‌گردد."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "آدرس صورتحساب"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "افزودن مقدار ویژگی"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "لطفا یک مجموعه هدف انتخاب کنید"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "قبل از اعمال تغییرات به سفارش، آنها را بررسی کنید."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "یک نقش انتخاب کنید"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "سفارش لغو شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "تخفیف"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "همه انواع"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "فقط پیش‌نویس سفارشات می‌تواند تکمیل شود"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "به‌روزرسانی محصول ناموفق بود"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "تنظیم {0} خط"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "افزودن مقادیر ویژگی"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "بعد از"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "کانال"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "بررسی سلامت"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "مقدار"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "شماره تلفن"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "مشتری جدید"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "تصویر"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "مدیر با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "گزینه‌های محصول"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "انتخاب کشور"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "در حال ایجاد..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "آیا مطمئن هستید که می‌خواهید این نمای عمومی را حذف کنید؟ این عملیات قابل بازگشت نیست و بر همه کاربران تأثیر می‌گذارد."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "حذف اجباری گروه گزینه"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "اضافه شد"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "تاریخچه مشتری"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "مقادیر ویژگی برای {entityIdsLength} {entityType} با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "حذف مشتری از گروه ناموفق بود"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "سیستم"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "محدودیت استفاده به ازای هر مشتری"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "آدرس صورتحساب تغییر کرد"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "یک گزینه انتخاب کنید"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "کپی به شخصی"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "کل بازپرداخت از حداکثر مبلغ قابل بازپرداخت {0} بیشتر است"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "حذف نمای عمومی"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "ایجاد"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "هر ۳۰ ثانیه"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "کشور جدید"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "از {0} به {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "ایجاد مشتری ناموفق بود"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "نقطه کانونی به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "مقادیر گزینه"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "آدرس صورتحساب پیش‌فرض"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "مشتری وجود ندارد"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "حذف کشورها از منطقه ناموفق بود"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "ایجاد تبلیغات ناموفق بود"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "امروز"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "دیروز"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "نام گزینه"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "آیا مطمئن هستید که می‌خواهید {0} {1} را از این منطقه حذف کنید؟"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "در حال افزودن {0} هزینه اضافی"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "آدرس پیوند"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "مقدار پیش‌فرض: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "تاریخچه سفارش"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "بازنویسی"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "شناسه تراکنش الزامی است"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "با عبارت باقاعده مطابقت دارد"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "نام نمای عمومی با موفقیت تغییر کرد"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "هیچ برچسبی انتخاب نشده است"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "بازگشت"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "نام نما با موفقیت تغییر کرد"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "اعمال فیلتر"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "آخرین نتیجه"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "به گروه اضافه شد"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "بینش‌ها"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "ایجاد انواع"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "در حال آزمایش روش ارسال..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "تیره"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "نتایج آزمون"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "افزودن مشتری"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "ذخیره تغییرات"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "آدرس به‌روزرسانی شد"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "بازپرداخت با موفقیت پردازش شد"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "منطقه جدید"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "به‌روزرسانی موقعیت مجموعه ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "بازپرداخت"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "تغییر"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "هیچ زبان عمومی پیکربندی نشده است"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "حذف {0} مورد"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "دنبال کردن"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "ایجاد نوع"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "مقادیر ویژگی برای {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "ذخیره چیدمان"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "بازنشانی رمز عبور تایید شد"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "حذف نما ناموفق بود"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "آیا مطمئن هستید که می‌خواهید از این صفحه خارج شوید؟ تمام تغییرات ذخیره نشده از بین می‌روند."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "تغییر وضعیت ستون سرفصل"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "تبلیغات جدید"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "نام مقدار گزینه"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "آخرین استفاده"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "دسته‌بندی مالیاتی پیش‌فرض است"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "نامک تنظیم شده است"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "به‌روزرسانی نقطه کانونی ناموفق بود"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "منطقه با موفقیت به‌روزرسانی شد"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "ایالت/استان"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "به‌روزرسانی گروه گزینه ناموفق بود"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "پیش‌فرض‌های کانال"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "ایجاد دسته‌بندی مالیاتی ناموفق بود"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "تنظیم معیارهای فیلتر برای ستون {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "کشور"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "محصول ساده"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "صف کارها"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "لطفاً قبل از بستن، ذخیره کلید API را تأیید کنید."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "تایید حذف"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "تغییر سفارش ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "شامل مالیات {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "معیارهای سفارش"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "زبان نمایش را انتخاب کنید"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "روش‌های احراز هویت"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "شروع"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "چرخش کلید API ناموفق بود"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "در"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "جستجوی نقش‌ها..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "انواع محصول"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "مدیریت نماهای عمومی"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "در حال پردازش..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} یافت شد"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "انتخاب بازه تاریخ"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "محصول"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "چرخش کلید API"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "دسته‌بندی"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "در حال جابجایی..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "اختصاص دادن"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "فروشنده با موفقیت ایجاد شد"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "روش ارسال با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "به‌روزرسانی نوع محصول ناموفق بود"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "برای مرتب‌سازی بکشید"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "مناطق"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "انتخاب کنید با موجودی باقی‌مانده در {count, plural, one {# مکان موجودی} other {# مکان موجودی}} که حذف می‌کنید چه کاری انجام شود. همه مکان‌های انتخاب‌شده موجودی باقی‌مانده خود را به تنها مکانی که انتخاب می‌کنید منتقل می‌کنند یا آن را کنار می‌گذارند."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "جستجوی مقادیر فاست..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "یادداشت"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "زبان‌های موجود"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "بارگذاری {0} مورد دیگر ({remaining} باقی‌مانده)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "مقادیر ویژگی"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "مرتب‌سازی مجدد اقلام ناموفق بود"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "کل سفارش‌ها"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "هیچ روش ارسال واجد شرایطی برای این سفارش یافت نشد."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "افزودن گزینه محصول"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "ارسال"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions باید در داخل DashboardBaseWidget استفاده شود"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "این گروه گزینه توسط متغیرهای موجود استفاده می‌شود. حذف اجباری آن ممکن است بر آن متغیرها تأثیر بگذارد. آیا مطمئن هستید؟"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "درخواست به‌روزرسانی ایمیل"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "خطا در انتقال به وضعیت"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "گروه مشتری با موفقیت ایجاد شد"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "پنجره جدید"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "پرداخت تایید شد"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "نقش با موفقیت به‌روزرسانی شد"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "یک کشور انتخاب کنید"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "به‌روزرسانی روش ارسال ناموفق بود"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} مکان موجودی حذف شد} other {{deleted} مکان موجودی حذف شد}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "روش‌های ارسال"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "یک آدرس انتخاب کنید"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "بله"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "نامک"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "تنظیم نقطه کانونی"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "پایان"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "یک ارز انتخاب کنید"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "محتوا یا قابلیت مشاهده یادداشت را به‌روزرسانی کنید"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "ابزارک آخرین سفارش‌ها"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "محتویات مجموعه {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "روش ارسال تغییر کرد"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "توضیحات مالیات"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "کوچکتر یا مساوی است با"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "مساوی نیست با"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "تازه‌سازی"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "مثلا اندازه"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "تسویه پرداخت"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "کانال‌ها"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "هزینه ارسال بازپرداخت شد"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "نوع فایل"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "محل انبار جدید"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} پرداخت قبل از خطا بازگردانده شد. برای جزئیات به تاریخچه سفارش مراجعه کنید."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "انتخاب مورد"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "محصول جدید"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "مدیریت برچسب‌ها"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "کالاهای بازپرداخت شده"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "افزودن اقدام"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "اختصاص گزینه‌ها به نوع موجود"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "تکثیر {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "حذف از گروه"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "به‌روزرسانی وضعیت تحویل ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "ایجاد گونه محصول جدید با گزینه‌ها، قیمت‌گذاری و موجودی"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "ویژگی‌های خصوصی در فروشگاه قابل مشاهده نیستند"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "یک دسته‌بندی مالیاتی انتخاب کنید"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "ایجاد شده"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "در حال اجرا نیست"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "تخصیص داده شده"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "سرفصل ۱"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "انتخاب زبان‌های موجود"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "افزودن {0} مورد"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "افزودن سطر بعد از"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "مجموع مالیات"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "وضعیت پیش‌نویس سفارش"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "گزینه‌های محصول با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "در حال بارگذاری مکان‌ها…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "ایجاد روش پرداخت ناموفق بود"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "مقدار ویژگی با موفقیت ایجاد شد"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "بازاریابی"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "سفارش پیش‌نویس حذف شد"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "بزرگتر از"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "ابزارک معیارها"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "جستجوی ارزها..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "حذف از کانال"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "عنوان"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "درج تصویر"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "به‌روزرسانی فروشنده ناموفق بود"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "کشور با موفقیت ایجاد شد"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "انتخاب فروشنده"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "در حال بارگذاری برچسب‌ها..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "ویژگی با موفقیت ایجاد شد"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} نوع"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "تسویه پرداخت ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "آدرس صورتحساب وجود ندارد"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {حذف {1} مکان موجودی ناموفق بود} other {حذف {2} مکان موجودی ناموفق بود}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "ویژگی"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "نمی‌توان از کانال فعال حذف کرد"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "تنظیم نشده"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "حذف اجباری"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "کانال جدید"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "نام گروه گزینه"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "و"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "ایجاد گروه مشتری ناموفق بود"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "ایجاد نقش ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "نام محصول"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "وضعیت تحویل با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "محصولات"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "آدرس ایجاد شد"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "کلید API با موفقیت چرخش یافت"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "افزودن گروه گزینه"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "بازپرداخت {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "نامک را به صورت دستی وارد کنید"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "هیچ ابزارکی در دسترس نیست"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "لغو پرداخت ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "پرداخت با موفقیت لغو شد"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "نمای عمومی با موفقیت تکثیر شد"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "ایجاد شده توسط"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "فیلتر کردن گونه‌ها..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "افزودن قیمت با ارز دیگر"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "آدرس ایمیل یا شناسه"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "بازپرداخت شماره {0} به {1} منتقل شد"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "مشتریان"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "سرفصل ۴"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "به‌روزرسانی محل انبار ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "سفارش ارسال شد"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "ذخیره آدرس"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "تبدیل به عمومی"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "وضعیت بعدی را انتخاب کنید"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "هیچ هشداری وجود ندارد"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "جابجایی {0} مجموعه به {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "آزمون"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "بین"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "یادداشت با موفقیت اضافه شد"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "یادداشت با موفقیت حذف شد"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "یادداشت با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "تسویه بازپرداخت ناموفق بود"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "سطح موجودی"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "افزودن مورد"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "کلید API با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "در حال بارگذاری پیش‌نمایش..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "بازگشت به جستجو"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "نما با موفقیت تکثیر شد"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "حذف گروه گزینه"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "توضیحات"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "کشورها"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "آدرس خیابان ۲"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "نمای عمومی با موفقیت حذف شد"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "ویرایش چیدمان"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "اختصاص به کانال"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "این هفته"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "گروه گزینه‌های محصول با موفقیت ایجاد شد"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "افزودن پرداخت دستی {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "در است"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "ایمیل"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "به‌روزرسانی مدیر ناموفق بود"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "مدیریت نماهای ذخیره شده شخصی خود برای این جدول"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "فیلتر بر اساس برچسب‌ها"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "برای دسترسی به داشبورد مدیریت وارد شوید"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "افزودن پرداخت به سفارش ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "نادرست"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "روشن"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "بازنشانی"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "مساوی است با"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "ایجاد گزینه‌ها"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "رمز عبور به‌روزرسانی شد"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "شامل نیست"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "گروه گزینه"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "جزئیات آدرس زیر را ویرایش کنید."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "دسته‌بندی مالیاتی با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "جابجایی مجموعه‌ها ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "به‌روزرسانی وضعیت پرداخت ناموفق بود"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "خلاصه سفارش‌های شما"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "آپلود"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "محصول با گزینه‌ها"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "نمایش همه {0} نتیجه"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "شناسه جستجو"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} بیشتر"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "گروه‌های گزینه"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "فیلدهای سفارشی"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "تمام حالات ممکن سفارش و انتقال‌های آنها. حالت فعلی مشخص شده است."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "سفارش‌ها"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "ابزارک خلاصه سفارش‌ها"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "افزودن اقلام"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "ترتیب پرداخت اضافی"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "ترتیب پرداخت"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "لغو شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "ایجاد شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "تحویل داده شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "پیش‌نویس"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "در حال تغییر"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "تا حدی تحویل داده شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "تا حدی ارسال شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "پرداخت تایید شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "پرداخت تسویه شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "ارسال شده"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "منابع نظارت شده"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "اطلاعات موجودیت"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "مجموع سفارش"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "فقط برای مدیران قابل مشاهده"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "تعداد"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "برچسب‌ها"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "مدیر ارشد"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "برخی منابع خاموش هستند"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "اقدام‌های موجود"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "درج پیوند"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "اگر فعال باشد، فیلترها از مجموعه والد به ارث برده می‌شوند و با فیلترهای تنظیم شده در این مجموعه ترکیب می‌شوند."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "یک منطقه انتخاب کنید"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "آزمون روش‌های ارسال"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "پرداخت با موفقیت تسویه شد"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} از منطقه حذف شد"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "فعال کردن"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "روش‌های پرداخت"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "مجاز"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "لغو شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "ایجاد شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "رد شده"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "خطا"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "ناموفق"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "در انتظار"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "تسویه شده"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "میانگین ارزش سفارش"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "ایجاد منطقه ناموفق بود"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "سطوح موجودی"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "به‌روزرسانی کلید API ناموفق بود"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "خطوط سفارش"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "تغییر نام نمای عمومی ناموفق بود"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "درج لینک جدید با URL و گزینه‌های هدف"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "ارتفاع"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "استرداد به مبلغ {formattedDiff} مورد نیاز است. مبالغ پرداخت را انتخاب کرده و یادداشتی برای ادامه وارد کنید."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "قیمت واحد"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "الگوی برنامه"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "پرداخت ناموفق بود"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "افزودن کانال"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "به‌روزرسانی گروه گزینه‌های محصول ناموفق بود"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "جستجوی کانال‌ها..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "افزودن گروه‌های مشتری"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "زبان‌های موجود"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "بازنشانی انتخاب"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "آدرسی وجود ندارد"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "روش پرداخت با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "اطلاعات مشتری به‌روزرسانی شد"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "تبدیل نما به عمومی ناموفق بود"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "انواع محصول"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "محصولات"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "تبلیغات"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "ایجاد گزینه محصول ناموفق بود"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "ایمیل قدیمی:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "نما را به عنوان \"عمومی\" ذخیره کنید تا برای همه کاربران در دسترس باشد."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "ایجاد گونه‌ها ناموفق بود"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "سطح موجودی را تنظیم می‌کند که در آن این نوع اتمام موجودی در نظر گرفته می‌شود. استفاده از مقدار منفی پشتیبانی از پیش‌سفارش را فعال می‌کند. می‌تواند توسط انواع محصول لغو شود."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "چرخش کلید"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "ایجاد متغیرهای محصول ناموفق بود"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "مخفی کردن رمز عبور"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "فروشنده جدید"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "مثلا قرمز، بزرگ، پنبه"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "به‌روزرسانی پروفایل ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "کدهای کوپن حذف شده"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "پاک کردن فیلتر"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "مناطق"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "فایل‌ها را برای آپلود اینجا رها کنید"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "تغییر وضعیت همه گونه‌های نمایان"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "تایید شده"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "گروه گزینه جدید"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "آخرین به‌روزرسانی {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "هنوز هیچ نمای عمومی ایجاد نشده است."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "به‌روزرسانی نقش ناموفق بود"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "این تنها باری است که کلید API کامل نمایش داده می‌شود. اکنون آن را کپی یا دانلود کنید — بعداً قابل بازیابی نیست."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "مجموعه با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "روش پرداخت با موفقیت به‌روزرسانی شد"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "نما با موفقیت حذف شد"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "گروه گزینه {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "یا"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "مدیریت برچسب‌ها"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "کد کوپن از سفارش حذف شد"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "هرگز"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "به‌روزرسانی مقدار ویژگی ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "حذف گروه"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "سفارش تحویل شد"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "آدرس ارسال وجود ندارد"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "گسترش پرس‌وجو حاوی نحو نامعتبر GraphQL است"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "خطای گسترش پرس‌وجو"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "خطای گسترش پرس‌وجو:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "گسترش پرس‌وجو نامعتبر است: باید حداقل یک فیلد سطح بالا داشته باشد"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "عدم تطابق گسترش پرس‌وجو:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "عمومی"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "دسته‌بندی مالیاتی با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "جابجایی"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "ویرایش یا حذف برچسب‌های موجود"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "شرایط بررسی صلاحیت این روش ارسال برای سفارش فعلی و آدرس ارسال برآورده نشده است."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "افزودن کد کوپن"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "کد کوپن برای سفارش تنظیم شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "فیلدهای سفارشی"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "روش ارسال جدید"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "حذف مکان‌های موجودی"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "بزرگتر یا مساوی است با"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "پیش‌نمایش"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} از {1} موجود برای انجام"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "از ابتدای ماه تاکنون"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "درخواست مشتری"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "آسیب دیده در حمل و نقل"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "در دسترس نیست"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "سایر"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "کالای اشتباه"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "خلاصه تغییرات"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "بازپرداخت‌ها ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "آخرین اجرا"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "جزئیات پرداخت"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "بازسازی فهرست جستجو"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "در حال اجرا"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "هر ۶۰ ثانیه"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "به‌روزرسانی گروه مشتری ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "فراداده پرداخت"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "لغو تغییر"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "همان پنجره"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "فیلترها را روی جدول اعمال کنید و برای شروع روی \"ذخیره نما\" کلیک کنید."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "نقش‌ها"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "پرداخت اضافی مورد نیاز است"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "به‌روزرسانی سفارش ناموفق بود"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "با موارد انتخاب شده..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "ایجاد محل انبار ناموفق بود"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "کوچکتر یا مساوی"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "اعضای گروه مشتری {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "وضعیت"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "دنبال نکردن"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "تحویل شماره {0} ایجاد شد"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "اجرای به‌روزرسانی‌های در انتظار نمایه جستجو"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "این یک نقش پیش‌فرض است و نمی‌تواند تغییر کند"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "نماهای ذخیره شده من"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "ایالت / استان"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "فعال"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "موارد در هر صفحه"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "ویرایش اعضا"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "موجودی در دست"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "فیلتر بر اساس {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "شناسه"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "هشدارها"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "مقادیر گزینه"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "پیش‌نمایش تغییرات"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "حذف {entityType} از کانال ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "نوع با موفقیت حذف شد"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "ویرایش ویژگی‌های لینک انتخاب شده"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "فروش"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "یک مجموعه مقصد انتخاب کنید"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "آخرین سفارش‌های شما"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "وظایف زمان‌بندی شده"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "آیا مطمئن هستید که می‌خواهید این مورد را حذف کنید؟ این عملیات قابل بازگشت نیست."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "انواع"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "فروشندگان"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "تنظیمات"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "فروشگاه تنظیمات"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "سرفصل ۳"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "به Vendure خوش آمدید"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "روش‌های ارسال"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} قابل بازپرداخت)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "شناسه"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "به‌روزرسانی مجموعه ناموفق بود"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "قیمت و مالیات"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "سفارش یافت نشد"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "خطا"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "سفارش تغییر کرد"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "درخواست بازنشانی رمز عبور"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "مبلغ پرداخت تخصیص‌یافته باید برابر با کل بازپرداخت باشد"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "مثلا کوچک"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "آیا مطمئن هستید که می‌خواهید {0} {entityType} را از کانال فعلی حذف کنید؟"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "افزودن برچسب‌ها..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "ایجاد گروه گزینه‌های محصول ناموفق بود"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} مورد انتخاب شده"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "جستجوی زبان‌ها..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "محل‌های انبار"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "رفتن به صفحه قبلی"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "محتویات"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "تبدیل نمای عمومی به نمای شخصی ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "نتیجه کار"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "افزودن پرداخت ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "سیستم"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "نام نوع"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "حذف"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "به‌روزرسانی مشتری ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "حذف گروه‌های گزینه؟"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "این پیش‌نمایشی از محتویات مجموعه بر اساس تنظیمات فیلتر فعلی است. پس از ذخیره مجموعه، محتویات به‌روزرسانی خواهند شد تا تنظیمات فیلتر جدید را منعکس کنند."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} مشتری از گروه حذف شد} other {{count} مشتری از گروه حذف شدند}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "دسته‌بندی‌های مالیاتی"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "نرخ‌های مالیات"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "حذف مشتریان از گروه با خطا مواجه شد"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "بارگذاری تنظیمات عمومی ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "اقلام را برای بازپرداخت انتخاب کنید و به صورت اختیاری به انبار برگردانید"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "ذخیره"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} از {0} ردیف انتخاب شده."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "پیش‌نمایش تغییرات سفارش"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "گروه گزینه‌های محصول با موفقیت به‌روزرسانی شد"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "صفحه با پرس‌وجوی پیش‌فرض ادامه می‌یابد."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "آدرس خیابان"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "فاست دیگری وجود ندارد"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "بازسازی فهرست جستجو شروع شد"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "موقعیت مجموعه به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "نام گروه گزینه"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "افزودن \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "نوع محصول جدید"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "بازپرداخت منتقل شد"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "استفاده از استراتژی احراز هویت بومی"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "تخصیص {entityIdsLength} {entityType} به کانال ناموفق بود"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "زبان پیش‌فرض"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "توکن"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "در حال تحویل..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "افزودن گروه گزینه به محصول"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "پیش‌نمایش {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "فروشنده با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "انتقال سفارش به وضعیت ناموفق بود"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "نمایش همه ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "ایجاد نرخ مالیات ناموفق بود"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "من این کلید API را ذخیره کرده‌ام"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "پیکربندی زبان‌های موجود برای فروشگاه و کانال‌های شما"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "محصول با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "افزودن نوع محصول"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "تایپ کنید و Enter یا کاما را برای افزودن فشار دهید..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "ویرایش یادداشت"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "فایلی یافت نشد. فیلترهای خود را تنظیم کنید."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "افزودن گزینه"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "ذخیره گروه گزینه"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "ایجاد {createCount} نوع"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "برای آزمایش این روش ارسال روی \"اجرای آزمون\" کلیک کنید."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "مدیر با موفقیت به‌روزرسانی شد"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "پاک کردن فیلترها"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "تحویل شماره {0} از {1} به {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "حذف نمای عمومی ناموفق بود"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "زبان پیش‌فرض"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "وضعیت"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "هیچ گزینه‌ای یافت نشد"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "باینری"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "گروه گزینه با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "روش ارسال جدید"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "هر ۱۰ ثانیه"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "بدون مالیات:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "افزودن موجودی به محل"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "مقدار گزینه با موفقیت اضافه شد"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "مجموعه به والد جدید منتقل شد"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "گروه گزینه حذف شد"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "انتقال به وضعیت انتخاب شده"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "یک پرداخت اضافی به مبلغ {formattedDiff} مورد نیاز خواهد بود."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "دنبال کردن موجودی به طور پیش‌فرض"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} از {total} انتخاب‌شده"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "روش ارسال با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "گروه مشتری جدید"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "برای مشتری قابل مشاهده"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "گروه گزینه با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "نرخ‌های مالیات"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "نامک به طور خودکار ایجاد خواهد شد..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "مشتری یافت نشد"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "انتخاب {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "مقادیر ویژگی جدید برای افزودن:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "پردازش بازپرداخت ناموفق بود"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "نام"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "شامل"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "گروه گزینه‌ای یافت نشد"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "هیچ موردی یافت نشد"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "جمع جزء"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "اقلام تحویل شده ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "مقدار به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "تایید نشده"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "تعداد"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "افزودن فیلتر"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "دسته‌بندی مالیاتی"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "نمایه"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "داده‌های آزمون به‌روزرسانی شده است. برای مشاهده نتایج به‌روز روی \"اجرای آزمون\" کلیک کنید."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "در نیست"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "خط سفارش به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "روش پرداخت جدید"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "مقدار تکراری \"{trimmed}\" از قبل وجود دارد"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "دلیل"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "گروه‌های مشتری"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} با موفقیت از کانال حذف شد"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "گروه‌های گزینه"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "افزودن هزینه اضافی"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "مقادیر فعلی ویژگی"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "صفحه {page} از {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "ماه گذشته"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "افزودن کشور"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "حذف مورد"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "ویدیو"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "کوچکتر از"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "امکان افزودن گونه وجود ندارد. اطمینان حاصل کنید که محصول والد فعال است."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "یک خطای ناشناخته رخ داد"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "معیارها"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "زبان"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "مجموعه جدید"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "بازپرداخت و لغو سفارش"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "به‌روزرسانی ایمیل تایید شد"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "بین است"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "بازپرداخت و لغو"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "در حال آزمایش روش‌های ارسال..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "ایجاد روش ارسال ناموفق بود"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} با موفقیت به کانال اختصاص داده شد"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "زبان‌های عمومی"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "مدیر جدید"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "حذف پیش‌نویس"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "منبع"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "عملیاتی موجود نیست"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "به‌روزرسانی کانال ناموفق بود"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "عمومی"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "حذف محصول از کانال ناموفق بود"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "افزودن آدرس جدید"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "ویژگی با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "منطقه با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "مقدار"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "مشتری به‌روزرسانی شد"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "ضریب تبدیل قیمت"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "سفارش فروشنده"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "ویژگی جدید"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "آیا مطمئن هستید که می‌خواهید این گروه گزینه را از محصول حذف کنید؟"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "توضیحات (متن جایگزین)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "هیچ برچسبی یافت نشد"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "ارز پیش‌فرض"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "برای این تغییرات هیچ پرداخت یا بازپرداختی لازم نیست."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "کل درآمد"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "اجرای بعدی"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "یادداشت خصوصی است"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "تاریخ متوسط"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "عدد نامعتبر"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "هنوز هیچ نمایی ذخیره نکرده‌اید."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "آیا مطمئن هستید که می‌خواهید این نما را حذف کنید؟ این عملیات قابل بازگشت نیست."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "مشاهده فرآیند سفارش"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "تکثیر نما ناموفق بود"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "استفاده به عنوان آدرس ارسال پیش‌فرض"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "ویرایش دستی نامک"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "فیلترها را برای پیش‌نمایش محتویات مجموعه اضافه کنید."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "گروه گزینه محصول"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "جمع جزء"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "کوچکتر از است"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "شناسه بازپرداخت"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "فیلدهای سفارشی سفارش به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "ماشین‌حساب"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "حذف گروه گزینه از کانال ناموفق بود: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "مشاهده داده‌های کار"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "جابجایی به سطح بالا"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "پاک کردن"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "خلاصه سفارش‌ها"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "جستجوی فایل‌ها..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "ویژگی جدید"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "اختصاص {entityType} به کانال"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "ادامه"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "تبلیغات"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "پیام خطا"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "افزودن سطح موجودی برای مکان دیگر"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "حذف آدرس"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "به‌روزرسانی ویژگی ناموفق بود"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters باید در داخل WidgetFiltersProvider استفاده شود"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "ویرایش آدرس"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "حذف ویژگی از کانال ناموفق بود: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "تنظیم پیوند"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "فروشنده جدید"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "ویرایش تصویر"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "مدیریت انواع"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "موجودی تخصیص داده شده"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "بزرگتر یا مساوی"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "سطح موجودی را تنظیم می‌کند که در آن این نوع اتمام موجودی در نظر گرفته می‌شود. استفاده از مقدار منفی پشتیبانی از پیش‌سفارش را فعال می‌کند."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "ایجاد گزینه‌های محصول"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "در حال ذخیره..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "مشاهده نتیجه"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "ردیف در هر صفحه"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "در حال بارگذاری مجموعه‌ها..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "مقدار ویژگی با موفقیت به‌روزرسانی شد"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "افزودن فایل"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "ذخیره تغییرات"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "مشتری به گروه اضافه شد"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "سفارش‌های فروشنده"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "افزودن مقدار گزینه ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "افزودن مقدار گزینه به {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} کالا بازپرداخت شد"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "هنوز هیچ گروه گزینه‌ای تعریف نشده است. برای ایجاد انواع مختلف محصول خود گروه‌های گزینه اضافه کنید (مثلا اندازه، رنگ، جنس)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "ایمیل جدید:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "به‌روزرسانی روش پرداخت ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "موجود:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "ایجاد شده در"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "ایجاد نوع محصول ناموفق بود"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "زبان: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "شما مجوز مشاهده تنظیمات زبان عمومی را ندارید"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "نرخ مالیات با موفقیت ایجاد شد"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "سرفصل ۶"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "کدهای کوپن اضافه شده"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "فعال"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "پایه مالیاتی"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "بارگذاری بیشتر"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "بازپرداخت تسویه شد"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "کلید API"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} با موفقیت تکثیر شد"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "گروه گزینه جدید"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "هنوز نتیجه‌ای وجود ندارد"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "پرداخت تسویه شد"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "شرط‌های موجود"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "فیلترهای فعال"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "پاک کردن همه"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "بزرگتر از است"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "بستن"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "افزودن پرداخت به سفارش"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "در حال بارگذاری..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "توکن برای مشخص کردن کانال هنگام انجام درخواست‌های API استفاده می‌شود."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "هیچ آدرسی یافت نشد"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "شناسه تحویل"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "پرداخت‌ها را برای بازپرداخت انتخاب کنید"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "حذف {failed} {entityName} ناموفق بود"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "آستانه اتمام موجودی"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "محصول با موفقیت از کانال حذف شد"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "به‌روزرسانی مقدار ناموفق بود"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "ایجاد کلید API ناموفق بود"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "تسویه بازپرداخت"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "روش پرداخت الزامی است"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "افزودن مشتری به گروه ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "مدیریت انواع"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "نمای عمومی \"{viewName}\" اعمال شد"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "مشتری ثبت‌نام شد"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "مناطق"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "جستجوی فروشندگان..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "تبلیغات با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "گزینه"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "فرآیند سفارش"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "شماره تلفن"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "خصوصی"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "نوع"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "تنظیمات عمومی با موفقیت به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "کلید API با موفقیت به‌روزرسانی شد"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "این زبان‌ها برای استفاده همه کانال‌ها در دسترس خواهد بود"

--- a/packages/dashboard/src/i18n/locales/fr.po
+++ b/packages/dashboard/src/i18n/locales/fr.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Nom complet"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Sélectionner des éléments"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Voir les modifications"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Code de suivi"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Les permissions sélectionnées seront appliquées à ces canaux."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Options de produit"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Nouveau taux de taxe"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Assigner un groupe d'options existant ou en créer un nouveau"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Nouveau rôle"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Appartement, suite, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Aucun autre élément"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Modifier le lien"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Ajoutez au moins un article à la commande"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Ajouter des produits pour créer une commande de test"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Échec de la création de l'adresse"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Basculer tout"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Modifier la valeur JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Utilisation de la stratégie d'authentification externe : {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Sélectionnez une raison..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Titre 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Échec de l'ajout du paiement"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Mis à jour"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Échec de la mise à jour des paramètres globaux"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Commande traitée avec succès"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Êtes-vous sûr de vouloir supprimer {0} {entityName} ?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Seuil global de rupture de stock"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Gérer les langues"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Duplication... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Supprimé avec succès"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Supprimer du canal actuel"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} ressources supprimées"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Taux de taxe mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Entrez une raison personnalisée..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Type"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Sélectionner {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Voir les valeurs"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Supprimer la ligne"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Conditions"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Actuel"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Aucune exécution"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Échec de la suppression de {1} emplacement de stock : {messages}} other {Échec de la suppression de {2} emplacements de stock : {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Lorsque ceci est activé, les prix saisis dans le catalogue de produits seront inclus dans la taxe pour la zone fiscale par défaut."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Créer des variantes pour votre produit"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Brouillon de commande terminé"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Actualisation automatique : {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Contrôles de santé"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} supprimé(s)"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Contrôles de santé"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Vendeurs"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Options"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} tâche annulée avec succès} other {{fulfilled} tâches annulées avec succès}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Vendeur"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "Réf. :"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Ajouter un paiement"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Testez cette méthode d'expédition en simulant une commande pour voir si elle est éligible et quel serait le coût d'expédition."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Explorer l'édition Enterprise"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Emplacements de stock"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Gestionnaire d'exécution"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Commandes"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Sélectionner les rôles"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Rôle créé avec succès"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette variante ?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Toutes les ressources sont opérationnelles"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Échec de la création de l'administrateur"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Non"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Variante de produit mise à jour avec succès"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Échec de la suppression de {failed} {entityName} : {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Produit mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Échec de la mise à jour du pays"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Tapez au moins 2 caractères pour rechercher..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Nom de famille"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Titre du lien"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Groupe de clients mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Champs personnalisés modifiés"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Emplacement de stock créé avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Erreur inconnue"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Le total du remboursement ne peut pas être négatif"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Voir les détails"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Sélectionnez un canal auquel assigner {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Client créé avec succès"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "7 derniers jours"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Échec de la création du canal"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Mode développeur"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Nouveau rôle"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Échec de la suppression des ressources : {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Retourner au stock"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Visibilité"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Variantes de produit"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Nouveau groupe de clients"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Créer « {0} »"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Renommer"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Choisissez votre langue d'affichage et vos paramètres régionaux préférés"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} groupes d'options supprimés du canal avec succès"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Le mode de livraison n'est pas éligible pour cette commande"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Échec de la mise à jour de l'adresse"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adresse supprimée avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Taux de taxe"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Le brouillon de commande n'est pas prêt à être finalisé"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Nouvelle collection"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Aperçus"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Exécuter"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Échec de la mise à jour du taux de taxe"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Voici le contenu de la collection <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privé"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Option de produit créée avec succès"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Produit parent"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Ville"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administrateurs"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Prix brut : <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Aller à la page suivante"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Supprimer le lien"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Ce champ est en lecture seule"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Nombre de commandes"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Commande mise à jour avec succès"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Hériter des filtres"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Gérer les vues globales sauvegardées visibles pour tous les utilisateurs"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Rechercher des méthodes de paiement..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Adresse de livraison supprimée pour la commande"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Créer {enabledCount} variantes"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Paiement #{0} transféré vers {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Erreur lors du chargement de l'historique client : {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "Suppression réussie de {selectionLength} {entityType} du canal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Ajouter une valeur d'option"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Paramètres globaux"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "est après"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Option de produit mise à jour avec succès"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Modifier les valeurs de facette"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Ajout..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Déplacer les collections"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Rôles"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Vue en grille"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Échec de la suppression de l'adresse"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Aucune méthode d'expédition disponible"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Vue globale convertie en vue personnelle avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Exécution transférée"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Êtes-vous sûr de vouloir supprimer {selectionLength} ressources ?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Se connecter"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Vue en liste"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Commande de Test"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Sélectionnez un client pour continuer"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Groupe d'options assigné avec succès"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Exécuter le test"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Taux de taxe : {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Veuillez ajouter des produits et compléter l'adresse de livraison pour exécuter le test."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Basculer la ligne d'en-tête"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Sélectionner une adresse"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Vérificateur d'éligibilité de paiement"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Zone fiscale par défaut"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Le brouillon de commande est prêt à être finalisé"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Métadonnées"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrer..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Nouvelle valeur de facette"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Canal mis à jour avec succès"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Afficher moins"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Date courte"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Devises disponibles"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Sélectionner {0} éléments"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Passée le"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "La rotation de cette clé invalidera immédiatement la clé actuelle. Toutes les intégrations qui l'utilisent cesseront de fonctionner jusqu'à ce qu'elles soient mises à jour avec la nouvelle clé."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Les données qui ont été transmises au travail"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Confirmer la navigation"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Cible du lien"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Terminer le brouillon"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Nom"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Échec de l'exécution de la commande"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Total"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Saisissez l'ID de transaction pour ce règlement de remboursement"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Votre API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Êtes-vous sûr de vouloir supprimer ce brouillon de commande ?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Exécution créée"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Trouvé {0} méthode(s) d'expédition éligible(s)"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Dimensions"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Afficher le mot de passe"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(max : {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Entreprise"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Ajouter une colonne après"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Actions"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Remises"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Saisir une note de remboursement"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Ligne de commande supprimée"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Contenu :"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Clé"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Confirmer"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Échec de la création de la collection"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Aller à la première page"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Échec de la création du produit"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Client"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Erreur lors du chargement de l'historique des commandes : {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Adresse de livraison définie pour la commande"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Point focal"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Variante unique, sans options"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Sélectionnez l'état suivant pour la commande"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Locale"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Tâches planifiées"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Saisir l'ID de transaction"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Actualiser les données"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Ajouter ou supprimer des valeurs de facette pour {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Voici les valeurs de facette pour la facette <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Paiement ajouté avec succès à la commande"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Adresse de facturation définie pour la commande"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Échec de la mise à jour de la zone"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Mot de passe"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Échec de la suppression"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "La tâche planifiée sera exécutée"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Nouvel emplacement de stock"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Permissions"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Adresse de livraison modifiée"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Aucun produit trouvé"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Ajouter une ligne avant"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Transition vers {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Ce mois-ci"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Échec de la création de la facette"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Échec de l'annulation des articles de la commande"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID de Transaction"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Alloué"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Ajouter un autre groupe d'options"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Choisissez ce qu'il advient du stock restant"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Découvrir Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Toutes les 5 secondes"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Collection créée avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Prix"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Brouillon de commande"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Portée"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Ajouter une condition"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Le mode de livraison est éligible pour cette commande"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administrateurs"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Supprimé du groupe"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Largeur"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Aucun paiement ou remboursement requis"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Télécharger en tant que fichier .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Lorsqu'activée, une promotion est disponible dans la boutique"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Lorsque suivi, les niveaux de stock des variantes de produit seront automatiquement ajustés lors de la vente. Ce paramètre peut être remplacé par les variantes de produit individuelles."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Mode de livraison défini pour la commande"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Échec de la mise à jour de la promotion"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Images"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Rechercher {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Modifier la ressource"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Annuler le paiement"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "File d'attente des tâches"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Ressources"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Adresse e-mail"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Régénérer le slug à partir du champ source"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Hériter des paramètres globaux"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Statut actuel"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Définissez une adresse de livraison et sélectionnez un mode d'expédition"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Désactivé"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Magasin de paramètres"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "File d'attente"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Nouveau taux de taxe"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Paiement transféré"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Restant :"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Aucun duplicateur trouvé avec le code « {duplicatorCode} » pour {entityName}s"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Les prix incluent la taxe pour la zone fiscale par défaut"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Remboursement total :"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Voir le résultat du travail"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Testez vos méthodes d'expédition en simulant une nouvelle commande."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Aucun élément sélectionné"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} sélectionné(s)"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Aucun pays trouvé"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Variantes créées avec succès"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Générer automatiquement le slug"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Supplément"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Méthodes de paiement"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Stock"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Aucun client trouvé"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Utiliser le seuil global de rupture de stock"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Nouveau groupe d'options de produit"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "État de paiement mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Créer nouveau"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Total du remboursement"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adresse supprimée"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Seuls les rôles assignés à votre compte sont disponibles."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Élément ajouté à la commande"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Modifier le point focal"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Aucun vendeur trouvé"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Ressource"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Ce groupe d'options est utilisé par un autre produit. Les modifications l'affecteront également.} other {Ce groupe d'options est partagé entre # produits. Les modifications les affecteront tous.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Mes vues sauvegardées"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Nouveau canal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Échec de la création du vendeur"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Configurer les paramètres de duplication pour les {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Aucune variante ne correspond au filtre actuel."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adresses"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Ajouter une nouvelle valeur d'option au groupe d'options {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Modification de commande #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Ajouter une colonne avant"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Langues du canal"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Échec de la création du groupe d'options"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Vrai"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Sélectionner un client"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Commande transférée"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Ce produit a des variantes existantes mais aucun groupe d'options défini. Vous devez ajouter des groupes d'options avant de créer de nouvelles variantes."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "est avant"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Supprimer le brouillon de commande"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Catalogue"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Nouvelle méthode de paiement"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promotion mise à jour avec succès"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Échec de l'annulation de {rejected} tâche} other {Échec de l'annulation de {rejected} tâches}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Sélectionner un canal"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Langue d'affichage"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Détails de l'exécution"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Abandonner le stock restant"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Maintenant"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Canaux"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Vue convertie globalement avec succès"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "avant"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Taille"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Aucune traduction trouvée pour {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Nouveau client"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Dernières commandes"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} de plus"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Utiliser comme adresse de facturation par défaut"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Supprimer"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Désactiver"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Collections"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Ajouter une variante"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Échec de la création du pays"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Pays"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Échec de la création des options de produit"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Échec du renommage de la vue"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Disponible"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtres"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Groupes de clients"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Clients"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Formatage d'exemple"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nouvelle option"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Limite d'utilisation"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Chargement des paramètres globaux..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adresse mise à jour avec succès"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Créé"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Chargement des adresses..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Sélectionnez une collection cible vers laquelle déplacer {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Détails du client mis à jour"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "pas dans"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Appliquer"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nouvelle option de produit"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Aller à la dernière page"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Annuler"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Variante de produit créée avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Remboursement de cette méthode"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Code postal"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Ajouter d'abord les options de produit"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Nouvelle catégorie fiscale"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Ajouter une option"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Remboursement partiel effectué"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Définir les champs personnalisés"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Collections"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Supprimer la variante"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Aucune modification apportée"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Zone d'expédition par défaut"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Motif :"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Adresse de livraison"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Transition vers {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Catégories de taxes"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Les collections privées ne sont pas visibles dans la boutique"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Lorsqu'activé, un produit est disponible dans la boutique"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "La tâche planifiée n'a pas pu être exécutée"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Groupes de clients"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Nouvelle promotion"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Adresse de livraison par défaut"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Remboursement requis"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Exécuter la commande"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Vous n'avez pas la permission de voir les paramètres du canal"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "30 derniers jours"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Aucune valeur de facette"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Une raison pour le remboursement est requise"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Impossible de supprimer le groupe d'options"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Échec de la mise à jour de la catégorie fiscale"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Remboursement réglé avec succès"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Titre 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Commande passée"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profil mis à jour avec succès"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "fin"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Méthode de paiement"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Modifier"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variante mise à jour avec succès"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtrer par nom de collection"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Note ajoutée"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Sélectionnez les quantités à exécuter et configurez le gestionnaire d'exécution"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Adresse de facturation supprimée de la commande"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Commence à"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Dupliquer"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Aucun résultat"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Paramètres des colonnes"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Échec de la suppression de {count} emplacement de stock} other {Échec de la suppression de {count} emplacements de stock}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Code"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Échec de la suppression des groupes d'options"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Commande livrée"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Transférer vers {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Stock restant"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Supprimer de la zone"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Sélectionnez parmi les langues globalement disponibles pour ce canal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette adresse ?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Échec de l'assignation du groupe d'options"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Échec de la mise à jour de la ressource"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Emplacement de stock mis à jour avec succès"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Confirmer l'action"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Pays mis à jour avec succès"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Facettes"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Échec de l'ajout de la note"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Échec de la suppression de la note"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Échec d'extension du document de requête"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Échec de la mise à jour de la note"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Rembourser la livraison"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Lecture seule"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Échec de la duplication de la vue globale"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Affichage de {shown} sur {total} • {selected} sélectionnées"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Méthode d'Expédition de Test"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Valeurs de facette"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Ressource mise à jour avec succès"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Thème"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} clients"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Sélectionner une langue"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Se déconnecter"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Tentatives"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Codes de devises disponibles"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Codes de langue disponibles"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Fil d'Ariane"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Catégorie"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Canaux"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Enfants"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Code promo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Créé le"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Code de devise"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Client"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Groupe de clients"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Clients"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Champs personnalisés"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Données"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Code de devise par défaut"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Code de langue par défaut"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Zone d'expédition par défaut"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Zone de taxe par défaut"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Description"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Durée"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Adresse e-mail"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Activé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Se termine le"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Erreur"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Ressource mise en avant"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Prénom"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Code gestionnaire d'exécution"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Par défaut"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Privé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Réglé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Nom de famille"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Nom"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Commande passée le"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID parent"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Limite d'utilisation par client"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Permissions"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Position"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Prix"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Prix incluent la taxe"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Prix avec taxe"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Variantes de produit"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Progrès"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Nom de la file"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Résultat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Nouvelles tentatives"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Vendeur"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Réglé le"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Lignes d'expédition"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Identifiant"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Commencé le"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Commence le"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "État"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Niveaux de stock"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Jeton"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Total"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Total avec taxe"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Type"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Mis à jour le"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Limite d'utilisation"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Utilisateur"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Valeur"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Liste de valeurs"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Méthode"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Résumé des taxes"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Définit les langues qui sont disponibles pour tous les canaux. Les canaux individuels peuvent ensuite supporter un sous-ensemble de ces langues."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Collections déplacées avec succès"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Enregistré"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Annuler la tâche"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Se termine à"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Page {0} sur {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Taux"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Taille, couleur, etc."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Parcourir les facettes"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Annulé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Créée"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Livré"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "En attente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Expédié"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Enregistrer la vue"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} sélectionné(s)"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Rechercher des groupes d'options..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Modifier la commande"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Éléments sélectionnés"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Valeurs"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Client défini pour la commande"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Facettes"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Êtes-vous sûr de vouloir retirer {count} client de ce groupe ?} other {Êtes-vous sûr de vouloir retirer {count} clients de ce groupe ?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Stock en Main"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "La reconstruction de l'index de recherche n'a pas pu être démarrée"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Adresse de Livraison"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Nouvelle zone"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Nouveau API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Supprimer la colonne"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Assigner un existant"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "est nul"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Voici les clients du groupe de clients <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Gérer les vues globales"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Canal par défaut"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Insérer une nouvelle image avec source, titre et dimensions"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Échec de la création de la valeur de facette"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Échec de la mise à jour de l'option de produit"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Mot de passe oublié ?</0><1>Demander la réinitialisation</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Code coupon"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Client vérifié"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Paramètres globaux"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Planification"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Impossible de déplacer une collection dans son propre descendant"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Nouvelle catégorie fiscale"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Aucun emplacement de stock disponible sur le canal actuel"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Canal créé avec succès"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Client mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Voir les données"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Supprimer la vue"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Ajouter une nouvelle adresse au client."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Plus de vues"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Modifier les propriétés de l'image sélectionnée"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Vue „{viewName}\" appliquée"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Suppression réussie de {successCount} facettes du canal"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Nouveau produit"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Nouvelle ressource"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Recalculer les frais de livraison"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Sélectionnez les options qui doivent s'appliquer à la variante existante « {0} »"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Ressources"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Cela supprimera tous les groupes d'options de ce produit et reviendra au choix de configuration des variantes."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Adresse de facturation"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Ajouter une valeur de facette"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Veuillez sélectionner une collection cible"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Examinez les modifications avant de les appliquer à la commande."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Sélectionner un rôle"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Commande annulée"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Remise"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Tous les types"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Seuls les brouillons de commande peuvent être finalisés"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Échec de la mise à jour du produit"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Ajustement de {0} lignes"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Ajouter des valeurs de facette"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "après"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Canal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Contrôles de santé"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Montant"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Numéro de téléphone"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Nouveau client"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Image"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administrateur créé avec succès"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Options de produit"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Sélectionner un pays"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Création..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Êtes-vous sûr de vouloir supprimer cette vue globale ? Cette action ne peut pas être annulée et affectera tous les utilisateurs."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Forcer la suppression du groupe d'options"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Ajouté"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Historique du client"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Valeurs de facette mises à jour avec succès pour {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Échec de la suppression du client du groupe"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Système"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Limite d'utilisation par client"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Adresse de facturation modifiée"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Sélectionner une option"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Copier vers Personnel"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Le total du remboursement dépasse le montant maximum remboursable de {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Supprimer la vue globale"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Créer"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Toutes les 30 secondes"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Nouveau pays"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "De {0} à {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Échec de la création du client"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Point focal mis à jour"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Valeurs d'option"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Adresse de facturation par défaut"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Aucun client"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Échec de la suppression des pays de la zone"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Échec de la création de la promotion"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Aujourd'hui"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Hier"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Nom de l'option"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Êtes-vous sûr de vouloir supprimer {0} {1} de cette zone ?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Ajout de {0} supplément(s)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Lien href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Fallback : {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Historique des commandes"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Remplacer"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "L'ID de transaction est requis"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "correspond au regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Vue globale renommée avec succès"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Aucune étiquette sélectionnée"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Retour"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Vue renommée avec succès"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Appliquer le filtre"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Dernier résultat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Ajouté au groupe"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Aperçus"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Créer des variantes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Test de la méthode d'expédition..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Sombre"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Résultats du Test"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Ajouter un client"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Enregistrer les modifications"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adresse mise à jour"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Remboursement traité avec succès"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Nouvelle zone"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Échec de la mise à jour de la position de la collection"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Remboursement"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Modifier"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Aucune langue globale configurée"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Suppression de {0} élément(s)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Suivre"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Créer une variante"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Valeurs de facette pour {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Enregistrer la disposition"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Réinitialisation de mot de passe vérifiée"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Échec de la suppression de la vue"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Êtes-vous sûr de vouloir quitter cette page ? Toutes les modifications non sauvegardées seront perdues."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Basculer la colonne d'en-tête"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Nouvelle promotion"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Nom de la valeur d'option"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Dernière utilisation"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Est la catégorie fiscale par défaut"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Le slug est défini"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Échec de la mise à jour du point focal"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zone mise à jour avec succès"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "État/Province"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Échec de la mise à jour du groupe d'options"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Paramètres par défaut du canal"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Échec de la création de la catégorie de taxe"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Définir les critères de filtre pour la colonne {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Pays"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Produit simple"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "File d'attente des tâches"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Veuillez confirmer que vous avez enregistré l'API Key avant de fermer."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Confirmer la suppression"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Échec de la modification de la commande"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "TVA incluse à {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Métriques des commandes"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Sélectionner la langue d'affichage"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Méthodes d'authentification"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "début"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Échec de la rotation de l'API Key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "dans"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Rechercher des rôles..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Variantes de produit"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Gérer les vues globales"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Traitement en cours..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} trouvé(s)"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Sélectionner une période"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Produit"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rotation de l'API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Catégorie"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Déplacement..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Assigner"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Vendeur créé avec succès"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Mode de livraison mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Échec de la mise à jour de la variante de produit"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Faire glisser pour réorganiser"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zones"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Choisissez ce qu'il advient du stock restant dans {count, plural, one {# emplacement de stock} other {# emplacements de stock}} que vous supprimez. Tous les emplacements sélectionnés transfèrent leur stock restant vers l'unique emplacement que vous choisissez, ou l'abandonnent."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Rechercher des valeurs de facettes..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Note"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Langues disponibles"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Charger {0} de plus ({remaining} restants)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Valeurs de facette"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Échec de la réorganisation des articles"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Total des commandes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Aucune méthode d'expédition éligible trouvée pour cette commande."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Ajouter une option de produit"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Expédition"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions doit être utilisé dans un DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Ce groupe d'options est utilisé par des variantes existantes. Forcer sa suppression peut affecter ces variantes. Êtes-vous sûr ?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Mise à jour d'e-mail demandée"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Erreur lors de la transition vers l'état"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Groupe de clients créé avec succès"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nouvelle fenêtre"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Paiement autorisé"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Rôle mis à jour avec succès"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Sélectionner un pays"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Échec de la mise à jour du mode de livraison"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} emplacement de stock supprimé} other {{deleted} emplacements de stock supprimés}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Méthodes d'expédition"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Sélectionner une adresse"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Oui"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Définir le point focal"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "fin"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Sélectionner une devise"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Mettre à jour le contenu ou la visibilité de la note"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget Dernières Commandes"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Contenu de la collection pour {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Mode de livraison modifié"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Description de la taxe"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "est inférieur ou égal à"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "n'est pas égal à"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Actualiser"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "ex. Taille"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Régler le paiement"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Canaux"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Frais de port remboursés"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Type d'asset"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Nouvel emplacement de stock"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} paiement(s) remboursé(s) avant l'échec. Consultez l'historique de la commande pour plus de détails."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Sélectionner un élément"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Nouveau produit"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gérer les étiquettes"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Articles remboursés"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Ajouter une action"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Assigner des options à la variante existante"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Dupliquer {0}s"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Retirer du groupe"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Échec de la mise à jour de l'état d'exécution"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Créer une nouvelle variante de produit avec options, tarification et stock"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Les facettes privées ne sont pas visibles dans la boutique"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Sélectionner une catégorie fiscale"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Créé"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "N'est pas en cours d'exécution"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Assigné"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Titre 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Sélectionner les langues disponibles"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Ajout de {0} élément(s)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Ajouter une ligne après"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Total des taxes"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Statut du brouillon de commande"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Options de produit créées avec succès"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Chargement des emplacements…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Échec de la création de la méthode de paiement"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Valeur de facette créée avec succès"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Brouillon de commande supprimé"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "supérieur à"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Widget Métriques"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Rechercher des devises..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Retirer du canal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Titre"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Insérer une image"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Échec de la mise à jour du vendeur"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Pays créé avec succès"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Sélectionner un vendeur"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Chargement des étiquettes..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Facette créée avec succès"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} variantes"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Échec du règlement du paiement"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Aucune adresse de facturation"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Échec de la suppression de {1} emplacement de stock} other {Échec de la suppression de {2} emplacements de stock}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Facette"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Impossible de supprimer du canal actif"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Non défini"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Forcer la suppression"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Nouveau canal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Nom du groupe d'options"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "ET"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Échec de la création du groupe de clients"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Échec de la création du rôle"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Nom du produit"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "État d'exécution mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Produits"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adresse créée"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key roté avec succès"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Ajouter un groupe d'options"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Rembourser {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Saisir le slug manuellement"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Aucun widget disponible"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Échec de l'annulation du paiement"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Paiement annulé avec succès"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Vue globale dupliquée avec succès"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Créé par"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtrer les variantes..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Ajouter un prix dans une autre devise"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Adresse e-mail ou identifiant"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Remboursement #{0} transféré vers {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Clients"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Titre 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Échec de la mise à jour de l'emplacement de stock"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Commande expédiée"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Enregistrer l'adresse"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Rendre global"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Sélectionner l'état suivant"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Aucune alerte"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Déplacement de {0} collection{1} dans {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "entre"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Note ajoutée avec succès"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Note supprimée avec succès"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Note mise à jour avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Échec du règlement du remboursement"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Niveau de stock"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Ajouter un élément"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key créé avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Chargement de l'aperçu…"
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Retour à la recherche"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Vue dupliquée avec succès"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Supprimer le groupe d'options"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Description"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Pays"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Adresse de Rue 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Vue globale supprimée avec succès"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Modifier la disposition"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Assigner au canal"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Cette semaine"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Groupe d'options de produit créé avec succès"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Ajouter un paiement manuel de {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "est dans"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-mail"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Échec de la mise à jour de l'administrateur"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Gérez vos vues personnelles sauvegardées pour ce tableau"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtrer par étiquettes"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Connectez-vous pour accéder au tableau de bord administrateur"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Ajouter un paiement à la commande ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Faux"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Clair"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "est égal à"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Créer des options"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Mot de passe mis à jour"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "ne contient pas"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Groupe d'options"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Modifiez les détails de l'adresse ci-dessous."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Catégorie de taxe créée avec succès"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Échec du déplacement des collections"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Échec de la mise à jour de l'état de paiement"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Résumé de vos commandes"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Télécharger"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Produit avec options"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Affichage de tous les {0} résultats"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "ID de recherche"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} de plus"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Groupes d'options"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Champs personnalisés"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Tous les états de commande possibles et leurs transitions. L'état actuel est mis en surbrillance."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Commandes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget Résumé des Commandes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "orderState.Ajout d'articles"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Organisation de paiement supplémentaire"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "orderState.Organisation du paiement"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "orderState.Annulé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "orderState.Créé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Livré"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "orderState.Brouillon"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "En modification"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Partiellement livré"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Partiellement expédié"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "orderState.Paiement autorisé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "orderState.Paiement réglé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Expédié"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Ressources surveillées"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Informations de l'entité"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Total de la commande"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Visible aux administrateurs uniquement"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Qté"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Étiquettes"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super Administrateur"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Certaines ressources sont indisponibles"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Actions disponibles"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Insérer un lien"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Si activé, les filtres seront hérités de la collection parente et combinés avec les filtres définis sur cette collection."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Sélectionner une zone"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Méthodes d'expédition de test"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Paiement réglé avec succès"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} supprimé(s) de la zone"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Activer"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Méthodes de paiement"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autorisé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Annulé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Créé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Refusé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Erreur"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Échoué"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "En attente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Réglé"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Valeur moyenne des commandes"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Échec de la création de la zone"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Niveaux de stock"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Échec de la mise à jour de l'API Key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Lignes de commande"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Échec du renommage de la vue globale"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Insérer un nouveau lien hypertexte avec URL et options de cible"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Hauteur"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Un remboursement de {formattedDiff} est requis. Sélectionnez les montants de paiement et saisissez une note pour continuer."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Prix unitaire"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Modèle de planification"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Paiement échoué"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Ajouter un canal"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Échec de la mise à jour du groupe d'options de produit"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Rechercher des canaux..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Ajouter des groupes de clients"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Langues disponibles"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Réinitialiser la sélection"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Aucune adresse"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Mode de paiement créé avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Informations du client mises à jour"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Échec de la conversion de la vue en vue globale"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Variantes de produit"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Produits"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promotions"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Échec de la création de l'option de produit"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Ancien e-mail :"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Enregistrez une vue comme « Globale » pour la rendre disponible à tous les utilisateurs."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Échec de la création des variantes"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Définit le niveau de stock à partir duquel cette variante est considérée comme en rupture de stock. L'utilisation d'une valeur négative active le support de commande en attente. Peut être remplacé par les variantes de produit."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rotation de la clé"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Échec de la création des variantes du produit"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Masquer le mot de passe"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Nouveau vendeur"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "ex. Rouge, Grande, Coton"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Échec de la mise à jour du profil"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Codes coupon supprimés"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Effacer le filtre"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Régions"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Déposez les fichiers ici pour les téléverser"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Basculer toutes les variantes visibles"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Vérifié"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Nouveau groupe d'options"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Dernière mise à jour {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Aucune vue globale n'a encore été créée."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Échec de la mise à jour du rôle"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "C'est la seule fois que l'API Key complet sera affiché. Copiez-le ou téléchargez-le maintenant — il ne pourra pas être récupéré ultérieurement."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Collection mise à jour avec succès"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Mode de paiement mis à jour avec succès"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Vue supprimée avec succès"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Groupe d'options {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "OU"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Gérer les étiquettes"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Code de coupon retiré de la commande"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Jamais"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Échec de la mise à jour de la valeur de facette"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Supprimer le groupe"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Commande exécutée"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Aucune adresse de livraison"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "L'extension de requête contient une syntaxe GraphQL invalide"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Erreur d'extension de requête"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Erreur d'extension de requête : "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "L'extension de requête est invalide : doit avoir au moins un champ de niveau supérieur"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Incompatibilité d'extension de requête : "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "public"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Catégorie de taxe mise à jour avec succès"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Déplacer"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Modifier ou supprimer les étiquettes existantes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Les conditions de vérification d'éligibilité de cette méthode d'expédition ne sont pas remplies pour la commande et l'adresse de livraison actuelles."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Ajouter un code coupon"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Code de coupon défini pour la commande"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Champs personnalisés"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Nouvelle méthode d'expédition"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Supprimer les emplacements de stock"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "est supérieur ou égal à"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Aperçu"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} sur {1} disponibles à exécuter"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Mois en cours"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Demande du client"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Endommagé lors de la livraison"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Non disponible"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Autre"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Mauvais article"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Résumé des modifications"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Remboursements ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Dernière exécution"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Détails du paiement"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Reconstruire l'index de recherche"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "En cours d'exécution"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Toutes les 60 secondes"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Échec de la mise à jour du groupe de clients"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Métadonnées de paiement"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Annuler la modification"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Même fenêtre"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Appliquez des filtres au tableau et cliquez sur « Enregistrer la vue » pour commencer."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Rôles"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Paiement supplémentaire requis"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Échec de la mise à jour de la commande"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Avec la sélection..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Échec de la création de l'emplacement de stock"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "inférieur ou égal à"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Membres du groupe de clients pour {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "État"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Ne pas suivre"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Exécution #{0} créée"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Exécution des mises à jour d'index de recherche en attente"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "C'est un rôle par défaut et il ne peut pas être modifié"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Mes vues sauvegardées"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "État / Province"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Activé"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Éléments par page"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Modifier les membres"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Stock en main"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtrer par {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Alertes"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Valeurs d'option"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Aperçu des modifications"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Échec de la suppression de {entityType} du canal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variante supprimée avec succès"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Modifier les propriétés du lien sélectionné"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Ventes"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Sélectionner une collection de destination"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Vos dernières commandes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Tâches planifiées"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Êtes-vous sûr de vouloir supprimer cet élément ? Cette action ne peut pas être annulée."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Variantes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Vendeurs"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Paramètres"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Magasin de paramètres"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Titre 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Bienvenue sur Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Méthodes d'expédition"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} remboursable)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identifiant"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Échec de la mise à jour de la collection"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Prix et taxe"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Commande non trouvée"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Erreur"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Commande modifiée"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Réinitialisation de mot de passe demandée"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Le montant du paiement alloué doit être égal au total du remboursement"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "ex. Petit"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Êtes-vous sûr de vouloir supprimer {0} {entityType} du canal actuel ?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Ajouter des étiquettes..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Échec de la création du groupe d'options de produit"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} éléments sélectionnés"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Rechercher des langues..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Emplacements de stock"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Aller à la page précédente"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Contenu"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Échec de la conversion de la vue globale en vue personnelle"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Le résultat du travail"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Ajouter un paiement ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Système"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Nom de la variante"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Supprimer"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Échec de la mise à jour du client"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Supprimer les groupes d'options ?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Ceci est un aperçu du contenu de la collection basé sur les paramètres de filtre actuels. Une fois que vous enregistrez la collection, le contenu sera mis à jour pour refléter les nouveaux paramètres de filtre."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} client retiré du groupe} other {{count} clients retirés du groupe}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Catégories de taxes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Taux de taxes"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Échec de la suppression des clients du groupe"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Échec du chargement des paramètres globaux"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Sélectionnez les articles à rembourser et éventuellement retourner au stock"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Enregistrer"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} sur {0} ligne(s) sélectionnée(s)."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Aperçu des modifications de commande"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Groupe d'options de produit mis à jour avec succès"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "La page continuera avec la requête par défaut."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Adresse de Rue"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Plus de facettes"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Reconstruction de l'index de recherche démarrée"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Position de la collection mise à jour"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Nom du groupe d'options"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Ajouter « {newOptionInput} »"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Nouvelle variante de produit"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Remboursement transféré"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Utilisation de la stratégie d'authentification native"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Échec de l'attribution de {entityIdsLength} {entityType} au canal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Langue par défaut"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Jeton"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Exécution..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Ajouter un groupe d'options au produit"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Aperçu de {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Vendeur mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Échec de la transition de la commande vers l'état"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Tout afficher ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Échec de la création du taux de taxe"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "J'ai enregistré cet API Key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Configurez les langues disponibles pour votre boutique et vos canaux"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Produit créé avec succès"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Ajouter une variante de produit"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Saisissez et appuyez sur Entrée ou virgule pour ajouter..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Modifier la note"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Aucun asset trouvé. Essayez d'ajuster vos filtres."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Ajouter une option"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Enregistrer le groupe d'options"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Créer {createCount} variantes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Cliquez sur « Exécuter le test » pour tester cette méthode d'expédition."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administrateur mis à jour avec succès"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Effacer les filtres"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Exécution #{0} de {1} à {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Échec de la suppression de la vue globale"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Langue par défaut"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Statut"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Aucune option trouvée"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binaire"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Groupe d'options mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Nouvelle méthode d'expédition"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Toutes les 10 secondes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "ex. taxe :"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Ajouter du stock à l'emplacement"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Valeur d'option ajoutée avec succès"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Collection déplacée vers le nouveau parent"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Groupe d'options supprimé"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Transition vers l'état sélectionné"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Un paiement supplémentaire de {formattedDiff} sera requis."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Suivre l'inventaire par défaut"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} sur {total} sélectionnées"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Mode de livraison créé avec succès"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nouveau groupe de clients"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Visible au client"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Groupe d'options créé avec succès"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Taux de taxes"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Le slug sera généré automatiquement..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Client non trouvé"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Sélectionner {0}s"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Nouvelles valeurs de facette à ajouter :"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Échec du traitement du remboursement"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Prénom"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "contient"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Aucun groupe d'options trouvé"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Aucun élément trouvé"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Sous-total"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Éléments exécutés ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Valeur mise à jour"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Non vérifié"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Quantité"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Catégorie de taxe"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Les données de test ont été mises à jour. Cliquez sur « Lancer le Test » pour voir les résultats mis à jour."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "n'est pas dans"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Ligne de commande mise à jour"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Nouvelle méthode de paiement"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "La valeur en double \"{trimmed}\" existe déjà"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Raison"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Groupes de clients"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} supprimé du canal avec succès"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Groupes d'options"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Ajouter un supplément"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Valeurs de facette actuelles"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Page {page} sur {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Mois dernier"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Ajouter un pays"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Supprimer l'élément"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Vidéo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "inférieur à"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "La variante n'a pas pu être ajoutée. Assurez-vous que le produit parent est activé."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Une erreur inconnue s'est produite"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Métriques"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Langue"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Nouvelle collection"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Rembourser et annuler la commande"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Mise à jour d'e-mail vérifiée"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "est entre"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Rembourser et annuler"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Test des méthodes d'expédition..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Échec de la création du mode de livraison"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "Attribution réussie de {entityIdsLength} {entityType} au canal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Langues globales"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Nouvel administrateur"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Supprimer le brouillon"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Source"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Aucune action disponible"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Échec de la mise à jour du canal"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Général"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Échec de la suppression du produit du canal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Ajouter une nouvelle adresse"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Facette mise à jour avec succès"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zone créée avec succès"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Valeur"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Client mis à jour"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Facteur de conversion des prix"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Commande de vendeur"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Nouvelle facette"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Êtes-vous sûr de vouloir supprimer ce groupe d'options du produit ?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Description (alt)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Aucune étiquette trouvée"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Devise par défaut"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Aucun paiement ou remboursement n'est requis pour ces modifications."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Revenu total"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Prochaine exécution"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "La note est privée"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Date moyenne"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Nombre invalide"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Vous n'avez pas encore enregistré de vues."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Êtes-vous sûr de vouloir supprimer cette vue ? Cette action ne peut pas être annulée."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Voir le processus de commande"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Échec de la duplication de la vue"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Utiliser comme adresse de livraison par défaut"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Modifier le slug manuellement"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Ajouter des filtres pour prévisualiser le contenu de la collection."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Groupe d'options de produit"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Sous-total"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "est inférieur à"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID de remboursement"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Champs personnalisés de la commande mis à jour"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Calculateur"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Échec de la suppression du groupe d'options du canal : {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Voir les données du travail"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Déplacer au niveau supérieur"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Effacer"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Résumé des commandes"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Rechercher des assets..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Nouvelle facette"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Assigner {entityType} au canal"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Continuer"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promotions"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Message d'erreur"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Ajouter un niveau de stock pour un autre emplacement"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Supprimer l'adresse"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Échec de la mise à jour de la facette"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters doit être utilisé dans un WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Modifier l'adresse"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Échec de la suppression de la facette du canal : {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Définir le lien"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Nouveau vendeur"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Modifier l'image"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Gérer les variantes"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Stock alloué"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "supérieur ou égal à"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Définit le niveau de stock à partir duquel cette variante est considérée comme en rupture de stock. L'utilisation d'une valeur négative active le support de commande en attente."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Créer des options de produit"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Enregistrement..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Voir le résultat"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Lignes par page"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Chargement des collections..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Valeur de facette mise à jour avec succès"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Ajouter une ressource"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Enregistrer les modifications"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Client ajouté au groupe"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Commandes de vendeur"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Échec de l'ajout de la valeur d'option"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Ajouter une valeur d'option à {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} article(s) remboursé(s)"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Aucun groupe d'options défini pour l'instant. Ajoutez des groupes d'options pour créer différentes variantes de votre produit (ex. : Taille, Couleur, Matériau)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Nouvel e-mail :"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Échec de la mise à jour de la méthode de paiement"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Disponible :"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Créé le"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Échec de la création de la variante de produit"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Langue : {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Vous n'avez pas la permission de voir les paramètres linguistiques globaux"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Taux de taxe créé avec succès"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Titre 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Codes coupon ajoutés"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Actif"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Base de taxe"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Charger plus"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Remboursement réglé"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "Duplication réussie de {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Nouveau groupe d'options"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Aucun résultat pour l'instant"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Paiement réglé"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Conditions disponibles"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Filtres actifs"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Tout effacer"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "est supérieur à"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Fermer"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Ajouter un paiement à la commande"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Chargement..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Le jeton est utilisé pour spécifier le canal lors des requêtes API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Aucune adresse trouvée"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID d'exécution"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Sélectionnez les paiements à rembourser"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Échec de la suppression de {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Seuil de rupture de stock"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produit supprimé du canal avec succès"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Échec de la mise à jour de la valeur"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Échec de la création de l'API Key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Régler le remboursement"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "La méthode de paiement est requise"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Échec de l'ajout du client au groupe"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Gérer les variantes"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Vue globale „{viewName}\" appliquée"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Client enregistré"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zones"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Rechercher des vendeurs..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Promotion créée avec succès"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Option"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Processus de commande"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Numéro de téléphone"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privé"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variante"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Paramètres globaux mis à jour avec succès"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key mis à jour avec succès"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Ces langues seront disponibles pour tous les canaux"

--- a/packages/dashboard/src/i18n/locales/he.po
+++ b/packages/dashboard/src/i18n/locales/he.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "שם מלא"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "בחר פריטים"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "צפה בשינויים"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "קוד מעקב"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "ההרשאות שנבחרו יוחלו על ערוצים אלה."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "אפשרויות מוצר"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "שיעור מס חדש"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "הקצאת קבוצת אפשרויות קיימת או יצירת קבוצה חדשה"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "תפקיד חדש"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "דירה, יחידה וכו'"
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "אין פריטים נוספים"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "ערוך קישור"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "הוסף לפחות פריט אחד להזמנה"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "הוסף מוצרים ליצירת הזמנת בדיקה"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "יצירת הכתובת נכשלה"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "החלף הכל"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "עריכת ערך JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "משתמש באסטרטגיית אימות חיצונית: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "בחר סיבה..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "כותרת 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "הוספת התשלום נכשלה"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "עודכן"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "עדכון ההגדרות הגלובליות נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "ההזמנה מולאה בהצלחה"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "האם אתה בטוח שברצונך למחוק {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "סף גלובלי של אזילת מלאי"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "נהל שפות"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "משכפל... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "נמחק בהצלחה"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "הסר מהערוץ הנוכחי"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "נמחקו {selectionLength} קבצים"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "שיעור המס עודכן בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "הזן סיבה מותאמת אישית..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "סוג"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "בחר {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "צפה בערכים"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "מחק שורה"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "תנאים"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "נוכחי"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "אין משלוחים"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {מחיקת {1} מיקום מלאי נכשלה: {messages}} two {מחיקת {2} מיקומי מלאי נכשלה: {messages}} other {מחיקת {2} מיקומי מלאי נכשלה: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "כאשר זה מופעל, המחירים שהוזנו בקטלוג המוצרים יכללו מע\"מ עבור אזור המס המחדלי."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "צור גרסאות למוצר שלך"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "הזמנת הטיוטה הושלמה"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "רענון אוטומטי: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "בדיקות תקינות"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "נמחקו {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "בדיקות תקינות"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "מוכרים"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "אפשרויות"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} משימה בוטלה בהצלחה} other {{fulfilled} משימות בוטלו בהצלחה}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "מוכר"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "מק״ט:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "הוספת תשלום"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "בדוק שיטת משלוח זו על ידי סימולציה של הזמנה כדי לראות אם היא זכאית ומה תהיה עלות המשלוח."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "גלה את מהדורת הארגון"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "מיקומי מלאי"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "מטפל במשלוח"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "הזמנות"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "בחירת תפקידים"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "התפקיד נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "האם אתה בטוח שברצונך למחוק גרסה זו?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "כל המשאבים פעילים"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "יצירת מנהל נכשלה"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "לא"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "גרסת המוצר עודכנה בהצלחה"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "מחיקת {failed} {entityName} נכשלה: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "המוצר עודכן בהצלחה"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "עדכון המדינה נכשל"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "הקלד לפחות 2 תווים לחיפוש..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "שם משפחה"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "כותרת קישור"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "קבוצת הלקוחות עודכנה בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "השדות המותאמים אישית השתנו"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "מיקום המלאי נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "שגיאה לא ידועה"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "סך ההחזר לא יכול להיות שלילי"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "צפה בפרטים"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "בחר ערוץ להקצאת {0} {entityType} אליו"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "הלקוח נוצר בהצלחה"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "7 הימים האחרונים"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "יצירת הערוץ נכשלה"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "מצב פיתוח"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "תפקיד חדש"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "מחיקת הקבצים נכשלה: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "החזר למלאי"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "נראות"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "גרסאות מוצר"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "קבוצת לקוחות חדשה"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "צור \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "שנה שם"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "בחר את שפת התצוגה המועדפת ואת הגדרות האזור"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} קבוצות אפשרויות הוסרו בהצלחה מהערוץ"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "שיטת המשלוח אינה זכאית להזמנה זו"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "עדכון הכתובת נכשל"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "הכתובת נמחקה בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "שיעור מס"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "טיוטת ההזמנה אינה מוכנה להשלמה"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "אוסף חדש"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "תובנות"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "הרץ"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "עדכון שיעור המס נכשל"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "זהו התוכן של האוסף <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "פרטי"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "אפשרות מוצר נוצרה בהצלחה"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "מוצר הורה"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "עיר"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "מנהלים"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "מחיר ברוטו: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "עבור לעמוד הבא"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "הסר קישור"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "שדה זה הוא לקריאה בלבד"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "מספר הזמנות"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "ההזמנה עודכנה בהצלחה"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "ירש מסננים"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "נהל תצוגות שמורות גלובליות הגלויות לכל המשתמשים"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "חפש אמצעי תשלום..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "כתובת משלוח בוטלה להזמנה"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "יצירת {enabledCount} גרסאות"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "התשלום מס' {0} הועבר ל-{1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "שגיאה בטעינת היסטוריית לקוח: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} הוסרו מהערוץ בהצלחה"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "הוסף ערך אפשרות"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "הגדרות גלובליות"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "אחרי"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "אפשרות מוצר עודכנה בהצלחה"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "ערוך ערכי מאפיינים"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "מוסיף..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "העבר אוספים"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "תפקידים"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "תצוגת רשת"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "מחיקת הכתובת נכשלה"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "אין שיטות משלוח זמינות"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "התצוגה הגלובלית הומרה לתצוגה אישית בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "המשלוח הועבר"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "האם אתה בטוח שברצונך למחוק {selectionLength} קבצים?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "התחבר"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "תצוגת רשימה"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "הזמנת בדיקה"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "בחר לקוח כדי להמשיך"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "קבוצת האפשרויות הוקצתה בהצלחה"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "הרץ בדיקה"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "שיעור מס: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "אנא הוסף מוצרים והשלם את כתובת המשלוח כדי להריץ את הבדיקה."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "החלף שורת כותרת"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "בחר כתובת"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "בודק זכאות תשלום"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "אזור מס ברירת מחדל"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "טיוטת ההזמנה מוכנה להשלמה"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "מטא-דאטה"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "סנן..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "ערך מאפיין חדש"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "הערוץ עודכן בהצלחה"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "הצג פחות"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "תאריך קצר"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "מטבעות זמינים"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "בחר {0} פריטים"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "בוצעה ב"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "סיבוב מפתח זה יבטל מיידית את המפתח הנוכחי. כל האינטגרציות המשתמשות בו יפסיקו לפעול עד לעדכונן עם המפתח החדש."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "הנתונים שהועברו למשימה"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "אשר ניווט"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "יעד קישור"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "השלם טיוטה"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "שם"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "מילוי ההזמנה נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "סה\"כ"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "הזן את מזהה העסקה לסילוק החזר זה"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "מפתח ה-API שלך"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "האם אתה בטוח שברצונך למחוק הזמנת טיוטה זו?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "המשלוח נוצר"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "נמצאו {0} שיטות משלוח זכאיות"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "ממדים"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "הצג סיסמה"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(מקס: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "חברה"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "הוסף עמודה אחרי"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "פעולות"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "הנחות"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "הזן הערת החזר"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "שורת ההזמנה הוסרה"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "תוכן:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "מפתח"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "אשר"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "יצירת האוסף נכשלה"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "עבור לעמוד הראשון"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "יצירת המוצר נכשלה"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "לקוח"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "שגיאה בטעינת היסטוריית הזמנה: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "כתובת משלוח הוגדרה להזמנה"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "נקודת מיקוד"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "גרסה אחת, ללא אפשרויות"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "בחר את המצב הבא להזמנה"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "אזור"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "משימות מתוזמנות"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "הזן מזהה עסקה"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "רענן נתונים"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "הוסף או הסר ערכי מאפיינים עבור {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "אלה ערכי המאפיינים עבור המאפיין <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "התשלום נוסף להזמנה בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "כתובת חיוב הוגדרה עבור ההזמנה"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "עדכון האזור נכשל"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "סיסמה"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "המחיקה נכשלה"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "המשימה המתוזמנת תתבצע"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "מיקום מלאי חדש"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "הרשאות"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "כתובת המשלוח השתנתה"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "לא נמצאו מוצרים"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "הוסף שורה לפני"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "מעבר ל-{suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "החודש"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "יצירת המאפיין נכשלה"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "נכשל בביטול פריטי ההזמנה"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "מזהה עסקה"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "מוקצה"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "הוסף קבוצת אפשרויות נוספת"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "בחר מה לעשות במלאי שנותר"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "חקור את הפלטפורמה והענן"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "כל 5 שניות"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "האוסף נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "מחיר"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "הזמנת טיוטה"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "היקף"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "הוספת תנאי"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "שיטת המשלוח זכאית להזמנה זו"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "מנהלים"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "הוסר מהקבוצה"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "רוחב"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "לא נדרש תשלום או החזר"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "הורדה כקובץ .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "כאשר מופעל, המבצע זמין בחנות"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "כאשר עוקבים, רמות מלאי גרסת המוצר יותאמו אוטומטית במכירה. ניתן לעקוף הגדרה זו על ידי גרסאות מוצר בודדות."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "שיטת משלוח הוגדרה להזמנה"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "עדכון המבצע נכשל"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "תמונות"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "מפתחות API"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "חפש {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "ערוך קובץ"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "בטל תשלום"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "תור משימות"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "קבצים"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "כתובת דוא\"ל"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "צור מחדש slug משדה מקור"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "ירש מהגדרות גלובליות"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "לא נמצאו תוצאות"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "מצב נוכחי"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "הגדר כתובת משלוח ובחר שיטת משלוח"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "כבוי"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "חנות הגדרות"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "תור"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "שיעור מס חדש"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "התשלום הועבר"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "נותר:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "לא נמצא משכפל עם קוד \"{duplicatorCode}\" עבור {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "המחירים כוללים מע\"מ עבור אזור המס המחדלי"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "סה\"כ החזר:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "צפה בתוצאת משימה"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "בדוק את שיטות המשלוח שלך על ידי סימולציה של הזמנה חדשה."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "לא נבחרו פריטים"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} נבחרו"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "לא נמצאו מדינות"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "הגרסאות נוצרו בהצלחה"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "צור slug אוטומטית"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "עמלה"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "אמצעי תשלום"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "מלאי"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "לא נמצאו לקוחות"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "השתמש בסף אזילת מלאי גלובלי"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "קבוצת אפשרויות מוצר חדשה"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "מצב התשלום עודכן בהצלחה"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "יצירת חדש"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "סך ההחזר"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "הכתובת נמחקה"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "רק תפקידים שהוקצו לחשבונך זמינים."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "הפריט נוסף להזמנה"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "עריכת נקודת המיקוד"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "לא נמצאו מוכרים"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "קובץ"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {קבוצת אפשרויות זו משמשת מוצר אחד נוסף. שינויים ישפיעו גם עליו.} other {קבוצת אפשרויות זו משותפת ל-# מוצרים. שינויים ישפיעו על כולם.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "התצוגות השמורות שלי"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "ערוץ חדש"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "יצירת המוכר נכשלה"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "הגדרת אפשרויות שכפול עבור {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "אין וריאנטים התואמים את הסינון הנוכחי."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "כתובות"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "הוספת ערך אפשרות חדש לקבוצת האפשרויות {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "שינוי הזמנה מס' {0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "הוסף עמודה לפני"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "שפות ערוץ"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "יצירת קבוצת האפשרויות נכשלה"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "אמת"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "בחר לקוח"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "ההזמנה הועברה"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "למוצר זה יש גרסאות קיימות אך לא הוגדרו קבוצות אפשרויות. עליך להוסיף קבוצות אפשרויות לפני יצירת גרסאות חדשות."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "לפני"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "מחק הזמנת טיוטה"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "קטלוג"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "אמצעי תשלום חדש"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "המבצע עודכן בהצלחה"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {ביטול {rejected} משימה נכשל} other {ביטול {rejected} משימות נכשל}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "בחר ערוץ"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "שפת תצוגה"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "פרטי משלוח"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "מחיקת המלאי שנותר"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "עכשיו"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "ערוצים"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "התצוגה הומרה לגלובלית בהצלחה"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "לפני"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "גודל"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "לא נמצא תרגום עבור {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "לקוח חדש"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "הזמנות אחרונות"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} נוספים"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "השתמש ככתובת חיוב ברירת מחדל"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "מחק"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "השבת"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "אוספים"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "הוסף גרסה"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "יצירת המדינה נכשלה"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "מדינות"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "יצירת אפשרויות המוצר נכשלה"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "שינוי שם התצוגה נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "זמין"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "מסננים"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "קבוצות לקוחות"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "לקוחות"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "עיצוב לדוגמה"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "אפשרות חדשה"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "מגבלת שימוש"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "טוען הגדרות גלובליות..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "הכתובת עודכנה בהצלחה"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "נוצר"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "טוען כתובות..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "בחר אוסף יעד להעברת {0} אליו."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "פרטי הלקוח עודכנו"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "לא ב"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "החל"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "אפשרות מוצר חדשה"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "עבור לעמוד האחרון"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "ביטול"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "גרסת המוצר נוצרה בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "החזר משיטה זו"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "מיקוד"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "הוסף תחילה אפשרויות מוצר"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "קטגוריית מס חדשה"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "הוסף אפשרות"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "החזר חלקי הושלם"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "הגדר שדות מותאמים אישית"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "אוספים"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "מחיקת גרסה"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "לא בוצעו שינויים"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "אזור משלוח ברירת מחדל"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "סיבה:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "כתובת משלוח"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "מעבר ל-{0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "קטגוריות מס"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "אוספים פרטיים אינם גלויים בחנות"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "כאשר מופעל, המוצר זמין בחנות"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "המשימה המתוזמנת לא הצליחה להתבצע"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "קבוצות לקוחות"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "מושבת"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "מבצע חדש"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "כתובת משלוח ברירת מחדל"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "נדרש החזר"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "מלא הזמנה"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "אין לך הרשאה לצפות בהגדרות הערוץ"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "30 הימים האחרונים"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "אין ערכי מאפיינים"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "נדרשת סיבה להחזר"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "לא ניתן להסיר את קבוצת האפשרויות"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "עדכון קטגוריית המס נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "ההחזר סולק בהצלחה"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "עדכן"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "כותרת 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "ההזמנה בוצעה"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "הפרופיל עודכן בהצלחה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "סיום"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "אמצעי תשלום"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "ערוך"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "הגרסה עודכנה בהצלחה"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "סנן לפי שם אוסף"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "ההערה נוספה"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "בחר כמויות למילוי והגדר את מטפל המשלוח"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "כתובת חיוב הוסרה מההזמנה"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "מתחיל ב"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "שכפל"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "אין תוצאות"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "הגדרות עמודות"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {מחיקת {count} מיקום מלאי נכשלה} two {מחיקת {count} מיקומי מלאי נכשלה} other {מחיקת {count} מיקומי מלאי נכשלה}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "קוד"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "הסרת קבוצות האפשרויות נכשלה"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "ההזמנה נמסרה"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "העברה אל {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "מלאי שנותר"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "הסר מהאזור"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "בחר מתוך השפות הזמינות גלובלית עבור ערוץ זה"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "האם אתה בטוח שברצונך למחוק כתובת זו?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "הקצאת קבוצת האפשרויות נכשלה"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "עדכון הקובץ נכשל"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "מיקום המלאי עודכן בהצלחה"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "אשר פעולה"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "המדינה עודכנה בהצלחה"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "מאפיינים"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "הוספת ההערה נכשלה"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "מחיקת ההערה נכשלה"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "הרחבת מסמך השאילתה נכשלה"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "עדכון ההערה נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "החזר משלוח"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "לקריאה בלבד"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "שכפול התצוגה הגלובלית נכשל"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "מציג {shown} מתוך {total} • {selected} נבחרו"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "בדוק שיטת משלוח"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "ערכי מאפיינים"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "הקובץ עודכן בהצלחה"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "ערכת נושא"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} לקוחות"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "מפתחות API"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "בחר שפה"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "התנתק"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "ניסיונות"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "קודי מטבעות זמינים"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "קודי שפות זמינות"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "ניווט פירורי לחם"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "קטגוריה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "ערוצים"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "ילדים"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "קוד"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "קוד קופון"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "נוצר ב"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "קוד מטבע"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "לקוח"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "קבוצת לקוחות"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "לקוחות"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "שדות מותאמים אישית"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "נתונים"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "קוד מטבע ברירת מחדל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "קוד שפת ברירת מחדל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "אזור משלוח ברירת מחדל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "אזור מס ברירת מחדל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "תיאור"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "משך זמן"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "כתובת דוא\"ל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "מופעל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "מסתיים ב"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "שגיאה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "קובץ מומלץ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "שם פרטי"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "קוד מטפל במשלוח"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "מזהה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "ברירת מחדל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "פרטי"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "סולק"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "שם משפחה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "שם"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "ההזמנה בוצעה ב"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "מזהה הורה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "מגבלת שימוש ללקוח"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "הרשאות"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "מיקום"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "מחיר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "המחירים כוללים מע\"מ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "מחיר כולל מע\"מ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "גרסאות מוצר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "התקדמות"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "שם תור"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "תוצאה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "ניסיונות חוזרים"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "מוכר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "סולק ב"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "שורות משלוח"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "התחיל ב"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "מתחיל ב"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "מצב"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "רמות מלאי"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "טוקן"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "סה\"כ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "סה\"כ כולל מע\"מ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "סוג"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "עודכן ב"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "מגבלת שימוש"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "משתמש"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "ערך"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "רשימת ערכים"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "אזור"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "שיטה"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "סיכום מס"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "מגדיר את השפות הזמינות עבור כל הערוצים. ערוצים בודדים יכולים אז לתמוך בתת-קבוצה של שפות אלה."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "אוספים הועברו בהצלחה"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "רשום"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "בטל משימה"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "מסתיים ב"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "עמוד {0} מתוך {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "שיעור"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "גודל, צבע וכו'"
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "עיון בפאספטים"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "אזור"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "בוטל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "נוצר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "נמסר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "בהמתנה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "נשלח"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "שמור תצוגה"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} נבחרו"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "חיפוש קבוצות אפשרויות..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "שנה הזמנה"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "פריטים שנבחרו"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "ערכים"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "הלקוח הוגדר להזמנה"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "מאפיינים"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {האם אתה בטוח שברצונך להסיר לקוח אחד מקבוצה זו?} two {האם אתה בטוח שברצונך להסיר {count} לקוחות מקבוצה זו?} other {האם אתה בטוח שברצונך להסיר {count} לקוחות מקבוצה זו?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "מלאי זמין"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "לא ניתן היה להתחיל בניית מחדש של אינדקס החיפוש"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "כתובת משלוח"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "אזור חדש"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "מפתח API חדש"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "מחק עמודה"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "הקצאת קיים"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "ריק"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "אלה הלקוחות בקבוצת הלקוחות <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "נהל תצוגות גלובליות"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "ערוץ ברירת מחדל"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "הוספת תמונה חדשה עם מקור, כותרת וממדים"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "יצירת ערך המאפיין נכשלה"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "עדכון אפשרות מוצר נכשל"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>שכחת סיסמה?</0><1>בקש איפוס</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "קוד קופון"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "הלקוח אומת"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "הגדרות גלובליות"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "לוח זמנים"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "לא ניתן להעביר אוסף לצאצא של עצמו"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "קטגוריית מס חדשה"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "אין מיקומי מלאי זמינים בערוץ הנוכחי"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "הערוץ נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "הלקוח עודכן בהצלחה"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "צפה בנתונים"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "מחק תצוגה"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "הוסף כתובת חדשה ללקוח."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "תצוגות נוספות"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "עריכת מאפייני התמונה הנבחרת"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "התצוגה \"{viewName}\" הוחלה"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} מאפיינים הוסרו מהערוץ בהצלחה"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "מוצר חדש"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "קובץ חדש"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "חישוב מחדש של המשלוח"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "בחר אילו אפשרויות יחולו על הגרסה הקיימת \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "קבצים"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "פעולה זו תסיר את כל קבוצות האפשרויות ממוצר זה ותחזור לבחירת הגדרת הגרסאות."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "כתובת חיוב"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "הוסף ערך מאפיין"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "אנא בחר אוסף יעד"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "בדוק את השינויים לפני החלתם על ההזמנה."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "בחר תפקיד"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "ההזמנה בוטלה"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "הנחה"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "כל הסוגים"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "רק טיוטות הזמנה ניתנות להשלמה"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "עדכון המוצר נכשל"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "מתאים {0} שורות"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "הוסף ערכי מאפיינים"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "אחרי"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "ערוץ"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "בדיקות תקינות"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "סכום"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "מספר טלפון"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "לקוח חדש"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "תמונה"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "מנהל נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "אפשרויות מוצר"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "בחר מדינה"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "יוצר..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "האם אתה בטוח שברצונך למחוק תצוגה גלובלית זו? לא ניתן לבטל פעולה זו והיא תשפיע על כל המשתמשים."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "הסרה מאולצת של קבוצת אפשרויות"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "נוסף"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "היסטוריית לקוח"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "ערכי המאפיינים עבור {entityIdsLength} {entityType} עודכנו בהצלחה"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "הסרת הלקוח מהקבוצה נכשלה"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "מערכת"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "מגבלת שימוש ללקוח"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "כתובת החיוב השתנתה"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "בחר אפשרות"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "העתק לאישי"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "סך ההחזר עולה על הסכום המקסימלי להחזר של {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "מחק תצוגה גלובלית"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "צור"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "כל 30 שניות"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "מדינה חדשה"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "מ-{0} ל-{1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "יצירת הלקוח נכשלה"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "נקודת המיקוד עודכנה"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "ערכי אפשרויות"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "כתובת חיוב ברירת מחדל"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "אין לקוח"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "נכשל בהסרת מדינות מהאזור"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "יצירת המבצע נכשלה"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "היום"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "אתמול"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "שם אפשרות"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "האם אתה בטוח שברצונך להסיר {0} {1} מאזור זה?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "מוסיף {0} תוספת(ות)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "כתובת קישור"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "ערך חלופי: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "היסטוריית הזמנה"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "דריסה"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "מזהה עסקה נדרש"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "תואם ביטוי רגולרי"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "שם התצוגה הגלובלית שונה בהצלחה"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "לא נבחרו תגיות"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "חזרה"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "שם התצוגה שונה בהצלחה"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "החל מסנן"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "תוצאה אחרונה"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "נוסף לקבוצה"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "תובנות"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "צור גרסאות"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "בודק שיטת משלוח..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "כהה"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "תוצאות בדיקה"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "הוסף לקוח"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "שמור שינויים"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "הכתובת עודכנה"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "ההחזר עובד בהצלחה"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "אזור חדש"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "נכשל בעדכון מיקום האוסף"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "החזר"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "שנה"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "לא הוגדרו שפות גלובליות"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "מסיר {0} פריטים"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "עקוב"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "צור גרסה"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "ערכי מאפיינים עבור {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "שמור פריסה"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "איפוס הסיסמה אומת"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "מחיקת התצוגה נכשלה"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "האם אתה בטוח שברצונך לעזוב דף זה? כל השינויים שלא נשמרו יאבדו."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "החלף עמודת כותרת"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "מבצע חדש"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "שם ערך אפשרות"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "שימוש אחרון"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "קטגוריית מס ברירת מחדל"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "ה-slug מוגדר"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "עדכון נקודת המיקוד נכשל"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "האזור עודכן בהצלחה"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "מדינה/מחוז"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "עדכון קבוצת האפשרויות נכשל"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "ברירות מחדל של ערוץ"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "יצירת קטגוריית המס נכשלה"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "הגדרת קריטריוני סינון לעמודה {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "מדינה"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "מוצר פשוט"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "תור משימות"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "אנא אשר ששמרת את מפתח ה-API לפני הסגירה."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "אשר מחיקה"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "שינוי ההזמנה נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "כולל מע\"מ בשיעור {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "מדדי הזמנות"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "בחר שפת תצוגה"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "שיטות אימות"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "התחלה"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "סיבוב מפתח ה-API נכשל"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "ב"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "חפש תפקידים..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "גרסאות מוצר"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "נהל תצוגות גלובליות"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "מעבד..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "נמצאו {totalItems} {0}"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "בחר טווח תאריכים"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "מוצר"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "סיבוב מפתח API"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "קטגוריה"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "מעביר..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "הקצה"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "המוכר נוצר בהצלחה"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "שיטת משלוח עודכנה בהצלחה"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "עדכון גרסת המוצר נכשל"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "גרור כדי לסדר מחדש"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "אזורים"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "בחר מה לעשות במלאי שנותר ב{count, plural, one {מיקום מלאי אחד} two {שני מיקומי מלאי} other {# מיקומי מלאי}} שאתה מוחק. כל המיקומים שנבחרו יעבירו את המלאי שנותר בהם למיקום היחיד שתבחר, או שהמלאי יימחק."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "חיפוש ערכי פאספט..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "הערה"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "שפות זמינות"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "טען עוד {0} ({remaining} נותרו)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "ערכי מאפיינים"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "נכשל בסידור מחדש של הפריטים"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "סך הזמנות"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "לא נמצאו שיטות משלוח זכאיות להזמנה זו."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "הוסף אפשרות מוצר"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "משלוח"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "יש להשתמש ב-useWidgetDimensions בתוך DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "קבוצת האפשרויות הזו בשימוש על ידי גרסאות קיימות. הסרה מאולצת עלולה להשפיע על גרסאות אלו. האם אתה בטוח?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "התבקש עדכון דוא\"ל"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "שגיאה במעבר למצב"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "קבוצת הלקוחות נוצרה בהצלחה"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "חלון חדש"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "התשלום אושר"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "התפקיד עודכן בהצלחה"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "בחר מדינה"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "עדכון שיטת משלוח נכשל"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {נמחק מיקום מלאי אחד} two {נמחקו שני מיקומי מלאי} other {נמחקו {deleted} מיקומי מלאי}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "שיטות משלוח"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "בחר כתובת"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "כן"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "הגדר נקודת מיקוד"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "סוף"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "בחר מטבע"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "עדכן את תוכן ההערה או נראותה"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "ווידג'ט הזמנות אחרונות"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "תוכן האוסף {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "שיטת המשלוח השתנתה"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "תיאור מס"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "קטן או שווה ל"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "לא שווה ל"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "רענן"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "לדוגמה גודל"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "סלק תשלום"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "ערוצים"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "דמי משלוח הוחזרו"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "סוג קובץ"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "מיקום מלאי חדש"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} תשלום(ים) הוחזרו לפני הכשל. בדוק את היסטוריית ההזמנה לפרטים."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "בחר פריט"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "מוצר חדש"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "נהל תגיות"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "פריטים הוחזרו"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "הוספת פעולה"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "הקצה אפשרויות לגרסה קיימת"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "שכפל {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "הסרה מהקבוצה"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "עדכון מצב המשלוח נכשל"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "יצירת גרסת מוצר חדשה עם אפשרויות, תמחור ומלאי"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "מאפיינים פרטיים אינם גלויים בחנות"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "בחר קטגוריית מס"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "נוצר"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "לא פועל"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "מוקצה"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "כותרת 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "בחר שפות זמינות"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "מוסיף {0} פריטים"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "הוסף שורה אחרי"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "סה\"כ מס"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "סטטוס טיוטת הזמנה"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "אפשרויות המוצר נוצרו בהצלחה"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "טוען מיקומים…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "יצירת אמצעי התשלום נכשלה"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "ערך המאפיין נוצר בהצלחה"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "שיווק"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "הזמנת הטיוטה נמחקה"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "גדול מ"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "ווידג'ט מדדים"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "חפש מטבעות..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "הסרה מהערוץ"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "כותרת"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "הוסף תמונה"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "עדכון המוכר נכשל"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "המדינה נוצרה בהצלחה"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "בחר מוכר"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "טוען תגיות..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "המאפיין נוצר בהצלחה"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} גרסאות"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "סילוק התשלום נכשל"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "אין כתובת חיוב"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {מחיקת {1} מיקום מלאי נכשלה} two {מחיקת {2} מיקומי מלאי נכשלה} other {מחיקת {2} מיקומי מלאי נכשלה}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "מאפיין"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "לא ניתן להסיר מערוץ פעיל"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "לא מוגדר"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "הסרה מאולצת"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "ערוץ חדש"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "שם קבוצת אפשרויות"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "וגם"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "יצירת קבוצת הלקוחות נכשלה"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "יצירת התפקיד נכשלה"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "שם מוצר"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "מצב המשלוח עודכן בהצלחה"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "מוצרים"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "הכתובת נוצרה"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "מפתח ה-API סובב בהצלחה"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "הוסף קבוצת אפשרויות"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "החזר {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "הזן slug באופן ידני"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "אין ווידג'טים זמינים"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "ביטול התשלום נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "התשלום בוטל בהצלחה"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "התצוגה הגלובלית שוכפלה בהצלחה"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "נוצר על ידי"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "סינון וריאנטים..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "הוסף מחיר במטבע אחר"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "כתובת דוא\"ל או מזהה"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "ההחזר מס' {0} הועבר ל-{1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "לקוחות"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "כותרת 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "עדכון מיקום המלאי נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "ההזמנה נשלחה"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "שמור כתובת"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "הפוך לגלובלי"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "בחר מצב הבא"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "אין התראות"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "מעביר {0} אוספים ל-{2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "בדיקה"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "בין"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "ההערה נוספה בהצלחה"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "ההערה נמחקה בהצלחה"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "ההערה עודכנה בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "סילוק ההחזר נכשל"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "רמת מלאי"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "הוסף פריט"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "מפתח ה-API נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "טוען תצוגה מקדימה..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "חזרה לחיפוש"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "התצוגה שוכפלה בהצלחה"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "הסרת קבוצת אפשרויות"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "תיאור"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "מדינות"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "כתובת רחוב 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "התצוגה הגלובלית נמחקה בהצלחה"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "ערוך פריסה"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "הקצה לערוץ"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "השבוע"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "קבוצת אפשרויות מוצר נוצרה בהצלחה"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "הוסף תשלום ידני של {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "ב"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "דוא״ל"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "עדכון מנהל נכשל"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "נהל את התצוגות השמורות האישיות שלך לטבלה זו"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "סנן לפי תגיות"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "התחבר כדי לגשת ללוח הבקרה של המנהל"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "הוסף תשלום להזמנה ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "שקר"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "בהיר"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "אפס"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "שווה ל"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "צור אפשרויות"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "הסיסמה עודכנה"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "אינו מכיל"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "קבוצת אפשרויות"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "ערוך את פרטי הכתובת למטה."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "קטגוריית המס נוצרה בהצלחה"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "העברת האוספים נכשלה"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "עדכון מצב התשלום נכשל"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "סיכום ההזמנות שלך"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "העלה"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "מוצר עם אפשרויות"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "מציג את כל {0} התוצאות"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "מזהה חיפוש"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} נוספים"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "קבוצות אפשרויות"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "שדות מותאמים אישית"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "כל מצבי ההזמנה האפשריים והמעברים ביניהם. המצב הנוכחי מודגש."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "הזמנות"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "ווידג'ט סיכום הזמנות"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "הוספת פריטים"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "ארגון תשלום נוסף"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "סידור תשלום"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "בוטלה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "נוצרה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "נמסר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "טיוטה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "בשינוי"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "נמסר חלקית"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "נשלח חלקית"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "התשלום אושר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "התשלום סולק"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "נשלח"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "משאבים מנוטרים"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "מידע ישות"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "סך הזמנה"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "גלוי למנהלים בלבד"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "כמות"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "תגיות"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "מנהל על"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "חלק מהמשאבים לא פעילים"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "פעולות זמינות"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "הוסף קישור"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "אם מופעל, המסננים יורשו מהאוסף ההורה וישולבו עם המסננים שהוגדרו באוסף זה."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "בחר אזור"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "בדוק שיטות משלוח"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "התשלום סולק בהצלחה"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} הוסרו מהאזור"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "הפעל"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "אמצעי תשלום"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "מאושר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "בוטל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "נוצר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "נדחה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "שגיאה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "נכשל"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "בהמתנה"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "מסולק"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "ערך ממוצע להזמנה"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "יצירת האזור נכשלה"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "רמות מלאי"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "עדכון מפתח ה-API נכשל"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "שורות הזמנה"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "שינוי שם התצוגה הגלובלית נכשל"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "הוספת קישור חדש עם URL ואפשרויות יעד"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "גובה"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "נדרש החזר כספי של {formattedDiff}. בחר סכומי תשלום והזן הערה כדי להמשיך."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "מחיר ליחידה"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "תבנית לוח זמנים"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "התשלום נכשל"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "הוסף ערוץ"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "עדכון קבוצת אפשרויות מוצר נכשל"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "חפש ערוצים..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "הוסף קבוצות לקוחות"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "שפות זמינות"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "איפוס בחירה"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "אין כתובת"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "אמצעי התשלום נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "מידע הלקוח עודכן"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "המרת התצוגה לגלובלית נכשלה"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "גרסאות מוצר"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "מוצרים"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "מבצעים"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "יצירת אפשרות מוצר נכשלה"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "דוא\"ל ישן:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "שמור תצוגה כ\"גלובלית\" כדי להפוך אותה לזמינה לכל המשתמשים."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "יצירת הגרסאות נכשלה"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "מגדיר את רמת המלאי שבה גרסה זו נחשבת אזלת מלאי. שימוש בערך שלילי מאפשר תמיכה בהזמנה מראש. ניתן לעקוף על ידי גרסאות מוצר."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "סיבוב מפתח"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "יצירת גרסאות המוצר נכשלה"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "הסתר סיסמה"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "מוכר חדש"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "לדוגמה אדום, גדול, כותנה"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "עדכון הפרופיל נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "קודי קופון שהוסרו"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "נקה מסנן"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "אזורים"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "גרור קבצים לכאן כדי להעלות"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "החלפת מצב כל הווריאנטים הגלויים"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "מאומת"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "קבוצת אפשרויות חדשה"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "עודכן לאחרונה {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "עדיין לא נוצרו תצוגות גלובליות."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "עדכון התפקיד נכשל"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "זוהי הפעם היחידה שמפתח ה-API המלא יוצג. העתק או הורד אותו כעת — לא ניתן יהיה לאחזרו מאוחר יותר."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "האוסף עודכן בהצלחה"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "אמצעי התשלום עודכן בהצלחה"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "התצוגה נמחקה בהצלחה"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "קבוצת אפשרויות {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "או"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "נהל תגיות"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "קוד קופון הוסר מההזמנה"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "לעולם לא"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "עדכון ערך המאפיין נכשל"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "הסר קבוצה"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "ההזמנה מולאה"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "אין כתובת משלוח"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "הרחבת השאילתה מכילה תחביר GraphQL לא תקין"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "שגיאה בהרחבת שאילתה"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "שגיאה בהרחבת שאילתה:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "הרחבת השאילתה אינה תקינה: חייב להיות לפחות שדה אחד ברמה העליונה"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "אי-התאמה בהרחבת שאילתה:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "ציבורי"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "קטגוריית המס עודכנה בהצלחה"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "העבר"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "ערוך או מחק תגיות קיימות"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "תנאי בודק הזכאות של שיטת משלוח זו אינם מתקיימים עבור ההזמנה וכתובת המשלוח הנוכחיים."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "הוסף קוד קופון"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "קוד קופון הוגדר עבור ההזמנה"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "שדות מותאמים אישית"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "שיטת משלוח חדשה"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "מחיקת מיקומי מלאי"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "גדול או שווה ל"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "תצוגה מקדימה"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} מתוך {1} זמינים למילוי"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "מתחילת החודש"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "בקשת הלקוח"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "ניזוק במשלוח"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "לא זמין"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "אחר"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "פריט שגוי"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "סיכום שינויים"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "החזרים ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "הרצה אחרונה"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "פרטי תשלום"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "בנה מחדש אינדקס חיפוש"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "פועל"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "כל 60 שניות"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "עדכון קבוצת הלקוחות נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "מטא-דאטה של תשלום"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "בטל שינוי"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "אותו חלון"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "החל מסננים על הטבלה ולחץ על \"שמור תצוגה\" כדי להתחיל."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "תפקידים"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "נדרש תשלום נוסף"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "עדכון ההזמנה נכשל"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "עם הנבחרים..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "יצירת מיקום המלאי נכשלה"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "קטן או שווה ל"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "חברי קבוצת לקוחות {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "מצב"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "אל תעקוב"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "משלוח מס' {0} נוצר"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "מריץ עדכוני אינדקס חיפוש ממתינים"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "זהו תפקיד ברירת מחדל ולא ניתן לשנות אותו"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "התצוגות השמורות שלי"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "מדינה / מחוז"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "מופעל"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "פריטים בעמוד"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "ערוך חברים"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "מלאי זמין"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "סנן לפי {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "מזהה"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "התראות"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "ערכי אפשרויות"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "תצוגה מקדימה של שינויים"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "הסרת {entityType} מהערוץ נכשלה"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "הגרסה נמחקה בהצלחה"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "עריכת מאפייני הקישור הנבחר"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "מכירות"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "בחר אוסף יעד"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "ההזמנות האחרונות שלך"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "משימות מתוזמנות"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "האם אתה בטוח שברצונך למחוק פריט זה? לא ניתן לבטל פעולה זו."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "גרסאות"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "מוכרים"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "הגדרות"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "חנות הגדרות"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "כותרת 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "ברוך הבא ל-Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "שיטות משלוח"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} ניתן להחזר)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "מזהה"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "עדכון האוסף נכשל"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "מחיר ומס"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "ההזמנה לא נמצאה"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "שגיאה"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "ההזמנה שונתה"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "התבקש איפוס סיסמה"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "סכום התשלום המוקצה חייב להיות שווה לסך ההחזר"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "לדוגמה קטן"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "האם אתה בטוח שברצונך להסיר {0} {entityType} מהערוץ הנוכחי?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "הוסף תגיות..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "יצירת קבוצת אפשרויות מוצר נכשלה"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} פריטים נבחרו"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "חפש שפות..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "מיקומי מלאי"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "עבור לעמוד הקודם"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "תוכן"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "המרת התצוגה הגלובלית לתצוגה אישית נכשלה"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "תוצאת המשימה"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "הוסף תשלום ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "מערכת"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "שם הגרסה"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "הסר"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "עדכון הלקוח נכשל"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "להסיר קבוצות אפשרויות?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "זוהי תצוגה מקדימה של תכני האוסף על סמך הגדרות המסנן הנוכחיות. לאחר שתשמור את האוסף, התוכן יעודכן כך שישקף את הגדרות המסנן החדשות."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {לקוח אחד הוסר מהקבוצה} two {{count} לקוחות הוסרו מהקבוצה} other {{count} לקוחות הוסרו מהקבוצה}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "קטגוריות מס"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "שיעורי מס"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "הסרת לקוחות מהקבוצה נכשלה"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "טעינת ההגדרות הגלובליות נכשלה"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "בחר פריטים להחזר ואופציונלית החזר למלאי"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "שמור"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} מתוך {0} שורה/ות נבחרו."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "תצוגה מקדימה של שינויי הזמנה"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "קבוצת אפשרויות מוצר עודכנה בהצלחה"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "הדף ימשיך עם שאילתת ברירת המחדל."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "כתובת רחוב"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "אין עוד פאספטים"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "החלה בניית מחדש של אינדקס החיפוש"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "מיקום האוסף עודכן"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "שם קבוצת אפשרויות"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "הוסף \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "גרסת מוצר חדשה"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "ההחזר הועבר"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "משתמש באסטרטגיית אימות מקורית"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "נכשל בהקצאת {entityIdsLength} {entityType} לערוץ"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "שפת ברירת מחדל"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "טוקן"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "ממלא..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "הוסף קבוצת אפשרויות למוצר"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "תצוגה מקדימה של {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "המוכר עודכן בהצלחה"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "מעבר ההזמנה למצב נכשל"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "הצג הכל ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "יצירת שיעור המס נכשלה"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "שמרתי את מפתח ה-API הזה"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "הגדר שפות זמינות עבור החנות והערוצים שלך"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "המוצר נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "הוסף גרסת מוצר"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "הקלד ולחץ Enter או פסיק להוספה..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "ערוך הערה"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "לא נמצאו קבצים. נסה לשנות את המסננים שלך."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "הוסף אפשרות"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "שמור קבוצת אפשרויות"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "צור {createCount} גרסאות"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "לחץ על \"הרץ בדיקה\" כדי לבדוק שיטת משלוח זו."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "מנהל עודכן בהצלחה"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "נקה מסננים"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "משלוח מס' {0} מ-{1} ל-{2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "מחיקת התצוגה הגלובלית נכשלה"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "שפת ברירת מחדל"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "סטטוס"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "לא נמצאו אפשרויות"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "בינארי"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "קבוצת האפשרויות עודכנה בהצלחה"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "שיטת משלוח חדשה"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "כל 10 שניות"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "ללא מע\"מ:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "הוסף מלאי למיקום"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "ערך האפשרות נוסף בהצלחה"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "האוסף הועבר להורה חדש"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "קבוצת האפשרויות הוסרה"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "מעבר למצב שנבחר"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "יידרש תשלום נוסף בסך {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "עקוב אחר מלאי כברירת מחדל"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} מתוך {total} נבחרו"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "שיטת משלוח נוצרה בהצלחה"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "קבוצת לקוחות חדשה"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "גלוי ללקוח"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "קבוצת האפשרויות נוצרה בהצלחה"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "שיעורי מס"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "ה-slug ייווצר אוטומטית..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "הלקוח לא נמצא"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "בחר {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "ערכי מאפיינים חדשים להוספה:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "נכשל בעיבוד ההחזר"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "שם פרטי"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "מכיל"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "לא נמצאו קבוצות אפשרויות"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "לא נמצאו פריטים"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "סכום ביניים"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "פריטים שמולאו ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "הערך עודכן"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "לא מאומת"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "כמות"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "הוסף מסנן"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "קטגוריית מס"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "פרופיל"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "נתוני הבדיקה עודכנו. לחץ על \"הרץ בדיקה\" כדי לראות תוצאות מעודכנות."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "לא ב"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "שורת ההזמנה עודכנה"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "אמצעי תשלום חדש"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "הערך הכפול \"{trimmed}\" כבר קיים"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "סיבה"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "קבוצות לקוחות"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} הוסר בהצלחה מהערוץ"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "קבוצות אפשרויות"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "הוסף תוספת"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "ערכי מאפיינים נוכחיים"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "עמוד {page} מתוך {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "החודש שעבר"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "הוסף מדינה"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "הסר פריט"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "וידאו"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "קטן מ"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "לא ניתן להוסיף את הגרסה. ודא שהמוצר הראשי מופעל."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "אירעה שגיאה לא ידועה"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "מדדים"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "שפה"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "אוסף חדש"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "החזר ובטל הזמנה"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "עדכון הדוא\"ל אומת"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "בין"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "החזר ובטל"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "בודק שיטות משלוח..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "יצירת שיטת משלוח נכשלה"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} הוקצו לערוץ בהצלחה"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "שפות גלובליות"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "מנהל חדש"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "מחק טיוטה"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "מקור"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "אין פעולות זמינות"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "עדכון הערוץ נכשל"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "כללי"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "נכשל בהסרת המוצר מהערוץ"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "הוסף כתובת חדשה"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "המאפיין עודכן בהצלחה"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "האזור נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "ערך"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "הלקוח עודכן"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "מקדם המרת מחיר"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "הזמנת מוכר"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "מאפיין חדש"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "האם אתה בטוח שברצונך להסיר את קבוצת האפשרויות הזו מהמוצר?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "תיאור (טקסט חלופי)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "לא נמצאו תגיות"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "מטבע ברירת מחדל"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "לא נדרש תשלום או החזר עבור שינויים אלה."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "סך הכנסות"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "הרצה הבאה"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "ההערה פרטית"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "תאריך בינוני"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "מספר לא תקין"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "עדיין לא שמרת תצוגות."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "האם אתה בטוח שברצונך למחוק תצוגה זו? לא ניתן לבטל פעולה זו."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "צפייה בתהליך ההזמנה"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "שכפול התצוגה נכשל"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "השתמש ככתובת משלוח ברירת מחדל"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "ערוך slug באופן ידני"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "הוסף מסננים לתצוגה מקדימה של תכני האוסף."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "קבוצת אפשרויות מוצר"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "סכום ביניים"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "קטן מ"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "מזהה החזר"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "שדות מותאמים אישית של הזמנה עודכנו"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "מחשבון"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "הסרת קבוצת האפשרויות מהערוץ נכשלה: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "צפה בנתוני משימה"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "העבר לרמה העליונה"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "נקה"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "סיכום הזמנות"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "חיפוש קבצים..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "מאפיין חדש"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "הקצה {entityType} לערוץ"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "המשך"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "מבצעים"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "הודעת שגיאה"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "הוסף רמת מלאי למיקום אחר"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "מחק כתובת"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "עדכון המאפיין נכשל"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "יש להשתמש ב-useWidgetFilters בתוך WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "ערוך כתובת"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "הסרת המאפיין מהערוץ נכשלה: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "הגדר קישור"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "מוכר חדש"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "ערוך תמונה"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "נהל גרסאות"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "מלאי מוקצה"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "גדול או שווה ל"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "מגדיר את רמת המלאי שבה גרסה זו נחשבת אזלת מלאי. שימוש בערך שלילי מאפשר תמיכה בהזמנה מראש."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "צור אפשרויות מוצר"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "שומר..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "צפה בתוצאה"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "שורות בעמוד"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "טוען אוספים..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "ערך המאפיין עודכן בהצלחה"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "הוסף קובץ"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "שמור שינויים"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "הלקוח נוסף לקבוצה"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "הזמנות מוכרים"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "הוספת ערך האפשרות נכשלה"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "הוסף ערך אפשרות ל-{groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} פריט(ים) הוחזרו"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "עדיין לא הוגדרו קבוצות אפשרויות. הוסף קבוצות אפשרויות ליצירת גרסאות שונות של המוצר שלך (לדוגמה גודל, צבע, חומר)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "דוא\"ל חדש:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "עדכון אמצעי התשלום נכשל"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "זמין:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "נוצר ב"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "יצירת גרסת המוצר נכשלה"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "שפה: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "אין לך הרשאה לצפות בהגדרות השפה הגלובליות"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "שיעור המס נוצר בהצלחה"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "כותרת 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "קודי קופון שנוספו"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "פעיל"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "בסיס מס"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "טען עוד"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "ההחזר סולק"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "מפתח API"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} שוכפלו בהצלחה"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "קבוצת אפשרויות חדשה"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "עדיין אין תוצאה"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "התשלום סולק"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "תנאים זמינים"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "מסננים פעילים"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "נקה הכל"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "גדול מ"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "סגירה"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "הוסף תשלום להזמנה"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "טוען..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "הטוקן משמש לציון הערוץ בעת ביצוע בקשות API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "לא נמצאו כתובות"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "מזהה משלוח"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "בחר תשלומים להחזר"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "מחיקת {failed} {entityName} נכשלה"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "סף אזילת מלאי"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "המוצר הוסר בהצלחה מהערוץ"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "עדכון הערך נכשל"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "יצירת מפתח ה-API נכשלה"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "סלק החזר"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "אמצעי תשלום נדרש"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "הוספת הלקוח לקבוצה נכשלה"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "נהל גרסאות"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "התצוגה הגלובלית \"{viewName}\" הוחלה"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "הלקוח נרשם"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "אזורים"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "חיפוש מוכרים..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "המבצע נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "אפשרות"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "תהליך הזמנה"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "מספר טלפון"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "פרטי"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "גרסה"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "ההגדרות הגלובליות עודכנו בהצלחה"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "מפתח ה-API עודכן בהצלחה"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "שפות אלה יהיו זמינות לכל הערוצים לשימוש"

--- a/packages/dashboard/src/i18n/locales/hr.po
+++ b/packages/dashboard/src/i18n/locales/hr.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Puno ime"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Odaberi stavke"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Pregled izmjena"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Kod praćenja"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Odabrane dozvole će se primijeniti na ove kanale."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Opcije proizvoda"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Nova porezna stopa"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Dodijelite postojeću grupu opcija ili stvorite novu"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Nova uloga"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Stan, apartman itd."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Nema više stavki"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Uredi poveznicu"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Dodajte barem jednu stavku u narudžbu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Dodajte proizvode za stvaranje probne narudžbe"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Stvaranje adrese nije uspjelo"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Prebaci sve"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Uredi JSON vrijednost"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Korištenje vanjske strategije autentifikacije: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Odaberite razlog..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Naslov 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Dodavanje plaćanja nije uspjelo"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Ažurirano"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Ažuriranje globalnih postavki nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Narudžba uspješno izvršena"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Jeste li sigurni da želite obrisati {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Globalni prag zaliha"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Upravljaj jezicima"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Dupliciranje... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Uspješno obrisano"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Ukloni iz trenutnog kanala"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Obrisano {selectionLength} datoteka"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Porezna stopa uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Unesite prilagođeni razlog..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Vrsta"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Odaberi {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Pregled vrijednosti"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Obriši redak"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Uvjeti"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Nema izvršenja"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Brisanje {1} skladišne lokacije nije uspjelo: {messages}} few {Brisanje {2} skladišne lokacije nije uspjelo: {messages}} other {Brisanje {2} skladišnih lokacija nije uspjelo: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Kada je ovo omogućeno, cijene unesene u katalog proizvoda bit će uključene u porez za zadanu poreznu zonu."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Stvorite varijante za svoj proizvod"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Skica narudžbe dovršena"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Automatsko osvježavanje: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Provjere zdravlja"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Obrisano {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Provjere zdravlja"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Prodavači"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Opcije"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {Uspješno otkazan {fulfilled} zadatak} few {Uspješno otkazana {fulfilled} zadatka} other {Uspješno otkazano {fulfilled} zadataka}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Prodavač"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "Šifra:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Dodaj plaćanje"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Testirajte ovaj način dostave simuliranjem narudžbe kako biste vidjeli je li prihvatljiv i kolika bi bila cijena dostave."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Istražite Enterprise izdanje"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Lokacije zaliha"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Rukovatelj izvršenja"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Narudžbe"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Odaberi uloge"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Uloga uspješno stvorena"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Jeste li sigurni da želite obrisati ovu varijantu?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Svi resursi su aktivni"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Neuspješno kreiranje administratora"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Ne"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Varijanta proizvoda uspješno ažurirana"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Brisanje {failed} {entityName} nije uspjelo: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Proizvod uspješno ažuriran"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Ažuriranje zemlje nije uspjelo"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Unesite najmanje 2 znaka za pretraživanje..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Prezime"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Naslov poveznice"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Grupa kupaca uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Prilagođena polja promijenjena"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Lokacija zaliha uspješno stvorena"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Nepoznata greška"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Ukupni povrat ne može biti negativan"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Pregled detalja"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Odaberite kanal za dodjelu {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Kupac uspješno stvoren"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Zadnjih 7 dana"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Stvaranje kanala nije uspjelo"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Razvojni način"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Nova uloga"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Brisanje datoteka nije uspjelo: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Vrati na zalihu"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Vidljivost"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Varijante proizvoda"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Nova grupa kupaca"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Stvori \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Preimenuj"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Odaberite željeni jezik prikaza i regionalne postavke"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "Uspješno uklonjeno {successCount} grupa opcija iz kanala"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Način dostave nije prihvatljiv za ovu narudžbu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Ažuriranje adrese nije uspjelo"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adresa uspješno obrisana"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Porezna stopa"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Nacrt narudžbe nije spreman za dovršenje"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Nova kolekcija"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Uvidi"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Pokreni"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Ažuriranje porezne stope nije uspjelo"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Ovo je sadržaj kolekcije <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privatno"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Opcija proizvoda uspješno stvorena"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Nadređeni proizvod"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Grad"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administratori"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Bruto cijena: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Idi na sljedeću stranicu"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Ukloni poveznicu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Ovo polje je samo za čitanje"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Broj narudžbi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Narudžba uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Naslijedi filtere"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Upravljajte globalnim spremljenim prikazima vidljivim svim korisnicima"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Pretraži načine plaćanja..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Adresa dostave uklonjena za narudžbu"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Stvori {enabledCount} varijanti"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Plaćanje #{0} prevedeno u {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Greška učitavanja povijesti kupca: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "Uspješno uklonjeno {selectionLength} {entityType} iz kanala"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Dodaj vrijednost opcije"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Globalne postavke"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "je nakon"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Opcija proizvoda uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Uredi vrijednosti svojstava"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Dodavanje..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Premjesti kolekcije"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Uloge"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Prikaz rešetke"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Brisanje adrese nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Nema dostupnih načina dostave"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Globalni prikaz uspješno pretvoren u osobni prikaz"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Izvršenje prevedeno"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Jeste li sigurni da želite obrisati {selectionLength} datoteka?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Prijava"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Prikaz popisa"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Testna narudžba"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Odaberite kupca za nastavak"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Grupa opcija uspješno dodijeljena"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Pokreni test"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Porezna stopa: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Molimo dodajte proizvode i dovršite adresu za dostavu kako biste pokrenuli test."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Prebaci redak zaglavlja"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Odaberi adresu"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Provjera prihvatljivosti plaćanja"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Zadana porezna zona"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Nacrt narudžbe je spreman za dovršenje"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metapodaci"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtriraj..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Nova vrijednost svojstva"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Kanal uspješno ažuriran"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Prikaži manje"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Kratki datum"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Dostupne valute"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Odaberi {0} stavki"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Naručeno"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Rotiranje ovog ključa odmah će poništiti trenutni ključ. Sve integracije koje ga koriste prestat će raditi dok se ne ažuriraju novim ključem."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Podaci koji su proslijeđeni zadatku"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Potvrdi navigaciju"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Cilj poveznice"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Dovrši skicu"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Naziv"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Izvršenje narudžbe nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Ukupno"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Unesite ID transakcije za ovo izvršenje povrata"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Vaš API ključ"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Jeste li sigurni da želite obrisati ovu skicu narudžbe?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Izvršenje stvoreno"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Pronađeno {0} prikladnih načina dostave"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Dimenzije"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Prikaži lozinku"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(maks: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Tvrtka"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Dodaj stupac nakon"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Radnje"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Popusti"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Unesite napomenu povrata"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Redak narudžbe uklonjen"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Sadržaj:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Ključ"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Potvrdi"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Stvaranje kolekcije nije uspjelo"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Idi na prvu stranicu"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Stvaranje proizvoda nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Kupac"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Greška učitavanja povijesti narudžbe: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Adresa dostave postavljena za narudžbu"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Žarišna točka"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Jedna varijanta, bez opcija"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Odaberite sljedeće stanje za narudžbu"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Lokalitet"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Planirani zadaci"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Unesite ID transakcije"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Osvježi podatke"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Dodaj ili ukloni vrijednosti svojstava za {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Ovo su vrijednosti svojstava za svojstvo <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Plaćanje uspješno dodano narudžbi"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Adresa za naplatu postavljena za narudžbu"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Ažuriranje zone nije uspjelo"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Lozinka"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Brisanje nije uspjelo"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Planirani zadatak će biti izvršen"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Nova lokacija zaliha"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Dozvole"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Adresa za dostavu promijenjena"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Nisu pronađeni proizvodi"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Dodaj redak prije"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Prijelaz u {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Ovaj mjesec"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Stvaranje svojstva nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Nije uspjelo otkazati stavke narudžbe"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID transakcije"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Dodijeljeno"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Dodaj još jednu grupu opcija"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Odaberite što učiniti s preostalom zalihom"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Istražite platformu i Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Svakih 5 sekundi"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Kolekcija uspješno stvorena"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Cijena"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Skica narudžbe"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Opseg"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Dodaj uvjet"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Način dostave je prihvatljiv za ovu narudžbu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administratori"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Uklonjeno iz grupe"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Širina"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Nije potrebno plaćanje ili povrat"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Preuzmi kao .env datoteku"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Kada je omogućeno, promocija je dostupna u trgovini"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Kada se prati, razine zaliha varijanti proizvoda će se automatski prilagoditi pri prodaji. Ovu postavku mogu nadjačati pojedinačne varijante proizvoda."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Način dostave postavljen za narudžbu"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Ažuriranje promocije nije uspjelo"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Slike"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API ključevi"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Pretraži {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Uredi datoteku"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Otkaži uplatu"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Red zadataka"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Datoteke"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Adresa e-pošte"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Ponovno generiraj URL naziv iz izvornog polja"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Naslijedi iz globalnih postavki"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Nisu pronađeni rezultati"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Trenutno stanje"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Postavite adresu dostave i odaberite način dostave"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Isključeno"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Pohrana postavki"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Red"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Nova porezna stopa"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Plaćanje prevedeno"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Preostalo:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Nije pronađen duplicator s kodom \"{duplicatorCode}\" za {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Cijene uključuju porez za zadanu poreznu zonu"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Ukupan povrat:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Pregled rezultata zadatka"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Testirajte svoje načine dostave simuliranjem nove narudžbe."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Nisu odabrane stavke"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} odabrano"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Nisu pronađene države"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Varijante uspješno stvorene"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Automatski generiraj URL naziv"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Dodatna naknada"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Načini plaćanja"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Zaliha"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Nisu pronađeni kupci"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Koristi globalni prag zaliha"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Nova grupa opcija proizvoda"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Stanje plaćanja uspješno ažurirano"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Stvori novo"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Ukupni povrat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adresa obrisana"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Dostupne su samo uloge dodijeljene vašem računu."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Stavka dodana narudžbi"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Uredi žarišnu točku"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Nisu pronađeni prodavači"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Datoteka"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Ova grupa opcija koristi se u jednom drugom proizvodu. Promjene će utjecati i na njega.} other {Ova grupa opcija dijeljena je na # proizvoda. Promjene će utjecati na sve njih.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Moji spremljeni prikazi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Novi kanal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Stvaranje prodavača nije uspjelo"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Konfiguriraj postavke dupliciranja za {0}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Nijedna varijanta ne odgovara trenutnom filtru."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adrese"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Dodajte novu vrijednost opcije u grupu opcija {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Izmjena narudžbe #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Dodaj stupac prije"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Jezici kanala"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Stvaranje grupe opcija nije uspjelo"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Točno"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Odaberi kupca"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Narudžba prevedena"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Ovaj proizvod ima postojeće varijante ali nema definiranih grupa opcija. Morate dodati grupe opcija prije stvaranja novih varijanti."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "je prije"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Obriši skicu narudžbe"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Katalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Novi način plaćanja"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promocija uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Nije moguće otkazati {rejected} zadatak} few {Nije moguće otkazati {rejected} zadatka} other {Nije moguće otkazati {rejected} zadataka}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Odaberite kanal"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Jezik prikaza"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Detalji izvršenja"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Odbaci preostalu zalihu"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Sada"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Kanali"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Prikaz uspješno pretvoren u globalni"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "prije"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Veličina"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Nije pronađen prijevod za {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Novi kupac"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Najnovije narudžbe"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} više"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Koristi kao zadanu adresu za naplatu"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Obriši"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Onemogući"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Kolekcije"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Dodaj varijantu"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Stvaranje zemlje nije uspjelo"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Zemlje"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Stvaranje opcija proizvoda nije uspjelo"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Preimenovanje prikaza nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Dostupno"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normalno"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filteri"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Grupe kupaca"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Kupci"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Primjer oblikovanja"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nova opcija"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Ograničenje korištenja"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Učitavanje globalnih postavki..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adresa uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Stvoreno"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Učitavanje adresa..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Odaberite ciljnu kolekciju za premještanje {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Detalji kupca ažurirani"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "nije u"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Primijeni"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nova opcija proizvoda"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Idi na posljednju stranicu"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Otkaži"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Varijanta proizvoda uspješno stvorena"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Povrat iz ove metode"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Poštanski broj"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Prvo dodajte opcije proizvoda"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Nova porezna kategorija"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Dodaj opciju"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Djelomični povrat završen"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Postavi prilagođena polja"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Kolekcije"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Obriši varijantu"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Nisu napravljene izmjene"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Zadana zona dostave"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Razlog:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Adresa za dostavu"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Prijelaz u {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Porezne kategorije"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Privatne kolekcije nisu vidljive u trgovini"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Kada je omogućeno, proizvod je dostupan u trgovini"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Planirani zadatak nije mogao biti izvršen"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Grupe kupaca"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Onemogućeno"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Nova promocija"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Zadana adresa za dostavu"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Potreban povrat"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Izvrši narudžbu"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Nemate dozvolu za pregled postavki kanala"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Zadnjih 30 dana"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Nema vrijednosti svojstava"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Potreban je razlog povrata"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Nije moguće ukloniti grupu opcija"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Ažuriranje porezne kategorije nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Povrat uspješno izvršen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Ažuriraj"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Naslov 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Narudžba postavljena"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profil uspješno ažuriran"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "kraj"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Način plaćanja"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Uredi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Varijanta uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtriraj po nazivu kolekcije"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Bilješka dodana"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Odaberite količine za izvršenje i konfigurirajte rukovatelja izvršenja"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Adresa za naplatu uklonjena s narudžbe"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Počinje u"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Dupliciraj"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Nema rezultata"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Postavke stupaca"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Brisanje {count} skladišne lokacije nije uspjelo} few {Brisanje {count} skladišne lokacije nije uspjelo} other {Brisanje {count} skladišnih lokacija nije uspjelo}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Kod"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Uklanjanje grupa opcija nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Narudžba dostavljena"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Prenesi na {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Preostala zaliha"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Ukloni iz zone"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Odaberite iz globalno dostupnih jezika za ovaj kanal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Jeste li sigurni da želite obrisati ovu adresu?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Dodjela grupe opcija nije uspjela"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Ažuriranje datoteke nije uspjelo"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Lokacija zaliha uspješno ažurirana"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Potvrdi radnju"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Država uspješno ažurirana"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Svojstva"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Dodavanje bilješke nije uspjelo"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Brisanje bilješke nije uspjelo"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Proširenje dokumenta upita nije uspjelo"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Ažuriranje bilješke nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Povrat dostave"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Samo za čitanje"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Dupliciranje globalnog prikaza nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Prikazano {shown} od {total} • odabrano {selected}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Testiraj način dostave"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Vrijednosti svojstava"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Datoteka uspješno ažurirana"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Tema"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} kupaca"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API ključevi"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Odaberite jezik"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Odjava"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Pokušaji"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Dostupni kodovi valuta"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Kodovi dostupnih jezika"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Navigacijske mrvice"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Kategorija"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Kanali"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Potomci"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Kod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Kod kupona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Stvoreno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Kod valute"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Kupac"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Grupa kupaca"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Kupci"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Prilagođena polja"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Podaci"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Zadani kod valute"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Zadani kod jezika"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Zadana zona dostave"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Zadana porezna zona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Opis"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Trajanje"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Adresa e-pošte"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Omogućeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Završava"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Greška"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Istaknuta datoteka"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Ime"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Kod rukovatelja izvršenja"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Zadano"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Privatno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Izvršeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Prezime"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Ime"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Narudžba postavljena"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID roditelja"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Ograničenje korištenja po kupcu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Dozvole"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Pozicija"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Cijena"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Cijene uključuju porez"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Cijena s porezom"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Varijante proizvoda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Napredak"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Ime reda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Rezultat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Ponavljanja"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Prodavač"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Naplaćeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Redci dostave"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "URL naziv"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Pokrenuto"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Počinje"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Stanje"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Razine zaliha"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Ukupno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Ukupno s porezom"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Tip"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Ažurirano"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Ograničenje korištenja"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Korisnik"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Vrijednost"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Popis vrijednosti"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zona"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Metoda"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Sažetak poreza"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Postavlja jezike koji su dostupni za sve kanale. Pojedinačni kanali tada mogu podržavati podskup ovih jezika."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Kolekcije uspješno premještene"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registriran"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Otkaži zadatak"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Završava u"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Stranica {0} od {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Stopa"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Veličina, boja itd."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Pregledaj facete"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Otkazano"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Kreirano"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Dostavljeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Na čekanju"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Poslano"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Spremi prikaz"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} odabrano"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Pretraži grupe opcija..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Izmijeni narudžbu"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Odabrane stavke"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Vrijednosti"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Kupac postavljen za narudžbu"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Svojstva"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Jeste li sigurni da želite ukloniti {count} kupca iz ove grupe?} few {Jeste li sigurni da želite ukloniti {count} kupca iz ove grupe?} other {Jeste li sigurni da želite ukloniti {count} kupaca iz ove grupe?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Zaliha na skladištu"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Ponovna izgradnja indeksa pretraživanja nije mogla započeti"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Adresa za dostavu"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Nova zona"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Novi API ključ"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Obriši stupac"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Dodijeli postojeće"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "je prazno"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Ovo su kupci u grupi kupaca <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Upravljaj globalnim prikazima"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Zadani kanal"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Umetni novu sliku s izvorom, naslovom i dimenzijama"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Stvaranje vrijednosti svojstva nije uspjelo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Nije uspjelo ažuriranje opcije proizvoda"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Zaboravili ste lozinku?</0><1>Zatraži poništavanje</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Kod kupona"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Kupac verificiran"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Globalne postavke"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Raspored"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Nije moguće premjestiti kolekciju u vlastiti podskup"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Nova porezna kategorija"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Nema dostupnih lokacija zaliha na trenutnom kanalu"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Kanal uspješno stvoren"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Kupac uspješno ažuriran"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Pregled podataka"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Obriši prikaz"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Dodajte novu adresu kupcu."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Više prikaza"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Uredi svojstva odabrane slike"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Primijenjen prikaz \"{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Uspješno uklonjeno {successCount} svojstava iz kanala"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Novi proizvod"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Nova datoteka"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Preračunaj dostavu"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Odaberite koje opcije trebaju primjenjivati na postojeću varijantu \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Datoteke"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Ovo će ukloniti sve grupe opcija s ovog proizvoda i vratiti se na izbor postavljanja varijanti."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Adresa za naplatu"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Dodaj vrijednost svojstva"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Molimo odaberite ciljnu kolekciju"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Pregledajte izmjene prije njihove primjene na narudžbu."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Odaberite uloga"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Narudžba otkazana"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Popust"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Sve vrste"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Samo nacrti narudžbi mogu biti dovršeni"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Ažuriranje proizvoda nije uspjelo"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Prilagođavanje {0} redaka"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Dodaj vrijednosti svojstava"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "nakon"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Kanal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Provjere zdravlja"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Iznos"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Telefonski broj"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Novi kupac"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Slika"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administrator uspješno kreiran"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Opcije proizvoda"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Odaberi državu"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Stvaranje..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Jeste li sigurni da želite obrisati ovaj globalni prikaz? Ova radnja se ne može poništiti i utjecat će na sve korisnike."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Prisilno ukloni grupu opcija"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Dodano"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Povijest kupca"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Vrijednosti svojstava uspješno ažurirane za {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Uklanjanje kupca iz grupe nije uspjelo"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Sustav"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Ograničenje korištenja po kupcu"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Adresa za naplatu promijenjena"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Odaberite opciju"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Kopiraj u osobno"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Ukupni povrat premašuje maksimalni iznos za povrat od {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Obriši globalni prikaz"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Stvori"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Svakih 30 sekundi"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Nova država"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "Od {0} do {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Stvaranje kupca nije uspjelo"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Žarišna točka ažurirana"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Vrijednosti opcija"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Zadana adresa za naplatu"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Nema kupca"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Nije uspjelo ukloniti države iz zone"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Stvaranje promocije nije uspjelo"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Danas"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Jučer"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Naziv opcije"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Jeste li sigurni da želite ukloniti {0} {1} iz ove zone?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Dodavanje {0} doplata(e)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "URL poveznice"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Zamjenska vrijednost: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Povijest narudžbe"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Premosti"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "ID transakcije je obavezan"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "odgovara regex-u"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Globalni prikaz uspješno preimenovan"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Nisu odabrane oznake"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Natrag"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Prikaz uspješno preimenovan"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Primijeni filter"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Posljednji rezultat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Dodano u grupu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Uvidi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Stvori varijante"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Testiranje načina dostave..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Tamna"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Rezultati testa"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Dodaj kupca"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Spremi izmjene"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adresa ažurirana"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Povrat uspješno obrađen"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Nova zona"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Nije uspjelo ažurirati poziciju kolekcije"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Povrat"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Izmijeni"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Nisu konfigurirani globalni jezici"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Uklanjanje {0} stavki"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Prati"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Stvori varijantu"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Vrijednosti svojstava za {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Spremi raspored"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Resetiranje lozinke verificirano"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Brisanje prikaza nije uspjelo"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Jeste li sigurni da želite napustiti ovu stranicu? Sve nespremljene promjene bit će izgubljene."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Prebaci stupac zaglavlja"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Nova promocija"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Naziv vrijednosti opcije"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Zadnji put korišteno"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Je zadana porezna kategorija"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "URL naziv je postavljen"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Ažuriranje žarišne točke nije uspjelo"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zona uspješno ažurirana"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Država/Pokrajina"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Ažuriranje grupe opcija nije uspjelo"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Zadane postavke kanala"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Stvaranje porezne kategorije nije uspjelo"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Postavi kriterije filtriranja za stupac {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Država"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Jednostavan proizvod"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Red zadataka"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Potvrdite da ste spremili API ključ prije zatvaranja."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Potvrdi brisanje"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Izmjena narudžbe nije uspjela"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Uključuje porez od {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Metrike narudžbi"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Odaberite jezik prikaza"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Metode provjere autentičnosti"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "početak"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Rotiranje API ključa nije uspjelo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "u"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Pretraži uloge..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Varijante proizvoda"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Upravljaj globalnim prikazima"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Obrada..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "Pronađeno {totalItems} {0}"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Odaberite razdoblje"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Proizvod"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rotiraj API ključ"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Kategorija"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Premještanje..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Dodijeli"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Prodavač uspješno stvoren"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Način dostave uspješno ažuriran"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Ažuriranje varijante proizvoda nije uspjelo"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Povucite za promjenu redoslijeda"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Odaberite što učiniti sa zalihom koja je preostala na {count, plural, one {# skladišnoj lokaciji} few {# skladišne lokacije} other {# skladišnih lokacija}} koje brišete. Sve odabrane lokacije prenose preostalu zalihu na jednu lokaciju koju odaberete ili je odbacuju."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Pretraži vrijednosti faceta..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Napomena"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Dostupni jezici"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Učitaj još {0} ({remaining} preostalo)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Vrijednosti svojstava"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Nije uspjelo preurediti stavke"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Ukupno narudžbi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Nisu pronađeni prihvatljivi načini dostave za ovu narudžbu."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Dodaj opciju proizvoda"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Dostava"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions mora se koristiti unutar DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Ova grupa opcija koristi se u postojećim varijantama. Prisilno uklanjanje može utjecati na te varijante. Jeste li sigurni?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Zatraženo ažuriranje e-pošte"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Greška prilikom prijelaza u stanje"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Grupa kupaca uspješno stvorena"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Novi prozor"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Plaćanje autorizirano"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Uloga uspješno ažurirana"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Odaberite državu"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Nije uspjelo ažuriranje načina dostave"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Izbrisana {deleted} skladišna lokacija} few {Izbrisane {deleted} skladišne lokacije} other {Izbrisano {deleted} skladišnih lokacija}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Načini dostave"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Odaberite adresu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Da"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "URL naziv"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Postavi žarišnu točku"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "kraj"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Odaberite valute"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Ažurirajte sadržaj ili vidljivost bilješke"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget najnovijih narudžbi"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Sadržaj kolekcije {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Način dostave promijenjen"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Opis poreza"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "manje je ili jednako"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "nije jednako"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Osvježi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "npr. Veličina"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Izvrši plaćanje"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Kanali"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Dostava vraćena"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Vrsta datoteke"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Nova lokacija zaliha"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} plaćanje/a vraćeno prije greške. Provjerite povijest narudžbe za detalje."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Odaberi stavku"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Novi proizvod"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Upravljaj oznakama"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Stavke vraćene"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Dodaj radnju"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Dodijeli opcije postojećoj varijanti"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Dupliciraj {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Ukloni iz grupe"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Ažuriranje stanja izvršenja nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Stvorite novu varijantu proizvoda s opcijama, cijenama i zalihama"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Privatna svojstva nisu vidljiva u trgovini"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Odaberite poreznu kategoriju"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Stvoreno"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Ne izvršava se"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Dodijeljeno"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Naslov 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Odaberi dostupne jezike"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Dodavanje {0} stavki"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Dodaj redak nakon"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Ukupno poreza"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Status nacrta narudžbe"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Opcije proizvoda uspješno stvorene"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Učitavanje lokacija…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Stvaranje načina plaćanja nije uspjelo"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Vrijednost svojstva uspješno stvorena"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Skica narudžbe obrisana"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "veće od"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Widget metrika"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Pretraži valute..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Ukloni iz kanala"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Naslov"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Umetni sliku"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Ažuriranje prodavača nije uspjelo"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Država uspješno stvorena"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Odaberi prodavača"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Učitavanje oznaka..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Svojstvo uspješno stvoreno"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} varijanti"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Izvršenje plaćanja nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Nema adrese za naplatu"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Brisanje {1} skladišne lokacije nije uspjelo} few {Brisanje {2} skladišne lokacije nije uspjelo} other {Brisanje {2} skladišnih lokacija nije uspjelo}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Svojstvo"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Nije moguće ukloniti iz aktivnog kanala"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Nije postavljeno"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Prisilno ukloni"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Novi kanal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Naziv grupe opcija"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "I"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Stvaranje grupe kupaca nije uspjelo"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Stvaranje uloge nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Naziv proizvoda"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Stanje izvršenja uspješno ažurirano"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Proizvodi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adresa stvorena"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API ključ uspješno rotiran"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Dodaj grupu opcija"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Povrat {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Ručno unesite URL naziv"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Nema dostupnih widgeta"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Otkazivanje plaćanja nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Plaćanje uspješno otkazano"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Globalni prikaz uspješno dupliciran"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Kreirao"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtriraj varijante..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Dodaj cijenu u drugoj valuti"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Adresa e-pošte ili identifikator"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Povrat #{0} preveden u {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Kupci"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Naslov 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Ažuriranje lokacije zaliha nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Narudžba poslana"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Spremi adresu"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Učini globalnim"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Odaberi sljedeće stanje"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Nema upozorenja"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Premještanje {0} kolekcija u {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "između"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Bilješka uspješno dodana"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Bilješka uspješno obrisana"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Bilješka uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Izvršenje povrata nije uspjelo"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Razina zaliha"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Dodaj stavku"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API ključ uspješno stvoren"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Učitavanje pregleda..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Natrag na pretraživanje"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Prikaz uspješno dupliciran"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Ukloni grupu opcija"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Opis"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Zemlje"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Ulica 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Globalni prikaz uspješno obrisan"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Uredi raspored"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Dodijeli kanalu"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Ovaj tjedan"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Grupa opcija proizvoda uspješno stvorena"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Dodaj ručnu uplatu od {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "je u"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-pošta"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Neuspješno ažuriranje administratora"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Upravljajte svojim osobnim spremljenim prikazima za ovu tablicu"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtriraj po oznakama"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Prijavite se za pristup admin nadzornoj ploči"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Dodaj plaćanje narudžbi ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Netočno"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Svijetla"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Resetiraj"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "jednako je"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Stvori opcije"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Lozinka ažurirana"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "ne sadrži"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Grupa opcija"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Uredite detalje adrese u nastavku."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Porezna kategorija uspješno stvorena"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Premještanje kolekcija nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Ažuriranje stanja plaćanja nije uspjelo"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Sažetak vaših narudžbi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Prenesi"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Proizvod s opcijama"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Prikazivanje svih {0} rezultata"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "ID pretraživanja"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} više"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Grupe opcija"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Prilagođena polja"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Sva moguća stanja narudžbe i njihovi prijelazi. Trenutno stanje je istaknuto."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Narudžbe"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget sažetka narudžbi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Dodavanje stavki"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Organiziranje dodatne uplate"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Uređenje plaćanja"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Otkazana"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Stvorena"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Dostavljeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Skica"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Mijenjanje"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Djelomično dostavljeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Djelomično poslano"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Plaćanje autorizirano"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Plaćanje izvršeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Poslano"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Praćeni resursi"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Informacije o entitetu"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Ukupno narudžba"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Vidljivo samo administratorima"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Kol."
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Oznake"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super administrator"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Neki resursi nisu dostupni"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Dostupne radnje"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Umetni poveznicu"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Ako je omogućeno, filteri će se naslijediti iz nadređene kolekcije i kombinirati s filterima postavljenim na ovoj kolekciji."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Odaberite zonu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Testiraj načine dostave"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Plaćanje uspješno izvršeno"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "Uklonjeno {0} {1} iz zone"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Omogući"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Načini plaćanja"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Odobreno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Otkazano"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Stvoreno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Odbačeno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Greška"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Neuspjelo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Na čekanju"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Naplaćeno"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Prosječna vrijednost narudžbe"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Stvaranje zone nije uspjelo"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Razine zaliha"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Ažuriranje API ključa nije uspjelo"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Redci narudžbe"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Preimenovanje globalnog prikaza nije uspjelo"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Umetni novu hipervezu s URL-om i opcijama cilja"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Visina"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Potreban je povrat novca u iznosu {formattedDiff}. Odaberite iznose plaćanja i unesite bilješku za nastavak."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Jedinična cijena"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Uzorak rasporeda"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Plaćanje nije uspjelo"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Dodaj kanal"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Neuspješno ažuriranje grupe opcija proizvoda"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Pretraži kanale..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Dodaj grupe kupaca"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Dostupni jezici"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Poništi odabir"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Nema adrese"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Način plaćanja uspješno stvoren"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Informacije o kupcu ažurirane"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Pretvaranje prikaza u globalni nije uspjelo"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Varijante proizvoda"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Proizvodi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promocije"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Nije uspjelo stvaranje opcije proizvoda"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Stara e-pošta:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Spremite prikaz kao \"Globalni\" kako bi bio dostupan svim korisnicima."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Stvaranje varijanti nije uspjelo"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Postavlja razinu zaliha pri kojoj se ova varijanta smatra rasprodanom. Korištenje negativne vrijednosti omogućuje podršku za prednarudžbe. Može se nadjačati varijantama proizvoda."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rotiraj ključ"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Stvaranje varijanti proizvoda nije uspjelo"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Sakrij lozinku"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Novi prodavač"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "npr. Crvena, Velika, Pamuk"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Ažuriranje profila nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Uklonjeni kodovi kupona"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Obriši filter"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regije"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Ispustite datoteke ovdje za prijenos"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Uključi/isključi sve vidljive varijante"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verificiran"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Nova grupa opcija"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Posljednje ažurirano {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Još nisu stvoreni globalni prikazi."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Ažuriranje uloge nije uspjelo"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Ovo je jedini put kada će se prikazati cijeli API ključ. Kopirajte ga ili preuzmite sada — kasnije ga neće biti moguće dohvatiti."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Kolekcija uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Način plaćanja uspješno ažuriran"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Prikaz uspješno obrisan"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Grupa opcija {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "ILI"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Upravljaj oznakama"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Kod kupona uklonjen s narudžbe"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Nikada"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Ažuriranje vrijednosti svojstva nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Ukloni grupu"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Narudžba izvršena"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Nema adrese za dostavu"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Proširenje upita sadrži nevaljanu GraphQL sintaksu"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Greška proširenja upita"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Greška proširenja upita:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Proširenje upita nije valjano: mora imati najmanje jedno polje najviše razine"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Nepodudaranje proširenja upita:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "javno"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Porezna kategorija uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Premjesti"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Uredi ili obriši postojeće oznake"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Uvjeti provjere prihvatljivosti ovog načina dostave nisu ispunjeni za trenutnu narudžbu i adresu dostave."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Dodaj kod kupona"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Kod kupona postavljen za narudžbu"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Prilagođena polja"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Novi način dostave"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Izbriši skladišne lokacije"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "veće je ili jednako"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Pregled"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} od {1} dostupno za ispunjenje"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Od početka mjeseca"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Zahtjev kupca"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Oštećeno pri dostavi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Nedostupno"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Ostalo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Pogrešan artikl"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Sažetak izmjena"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Povrati ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Posljednje izvršeno"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Detalji plaćanja"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Ponovno izgradi indeks pretraživanja"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Pokrenuto"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Svakih 60 sekundi"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Ažuriranje grupe kupaca nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Metapodaci plaćanja"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Otkaži izmjenu"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Isti prozor"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Primijenite filtere na tablicu i kliknite \"Spremi prikaz\" za početak."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Uloge"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Potrebno dodatno plaćanje"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Ažuriranje narudžbe nije uspjelo"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "S odabranima..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Stvaranje lokacije zaliha nije uspjelo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "manje ili jednako"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Članovi grupe kupaca {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Stanje"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Ne prati"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Izvršenje #{0} stvoreno"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Pokretanje preostalih ažuriranja indeksa pretrage"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Ovo je zadana uloga i ne može se mijenjati"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Moji spremljeni prikazi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Država / Pokrajina"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Omogućeno"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Stavki po stranici"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Uredi članove"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Zaliha na skladištu"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtriraj po {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Upozorenja"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Vrijednosti opcija"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Pregled izmjena"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Uklanjanje {entityType} iz kanala nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Varijanta uspješno obrisana"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Uredi svojstva odabrane poveznice"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Prodaja"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Odaberite odredišnu kolekciju"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Vaše najnovije narudžbe"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Planirani zadaci"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Jeste li sigurni da želite obrisati ovu stavku? Ova radnja se ne može poništiti."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Varijante"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Prodavači"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Postavke"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Pohrana postavki"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Naslov 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Dobrodošli u Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Načini dostave"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} povratno)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identifikator"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Ažuriranje kolekcije nije uspjelo"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Cijena i porez"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Narudžba nije pronađena"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Greška"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Narudžba izmijenjena"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Zatraženo resetiranje lozinke"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Dodijeljeni iznos plaćanja mora biti jednak ukupnom povratu"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "npr. Mala"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Jeste li sigurni da želite ukloniti {0} {entityType} iz trenutnog kanala?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Dodaj oznake..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Neuspješno stvaranje grupe opcija proizvoda"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} stavki odabrano"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Pretraži jezike..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Lokacije zaliha"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Idi na prethodnu stranicu"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Sadržaj"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Pretvaranje globalnog prikaza u osobni prikaz nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Rezultat zadatka"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Dodaj plaćanje ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Sustav"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Naziv varijante"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Ukloni"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Ažuriranje kupca nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Ukloniti grupe opcija?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Ovo je pregled sadržaja kolekcije temeljen na trenutnim postavkama filtra. Nakon što spremite kolekciju, sadržaj će biti ažuriran kako bi odražavao nove postavke filtra."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {Uklonjen {count} kupac iz grupe} few {Uklonjena {count} kupca iz grupe} other {Uklonjeno {count} kupaca iz grupe}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Porezne kategorije"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Porezne stope"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Nije uspjelo uklanjanje kupaca iz grupe"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Učitavanje globalnih postavki nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Odaberite stavke za povrat i po želji vratite na zalihu"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Spremi"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} od {0} redak(a) odabrano."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Pregled izmjena narudžbe"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Grupa opcija proizvoda uspješno ažurirana"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Stranica će nastaviti sa zadanim upitom."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Ulica"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Nema više faceta"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Ponovna izgradnja indeksa pretraživanja započela"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Pozicija kolekcije ažurirana"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Naziv grupe opcija"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Dodaj \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Nova varijanta proizvoda"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Povrat preveden"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Korištenje izvorne strategije autentifikacije"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Nije uspjelo dodijeliti {entityIdsLength} {entityType} kanalu"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Zadani jezik"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Izvršavanje..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Dodaj grupu opcija proizvodu"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Pregled {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Prodavač uspješno ažuriran"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Prijelaz narudžbe u stanje nije uspio"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Prikaži sve ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Stvaranje porezne stope nije uspjelo"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Spremio sam ovaj API ključ"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Konfigurirajte dostupne jezike za svoju trgovinu i kanale"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Proizvod uspješno stvoren"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Dodaj varijantu proizvoda"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Unesite i pritisnite Enter ili zarez za dodavanje..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Uredi bilješku"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Nisu pronađene datoteke. Pokušajte prilagoditi filtere."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Dodaj opciju"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Spremi grupu opcija"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Stvori {createCount} varijanti"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Kliknite \"Pokreni test\" za testiranje ovog načina dostave."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administrator uspješno ažuriran"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Obriši filtere"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Izvršenje #{0} od {1} do {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Brisanje globalnog prikaza nije uspjelo"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Zadani jezik"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Nema pronađenih opcija"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binarno"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Grupa opcija uspješno ažurirana"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Novi način dostave"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Svakih 10 sekundi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "bez PDV-a:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Dodaj zalihu lokaciji"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Vrijednost opcije uspješno dodana"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Kolekcija premještena u novi nadređeni element"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Grupa opcija uklonjena"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Prijelaz u odabrano stanje"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Bit će potrebno dodatno plaćanje od {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Prati zalihe prema zadanim postavkama"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "Odabrano {selected} od {total}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Način dostave uspješno stvoren"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nova grupa kupaca"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Vidljivo kupcu"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Grupa opcija uspješno stvorena"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Porezne stope"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "URL naziv će se automatski generirati..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Kupac nije pronađen"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Odaberi {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Nove vrijednosti svojstava za dodavanje:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Nije uspjelo obraditi povrat"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Ime"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "sadrži"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Nisu pronađene grupe opcija"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Nisu pronađene stavke"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Međuzbroj"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Izvršene stavke ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Vrijednost ažurirana"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Neverificiran"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Količina"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Dodaj filter"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Porezna kategorija"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Podaci testa su ažurirani. Kliknite \"Pokreni test\" za pregled ažuriranih rezultata."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "nije u"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Redak narudžbe ažuriran"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Novi način plaćanja"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Duplicirana vrijednost \"{trimmed}\" već postoji"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Razlog"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Grupe kupaca"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "Uspješno uklonjeno {entityType} iz kanala"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Grupe opcija"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Dodaj doplatu"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Trenutne vrijednosti svojstava"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Stranica {page} od {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Prošli mjesec"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Dodaj zemlju"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Ukloni stavku"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "manje od"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Varijanta se ne može dodati. Provjerite je li nadređeni proizvod omogućen."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Došlo je do nepoznate pogreške"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Metrike"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Jezik"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Nova kolekcija"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Povrat i otkazivanje narudžbe"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Ažuriranje e-pošte verificirano"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "je između"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Povrat i otkazivanje"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Testiranje načina dostave..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Nije uspjelo stvaranje načina dostave"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "Uspješno dodijeljeno {entityIdsLength} {entityType} kanalu"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Globalni jezici"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Novi administrator"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Obriši skicu"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Izvor"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Nema dostupnih radnji"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Ažuriranje kanala nije uspjelo"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Općenito"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Nije uspjelo ukloniti proizvod iz kanala"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Dodaj novu adresu"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Svojstvo uspješno ažurirano"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zona uspješno stvorena"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Vrijednost"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Kupac ažuriran"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Faktor pretvorbe cijene"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Narudžba prodavača"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Novo svojstvo"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Jeste li sigurni da želite ukloniti ovu grupu opcija s proizvoda?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Opis (alternativni tekst)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Nisu pronađene oznake"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Zadana valuta"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Za ove izmjene nije potrebno plaćanje ili povrat."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Ukupni prihod"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Sljedeće izvršenje"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Bilješka je privatna"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Srednji datum"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Nevažeći broj"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Još niste spremili nijedan prikaz."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Jeste li sigurni da želite obrisati ovaj prikaz? Ova radnja se ne može poništiti."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Pregled procesa narudžbe"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Dupliciranje prikaza nije uspjelo"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Koristi kao zadanu adresu za dostavu"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Ručno uredi URL naziv"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Dodajte filtre za pregled sadržaja kolekcije."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Grupa opcija proizvoda"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Međuzbroj"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "manje je od"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID povrata"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Prilagođena polja narudžbe ažurirana"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Kalkulator"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Uklanjanje grupe opcija iz kanala nije uspjelo: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Pregled podataka zadatka"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Premjesti na najvišu razinu"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Obriši"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Sažetak narudžbi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Pretraži datoteke..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Novo svojstvo"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Dodijeli {entityType} kanalu"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Nastavi"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promocije"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Poruka greške"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Dodaj razinu zaliha za drugu lokaciju"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Obriši adresu"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Ažuriranje svojstva nije uspjelo"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters mora se koristiti unutar WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Uredi adresu"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Uklanjanje svojstva iz kanala nije uspjelo: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Postavi poveznicu"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Novi prodavač"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Uredi sliku"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Upravljaj varijantama"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Zaliha dodijeljena"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "veće ili jednako"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Postavlja razinu zaliha pri kojoj se ova varijanta smatra rasprodanom. Korištenje negativne vrijednosti omogućuje podršku za prednarudžbe."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Stvori opcije proizvoda"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Spremanje..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Pregled rezultata"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Redaka po stranici"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Učitavanje kolekcija..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Vrijednost svojstva uspješno ažurirana"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Dodaj datoteku"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Spremi izmjene"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Kupac dodan u grupu"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Narudžbe prodavača"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Dodavanje vrijednosti opcije nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Dodaj vrijednost opcije u {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} stavki vraćeno"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Još nisu definirane grupe opcija. Dodajte grupe opcija za stvaranje različitih varijanti vašeg proizvoda (npr. Veličina, Boja, Materijal)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Nova e-pošta:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Ažuriranje načina plaćanja nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Dostupno:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Stvoreno u"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Stvaranje varijante proizvoda nije uspjelo"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Jezik: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Nemate dozvolu za pregled globalnih postavki jezika"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Porezna stopa uspješno stvorena"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Naslov 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Dodani kodovi kupona"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Aktivan"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Porezna osnovica"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Učitaj više"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Povrat izvršen"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API ključ"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "Uspješno duplicirano {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Nova grupa opcija"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Još nema rezultata"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Plaćanje izvršeno"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Dostupni uvjeti"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Aktivni filteri"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Obriši sve"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "veće je od"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Zatvori"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Dodaj plaćanje narudžbi"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Učitavanje..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Token se koristi za specificiranje kanala pri slanju API zahtjeva."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Nisu pronađene adrese"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID izvršenja"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Odaberite plaćanja za povrat"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Brisanje {failed} {entityName} nije uspjelo"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Prag zaliha"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Proizvod uspješno uklonjen iz kanala"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Ažuriranje vrijednosti nije uspjelo"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Stvaranje API ključa nije uspjelo"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Izvrši povrat"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Način plaćanja je obavezan"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Dodavanje kupca u grupu nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Upravljaj varijantama"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Primijenjen globalni prikaz \"{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Kupac registriran"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zone"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Pretraži prodavače..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Promocija uspješno stvorena"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Opcija"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Proces narudžbe"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Telefonski broj"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privatno"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Varijanta"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Globalne postavke uspješno ažurirane"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API ključ uspješno ažuriran"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Ovi jezici će biti dostupni za korištenje svim kanalima"

--- a/packages/dashboard/src/i18n/locales/hu.po
+++ b/packages/dashboard/src/i18n/locales/hu.po
@@ -13,6169 +13,6169 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Teljes név"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Válasszon elemeket"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Változások megtekintése"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Nyomkövetési kód"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "A kiválasztott jogosultságok ezekre a csatornákra lesznek alkalmazva."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Termékopciók"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Új adókulcs"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Meglévő opciócsoport hozzárendelése vagy új létrehozása"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Új szerepkör"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Emelet, ajtó stb."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Nincs több elem"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Hivatkozás szerkesztése"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Adjon hozzá legalább egy tételt a megrendeléshez"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Termékek hozzáadása tesztmegrendelés létrehozásához"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Cím létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Összes be-/kikapcsolása"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "JSON érték szerkesztése"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Külső hitelesítési stratégia használata: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Válasszon indokot..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "5. fejléc"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Fizetés hozzáadása sikertelen"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Frissítve"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Globális beállítások frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Megrendelés sikeresen teljesítve"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Biztosan törli a következőt: {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Globális készlethiány küszöbérték"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Nyelvek kezelése"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Másolás folyamatban... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Sikeresen törölve"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Eltávolítás az aktuális csatornából"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} média törölve"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Adókulcs sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Adjon meg egyéni indokot..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Típus"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "{0} kiválasztása"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Értékek megtekintése"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Sor törlése"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Feltételek"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Jelenlegi"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Nincsenek teljesítések"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Nem sikerült törölni {1} készlethelyet: {messages}} other {Nem sikerült törölni {2} készlethelyet: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Ha ez engedélyezve van, a termékkatalógusban megadott árak tartalmazzák az alapértelmezett adózóna adóját."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Hozzon létre termékváltozatokat a termékéhez"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Piszkozat megrendelés befejezve"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Automatikus frissítés: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Állapot-ellenőrzések"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} törölve"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Állapotfigyelés"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Eladók"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Opciók"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} feladat sikeresen megszakítva} other {{fulfilled} feladat sikeresen megszakítva}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Eladó"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Fizetés hozzáadása"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Tesztelje ezt a szállítási módot egy megrendelés szimulálásával, hogy megállapítsa, jogosult-e rá, és mennyi lenne a szállítási költség."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Enterprise Edition felfedezése"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Raktárhelyek"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Teljesítési kezelő"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Megrendelések"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Szerepkörök kiválasztása"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "A szerepkör sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Biztosan törli ezt a termékváltozatot?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Minden erőforrás működik"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Rendszergazda létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Nem"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Termékváltozat sikeresen frissítve"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "{failed} {entityName} törlése sikertelen: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Termék sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Ország frissítése sikertelen"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Írjon be legalább 2 karaktert a kereséshez..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Vezetéknév"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Link title"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Vásárlói csoport sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Egyéni mezők módosítva"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "A raktárhely sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Ismeretlen hiba"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "A visszatérítés összege nem lehet negatív"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Részletek megtekintése"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Válasszon csatornát, amelyhez hozzárendeli a következőt: {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "A vásárló sikeresen létrehozva"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Utolsó 7 nap"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Csatorna létrehozása sikertelen"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Fejlesztői mód"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Új szerepkör"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Média törlése sikertelen: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Visszahelyezés a készletbe"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Láthatóság"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Termékvariánsok"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Új vásárlói csoport"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "\"{0}\" létrehozása"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Átnevezés"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Válassza ki a kívánt megjelenítési nyelvet és területi beállításokat"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} opciócsoport sikeresen eltávolítva a csatornából"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "A szállítási mód nem alkalmazható erre a megrendelésre"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Cím frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Cím sikeresen törölve"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Adókulcs"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "A megrendelés piszkozata nem áll készen a teljesítésre"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Új gyűjtemény"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Elemzések"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Futtatás"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Adókulcs frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Ez a <0>{collectionName}</0> gyűjtemény tartalma."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privát"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "A termékopció sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Szülő termék"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Város"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Adminisztrátorok"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Bruttó ár: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Ugrás a következő oldalra"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Hivatkozás eltávolítása"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Ez a mező csak olvasható"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Megrendelések száma"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Megrendelés sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Szűrők öröklése"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Az összes felhasználó számára látható globális mentett nézetek kezelése"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Fizetési módok keresése..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Szállítási cím eltávolítva a megrendelésről"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "{enabledCount} variáns létrehozása"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "{0}. fizetés állapota megváltozott: {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Hiba a vásárló előzmények betöltésekor: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} sikeresen eltávolítva a csatornából"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Opcióérték hozzáadása"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Általános beállítások"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "utána van"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Termékopció sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Tulajdonságértékek szerkesztése"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Hozzáadás folyamatban..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Gyűjtemények áthelyezése"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Szerepkörök"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Rácsnézet"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Cím törlése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Nem áll rendelkezésre szállítási mód"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "A globális nézet sikeresen átalakítva személyes nézetté"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Teljesítési állapot megváltozott"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Biztosan törli a kiválasztott {selectionLength} médiafájlt?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Bejelentkezés"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Listanézet"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Megrendelés tesztelése"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Válasszon vásárlót a folytatáshoz"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Opciócsoport sikeresen hozzárendelve"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Teszt futtatása"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Adókulcs: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Kérjük, adjon hozzá termékeket és töltse ki a szállítási címet a teszt futtatásához."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Fejlécsor be-/kikapcsolása"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Válasszon címet"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Fizetési jogosultság ellenőrző"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Alapértelmezett adózóna"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "A megrendelés piszkozata készen áll a teljesítésre"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metaadatok"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Szűrés..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Új tulajdonságérték"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Csatorna sikeresen frissítve"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Kevesebb megjelenítése"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Rövid dátum"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Elérhető pénznemek"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "{0} tétel kiválasztása"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Leadva"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "A kulcs rotálása azonnal érvényteleníti a jelenlegi kulcsot. Az azt használó integrációk az új kulcsra való frissítésig nem fognak működni."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "A feladathoz átadott adatok"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Navigáció megerősítése"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Link target"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Piszkozat véglegesítése"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Név"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Megrendelés teljesítése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Összesen"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Adja meg a tranzakció ID-t ehhez a visszatérítési elszámoláshoz"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Az Ön API Key-e"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Biztosan törli ezt a piszkozat megrendelést?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Teljesítés létrehozva"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "{0} alkalmas szállítási mód{1} található"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Méretek"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Jelszó megjelenítése"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(max: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Cég"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Oszlop hozzáadása utána"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Műveletek"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Kedvezmények"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Adja meg a visszatérítési megjegyzést"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Megrendeléssor eltávolítva"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Tartalom:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Kulcs"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Megerősítés"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Gyűjtemény létrehozása sikertelen"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Ugrás az első oldalra"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Termék létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Vásárló"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Hiba a megrendelés előzmények betöltésekor: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Szállítási cím beállítva a megrendeléshez"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Fókuszpont"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Egyetlen variáns, opciók nélkül"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Válassza ki a megrendelés következő állapotát"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Területi beállítás"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Ütemezett feladatok"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Adja meg a tranzakció ID-t"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Adatok frissítése"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Tulajdonságértékek hozzáadása vagy eltávolítása: {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Ezek a <0>{facetName}</0> tulajdonság értékei."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "A fizetés sikeresen hozzáadva a megrendeléshez"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Számlázási cím beállítva a megrendeléshez"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Zóna frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Jelszó"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Törlés sikertelen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Az ütemezett feladat végre lesz hajtva"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Új raktárhely"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Jogosultságok"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Szállítási cím megváltoztatva"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Nem található termék"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Sor hozzáadása elé"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Átváltás erre: {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Ez a hónap"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Tulajdonság létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Megrendelési tételek törlése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "Tranzakció ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Lefoglalt"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Újabb opciócsoport hozzáadása"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Válassza ki, mi történjen a megmaradt készlettel"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Platform & Cloud felfedezése"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Minden 5 másodpercben"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "A gyűjtemény sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Ár"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Piszkozat megrendelés"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Hatókör"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Feltétel hozzáadása"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "A szállítási mód alkalmazható erre a megrendelésre"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Adminisztrátorok"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Eltávolítva a csoportból"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Szélesség"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Nem szükséges fizetés vagy visszatérítés"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Letöltés .env fájlként"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Ha engedélyezve van, a promóció elérhető az áruházban"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Nyomon követés esetén a termékváltozatok készletszintje automatikusan módosul az értékesítéskor. Ezt a beállítást az egyes termékváltozatok felülbírálhatják."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Szállítási mód beállítva a megrendeléshez"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Promóció frissítése sikertelen"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Képek"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "{name} keresése..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Média szerkesztése"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Fizetés megszakítása"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Feladatsor"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Média"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "E-mail cím"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Slug újragenerálása a forrásmezőből"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Öröklés a globális beállításokból"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Nem található eredmény"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Jelenlegi állapot"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Adjon meg szállítási címet és válasszon szállítási módot"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Ki"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Beállítástár"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Sor"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Új adókulcs"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Fizetés állapota megváltozott"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Fennmaradó:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Nem található duplikátor \"{duplicatorCode}\" kóddal a következőhöz: {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Az árak tartalmazzák az alapértelmezett adózóna adóját"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Visszatérítés összesen:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Feladat eredményének megtekintése"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Tesztelje szállítási módjait egy új megrendelés szimulálásával."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Nincs kijelölt elem"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} kiválasztva"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Nem található ország"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Variánsok sikeresen létrehozva"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "slug automatikus generálása"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Felár"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Fizetési módok"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Készlet"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Nem található vásárló"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Globális készlethiány-küszöbérték használata"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Új termékopció-csoport"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Fizetés állapota sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Új létrehozása"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Visszatérítés összege"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Cím törölve"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Csak a fiókjához rendelt szerepkörök érhetők el."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Tétel hozzáadva a megrendeléshez"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Fókuszpont szerkesztése"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Nem található eladó"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Eszköz"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Ezt az opciócsoportot egy másik termék is használja. A módosítások azt is érintik.} other {Ez az opciócsoport # termékben van használatban. A módosítások mindet érintik.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Saját mentett nézetek"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Új csatorna"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Eladó létrehozása sikertelen"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Duplikálási beállítások konfigurálása a(z) {0}s számára"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Egyetlen változat sem felel meg az aktuális szűrőnek."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Címek"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Új opcióérték hozzáadása a(z) {groupName} opciócsoporthoz"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Megrendelés módosítása #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Oszlop hozzáadása elé"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Csatorna nyelvei"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Opciócsoport létrehozása sikertelen"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Igaz"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Válasszon vásárlót"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Megrendelés állapota megváltozott"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Ennek a terméknek már vannak termékváltozatai, de nincsenek meghatározott opciócsoportok. Az új termékváltozatok létrehozása előtt opciócsoportokat kell hozzáadnia."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "előtte van"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Piszkozat megrendelés törlése"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Katalógus"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Új fizetési mód"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promóció sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Nem sikerült megszakítani {rejected} feladatot} other {Nem sikerült megszakítani {rejected} feladatot}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Csatorna kiválasztása"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Megjelenítési nyelv"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Teljesítés részletei"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Megmaradt készlet elvetése"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Most"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Csatornák"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Nézet sikeresen globálissá alakítva"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "előtt"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Méret"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Nem található fordítás a következőhöz: {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Új vásárló"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Legújabb megrendelések"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} további"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Használja alapértelmezett számlázási címként"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Törlés"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Letiltás"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Gyűjtemények"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Termékváltozat hozzáadása"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Ország létrehozása sikertelen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Országok"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Termékopciók létrehozása sikertelen"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Nézet átnevezése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Elérhető"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normál"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Szűrők"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Vásárlói csoportok"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Vásárlók"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Mintaformázás"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Új opció"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Felhasználási korlát"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Globális beállítások betöltése..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Cím sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Létrehozva"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Címek betöltése..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Válasszon célgyűjteményt, ahová a következőt áthelyezi: {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Vásárló adatai frissítve"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "nincs benne"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Alkalmaz"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Új termékopció"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Ugrás az utolsó oldalra"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Mégse"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "A termékváltozat sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Visszatérítés ezzel a módszerrel"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Irányítószám"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Először adjon hozzá termékopciókat"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Új adókategória"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Opció hozzáadása"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Részleges visszatérítés elvégezve"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Egyéni mezők beállítása"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Gyűjtemények"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Variáns törlése"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Nem történt módosítás"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Alapértelmezett szállítási zóna"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Ok:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Szállítási cím"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Átváltás erre: {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Adókategóriák"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "A privát gyűjtemények nem láthatók az áruházban"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Ha engedélyezve van, a termék elérhető az áruházban"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Az ütemezett feladat nem hajtható végre"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Vásárlói csoportok"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Letiltva"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Új promóció"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Alapértelmezett szállítási cím"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Visszatérítés szükséges"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Megrendelés teljesítése"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Nincs jogosultsága a csatornabeállítások megtekintéséhez"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Utolsó 30 nap"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Nincsenek tulajdonságértékek"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "A visszatérítés okának megadása kötelező"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Nem sikerült eltávolítani az opciócsoportot"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Adókategória frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "A visszatérítés sikeresen rendezve"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Frissítés"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "2. fejléc"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Megrendelés leadva"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profil sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Fizetési mód"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Termékváltozat sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Szűrés gyűjtemény neve szerint"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Megjegyzés hozzáadva"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Válassza ki a teljesítendő mennyiségeket és konfigurálja a teljesítési kezelőt"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Számlázási cím eltávolítva a megrendelésről"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Kezdés időpontja"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplikálás"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Nincs eredmény"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Oszlopbeállítások"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Nem sikerült törölni {count} készlethelyet} other {Nem sikerült törölni {count} készlethelyet}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Kód"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Nem sikerült eltávolítani az opciócsoportokat"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Megrendelés kézbesítve"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Átvitel ide: {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Megmaradt készlet"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Eltávolítás a zónából"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Válasszon a csatorna számára globálisan elérhető nyelvek közül"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Biztosan törli ezt a címet?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Nem sikerült hozzárendelni az opciócsoportot"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Média frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Raktárhely sikeresen frissítve"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Művelet megerősítése"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Ország sikeresen frissítve"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Tulajdonságok"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Megjegyzés hozzáadása sikertelen"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Megjegyzés törlése sikertelen"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "A lekérdezési dokumentum kiterjesztése sikertelen"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Megjegyzés frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Szállítási díj visszatérítése"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Csak olvasható"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Globális nézet másolása sikertelen"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "{total} elemből {shown} megjelenítve • {selected} kijelölve"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Szállítási mód tesztelése"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Tulajdonságértékek"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Média sikeresen frissítve"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Téma"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} vásárló"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Nyelv kiválasztása"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Kijelentkezés"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Kísérletek"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Elérhető pénznemkódok"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Elérhető nyelvkódok"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Navigációs útvonal"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Kategória"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Csatornák"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Alelemek"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Kód"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Kuponkód"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Létrehozva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Pénznemkód"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Vásárló"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Vásárlói csoport"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Vásárlók"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Egyéni mezők"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Adatok"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Alapértelmezett pénznemkód"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Alapértelmezett nyelvkód"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Alapértelmezett szállítási zóna"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Alapértelmezett adózóna"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Leírás"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Időtartam"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "E-mail cím"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Engedélyezve"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Végdátum"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Hiba"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Kiemelt média"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Keresztnév"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Teljesítési kezelőkód"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Alapértelmezett"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Privát"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Rendezett"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Vezetéknév"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Név"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Megrendelés dátuma"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "Szülő ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Vásárlónkénti felhasználási limit"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Jogosultságok"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Pozíció"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Ár"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Árak tartalmazzák az adót"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Ár adóval"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Termékváltozatok"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Folyamat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Sor neve"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Eredmény"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Újrapróbálkozások"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Eladó"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Rendezés dátuma"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Szállítási sorok"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Kezdés dátuma"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Kezdés időpontja"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Állapot"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Készletszintek"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Összesen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Összesen adóval"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Típus"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Frissítés dátuma"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Felhasználási limit"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Felhasználó"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Érték"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Értéklista"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zóna"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Módszer"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Adó összesítő"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Beállítja az összes csatorna számára elérhető nyelveket. Az egyes csatornák ezután ezen nyelvek egy részét támogathatják."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Gyűjtemények sikeresen áthelyezve"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Regisztrált"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Feladat megszakítása"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Végdátum"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "{0}. oldal / {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Kulcs"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Méret, szín stb."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Tulajdonságok böngészése"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zóna"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Törölve"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Létrehozva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Kézbesítve"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Függőben"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Elküldve"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Nézet mentése"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} kijelölve"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Opciócsoportok keresése..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Megrendelés módosítása"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Kiválasztott elemek"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Értékek"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Vásárló beállítva a megrendeléshez"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Tulajdonságok"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Biztosan eltávolít {count} ügyfelet ebből a csoportból?} other {Biztosan eltávolít {count} ügyfelet ebből a csoportból?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Aktuális készlet"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "A keresési index újraépítése nem indítható el"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Szállítási cím"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Új zóna"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Új API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Oszlop törlése"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Meglévő hozzárendelése"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "üres"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Ezek a <0>{customerGroupName}</0> vásárlói csoport tagjai."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Globális nézetek kezelése"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Alapértelmezett csatorna"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Új kép beszúrása forrással, címmel és méretekkel"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Tulajdonságérték létrehozása sikertelen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Termékopció frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Kuponkód"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Vásárló hitelesítve"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Általános beállítások"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Ütemezés"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Gyűjtemény nem helyezhető át saját leszármazottjába"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Új adókategória"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Nem érhető el raktárhely a jelenlegi csatornán"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "A csatorna sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Vásárló sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Adatok megtekintése"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Nézet törlése"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Új cím hozzáadása a vásárlóhoz."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "További nézetek"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "A kiválasztott kép tulajdonságainak szerkesztése"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "\"{viewName}\"  nézet alkalmazva"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} tulajdonság sikeresen eltávolítva a csatornából"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Új termék"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Új média"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Szállítási díj újraszámítása"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Válassza ki, mely beállítások vonatkozzanak a meglévő \"{0}\" termékváltozatra."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Média"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Ez eltávolítja az összes opciócsoportot ebből a termékből és visszatér a variáns beállítási lehetőséghez."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Számlázási cím"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Tulajdonságérték hozzáadása"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Kérjük, válasszon célgyűjteményt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Tekintse át a változtatásokat, mielőtt alkalmazza azokat a megrendelésre."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Szerepkör kiválasztása"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Megrendelés törölve"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Kedvezmény"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Minden típus"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Csak piszkozat megrendelések teljesíthetők"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Termék frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "{0} sor módosítása"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Tulajdonságértékek hozzáadása"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "után"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Csatorna"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Állapotfigyelés"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Összeg"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Telefonszám"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Új vásárló"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Kép"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "A rendszergazda sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Termékopciók"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Válasszon országot"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Létrehozás..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Biztosan törli ezt a globális nézetet? Ez a művelet nem vonható vissza, és minden felhasználót érint."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Opciócsoport kényszerített eltávolítása"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Hozzáadva"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Vásárló előzményei"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "{entityIdsLength} {entityType} tulajdonságértékei sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Vásárló eltávolítása a csoportból sikertelen"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Rendszer"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Vásárlónkénti felhasználási korlát"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Számlázási cím módosítva"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Válasszon egy lehetőséget"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Másolás személyes nézetbe"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "A visszatérítés összege meghaladja a maximálisan visszatéríthető {0} összeget"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Globális nézet törlése"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Létrehozás"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Minden 30 másodpercben"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Új ország"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "{0}-tól {1}-ig"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Vásárló létrehozása sikertelen"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Fókuszpont frissítve"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Opcióértékek"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Alapértelmezett számlázási cím"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Nincs vásárló"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Országok eltávolítása a zónából sikertelen"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Promóció létrehozása sikertelen"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Ma"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Tegnap"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Opció neve"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Biztosan eltávolítja a következőt: {0} {1} ebből a zónából?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "{0} felár hozzáadása"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Link href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Tartalék: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Megrendelési előzmények"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Felülbírálás"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "A tranzakció ID megadása kötelező"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "reguláris kifejezésre illeszkedik"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "A globális nézet sikeresen átnevezve"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Nincs kiválasztott címke"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Vissza"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Nézet sikeresen átnevezve"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Szűrő alkalmazása"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Utolsó eredmény"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Csoporthoz adva"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Elemzések"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Termékváltozatok létrehozása"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Szállítási mód tesztelése folyamatban..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Sötét"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Teszteredmények"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Vásárló hozzáadása"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Változtatások mentése"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Cím frissítve"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "A visszatérítés sikeresen feldolgozva"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Új zóna"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Gyűjtemény pozíciójának frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Visszatérítés"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Módosítás"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Nincsenek globális nyelvek beállítva"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "{0} tétel eltávolítása"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Nyomon követés"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Termékváltozat létrehozása"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Tulajdonságértékek: {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Elrendezés mentése"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Jelszó-visszaállítás megerősítve"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Nézet törlése sikertelen"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Biztosan elhagyja ezt az oldalt? A nem mentett módosítások elvesznek."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Fejlécoszlop be-/kikapcsolása"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Új promóció"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Opcióérték neve"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Utoljára használva"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Ez az alapértelmezett adókategória"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "A slug be van állítva"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "A fókuszpont frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zóna sikeresen frissítve"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Állam/Tartomány"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Nem sikerült frissíteni az opciócsoportot"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Csatorna alapértékei"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Adókategória létrehozása sikertelen"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Szűrési feltételek beállítása a(z) {columnId} oszlophoz"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Ország"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Egyszerű termék"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Feladatsor"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Kérjük, erősítse meg, hogy elmentette az API key-t a bezárás előtt."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Törlés megerősítése"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Megrendelés módosítása sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "{taxRate}% adót tartalmaz"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Megrendelési statisztikák"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Válasszon megjelenítési nyelvet"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Hitelesítési módszerek"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "kezdés"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Nem sikerült rotálni az API key-t"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "ebben"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Szerepkörök keresése..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Termékváltozatok"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Globális nézetek kezelése"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Feldolgozás..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} találat"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Válasszon dátumtartományt"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Termék"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "API Key rotálása"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Kategória"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Áthelyezés..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Hozzárendelés"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Az eladó sikeresen létrehozva"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Szállítási mód sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Termékváltozat frissítése sikertelen"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Húzza az átrendezéshez"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zónák"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Válassza ki, mi történjen a törlésre kijelölt {count, plural, one {# készlethelyen} other {# készlethelyen}} maradt készlettel. Minden kijelölt hely a megmaradt készletét az Ön által választott egyetlen helyre viszi át, vagy elveti azt."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Tulajdonságértékek keresése..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Megjegyzés"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Elérhető nyelvek"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "{0} további betöltése ({remaining} maradt)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Tulajdonságértékek"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Elemek átrendezése sikertelen"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Megrendelések összesen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Nem található megfelelő szállítási mód ehhez a megrendeléshez."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Termékopció hozzáadása"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Szállítás"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "A useWidgetDimensions csak DashboardBaseWidget-en belül használható"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Ez az opciócsoport meglévő változatok által használatban van. A kényszerített eltávolítás hatással lehet azokra a változatokra. Biztosan folytatja?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "E-mail frissítés kérve"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Hiba az állapotváltás során"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "A vásárlói csoport sikeresen létrehozva"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Új ablak"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Fizetés engedélyezve"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Szerepkör sikeresen frissítve"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Ország kiválasztása"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Szállítási mód frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} készlethely törölve} other {{deleted} készlethely törölve}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Szállítási módok"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Válasszon egy címet"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Igen"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Fókuszpont beállítása"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "vége"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Pénznem kiválasztása"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "A megjegyzés tartalmának vagy láthatóságának módosítása"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Legújabb megrendelések widget"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "A(z) {collectionName} gyűjtemény tartalma"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Szállítási mód megváltoztatva"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Adó leírása"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "kisebb vagy egyenlő mint"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "nem egyenlő"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Frissítés"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "pl. Méret"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Fizetés rendezése"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Csatornák"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Szállítás visszatérítve"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Eszköztípus"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Új raktárhely"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} fizetés visszatérítve a hiba előtt. A részletekért tekintse meg a megrendelés előzményeit."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Válasszon elemet"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Új termék"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Címkék kezelése"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Visszatérített tételek"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Művelet hozzáadása"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Opciók hozzárendelése meglévő termékváltozathoz"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "{0} másolása"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Eltávolítás a csoportból"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Teljesítési állapot frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Új termékvariáns létrehozása opciókkal, árazással és készlettel"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "A privát tulajdonságok nem láthatók az áruházban"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Adókategória kiválasztása"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Nem fut"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Hozzárendelve"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "1. fejléc"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Válasszon elérhető nyelveket"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "{0} tétel hozzáadása"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Sor hozzáadása utána"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Adó összesen"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Piszkozat megrendelés állapota"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "A termékopciók sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Helyek betöltése…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Fizetési mód létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "A tulajdonságérték sikeresen létrehozva"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Piszkozat megrendelés törölve"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "nagyobb mint"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Statisztikák widget"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Pénznemek keresése..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Eltávolítás a csatornából"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Cím"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Kép beszúrása"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Eladó frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Az ország sikeresen létrehozva"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Válasszon eladót"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Címkék betöltése..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "A tulajdonság sikeresen létrehozva"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} termékváltozat"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Fizetés rendezése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Nincs számlázási cím"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Nem sikerült törölni {1} készlethelyet} other {Nem sikerült törölni {2} készlethelyet}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Tulajdonság"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Nem távolítható el az aktív csatornából"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Nincs beállítva"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Kényszerített eltávolítás"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Új csatorna"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Opciócsoport neve"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "ÉS"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Vásárlói csoport létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Szerepkör létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Terméknév"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Teljesítési állapot sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Termékek"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Cím létrehozva"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API key sikeresen rotálva"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Opciócsoport hozzáadása"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "{0} visszatérítése"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Adja meg a slug-ot manuálisan"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Nincsenek elérhető widgetek"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Fizetés törlése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Fizetés sikeresen visszavonva"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "A globális nézet sikeresen duplikálva"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Létrehozta"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Változatok szűrése..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Ár hozzáadása másik pénznemben"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "E-mail cím vagy azonosító"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "#{0} visszatérítés állapota {1} értékre változott"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Vásárlók"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "4. fejléc"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Raktárhely frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Megrendelés elküldve"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Cím mentése"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Globálissá tétel"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Válassza ki a következő állapotot"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Nincsenek értesítések"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "{0} gyűjtemény{1} áthelyezése ide: {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Teszt"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "között"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Megjegyzés sikeresen hozzáadva"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Megjegyzés sikeresen törölve"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Megjegyzés sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Visszatérítés rendezése sikertelen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Készletszint"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Tétel hozzáadása"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API key sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Előnézet betöltése…"
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Vissza a kereséshez"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Nézet sikeresen másolva"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Opciócsoport eltávolítása"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Leírás"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Országok"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Utca, házszám 2."
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "A globális nézet sikeresen törölve"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Elrendezés szerkesztése"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Hozzárendelés csatornához"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Ez a hét"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "A termékopció-csoport sikeresen létrehozva"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Manuális fizetés hozzáadása: {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "szerepel"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-mail"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Rendszergazda frissítése sikertelen"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Személyes mentett nézetek kezelése ehhez a táblázathoz"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Szűrés címkék szerint"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Bejelentkezés az adminisztrációs felület eléréséhez"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Fizetés hozzáadása a megrendeléshez ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Hamis"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Világos"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Visszaállítás"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "egyenlő"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Opciók létrehozása"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Jelszó frissítve"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "nem tartalmazza"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Opciócsoport"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Szerkessze az alábbi cím adatait."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Az adókategória sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Gyűjtemények áthelyezése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Fizetési állapot frissítése sikertelen"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Megrendelései összesítése"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Feltöltés"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Termék opciókkal"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Összes {0} találat megjelenítve"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Keresési azonosító"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} további"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Opciócsoportok"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Egyéni mezők"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Az összes lehetséges rendelési állapot és azok átmenetei. A jelenlegi állapot ki van emelve."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Megrendelések"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Megrendelések összesítő widget"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Tételek hozzáadása"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Pótlólagos fizetés intézése"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Fizetés intézése"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Törölve"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Létrehozva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Teljesítve"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Piszkozat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Módosítás alatt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Részben teljesítve"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Részben kiszállítva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Fizetés jóváhagyva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Fizetés teljesítve"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Kiszállítva"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Figyelt erőforrások"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Entitás adatai"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Megrendelés összege"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Csak rendszergazdák számára látható"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Menny."
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Címkék"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Szuper adminisztrátor"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Egyes erőforrások nem érhetők el"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Elérhető műveletek"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Link beszúrása"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Ha engedélyezve van, a szűrők a szülő gyűjteményből öröklődnek, és kombinálódnak az ezen a gyűjteményen beállított szűrőkkel."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Válasszon zónát"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Szállítási módok tesztelése"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Fizetés sikeresen teljesítve"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} eltávolítva a zónából"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Engedélyezés"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Fizetési módok"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Jóváhagyva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Visszavonva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Létrehozva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Elutasítva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Hiba"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Sikertelen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Függőben"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Rendezve"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Átlagos megrendelési érték"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Zóna létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Készletszintek"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Nem sikerült frissíteni az API key-t"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Megrendeléssorok"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Globális nézet átnevezése sikertelen"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Új hivatkozás beszúrása URL-lel és célbeállításokkal"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Magasság"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} összegű visszatérítés szükséges. A folytatáshoz válassza ki a fizetési összegeket és adjon meg egy megjegyzést."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Egységár"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Ütemezési minta"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Fizetés sikertelen"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Csatorna hozzáadása"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Termékopció-csoport frissítése sikertelen"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Csatornák keresése..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Vásárlói csoportok hozzáadása"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Elérhető nyelvek"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Kijelölés visszaállítása"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Nincs cím"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "A fizetési mód sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Vásárló adatai frissítve"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Nézet globálissá alakítása sikertelen"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Termékváltozatok"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Termékek"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promóciók"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Termékopció létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Régi e-mail cím:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Mentsen egy nézetet \"Globális\"-ként, hogy az összes felhasználó számára elérhető legyen."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Nem sikerült létrehozni a variánsokat"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Beállítja azt a készletszintet, amelynél ez a termékváltozat készleten kívülinek minősül. Negatív érték használata lehetővé teszi az utórendelés támogatását. Felülírható termékváltozatok által."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Kulcs rotálása"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Nem sikerült létrehozni a termékváltozatokat"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Jelszó elrejtése"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Új eladó"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "pl. Piros, Nagy, Pamut"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Profil frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Kuponkódok eltávolítva"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Szűrő törlése"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Régiók"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Húzza ide a fájlokat a feltöltéshez"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Az összes látható változat ki-/bekapcsolása"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Ellenőrzött"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Új opciócsoport"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Utoljára frissítve: {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Még nem lett globális nézet létrehozva."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Szerepkör frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Ez az egyetlen alkalom, amikor a teljes API key megjelenik. Másolja ki vagy töltse le most — később nem lehet lekérni."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Gyűjtemény sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Fizetési mód sikeresen frissítve"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Nézet sikeresen törölve"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Opciócsoport: {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "VAGY"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Címkék kezelése"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Kuponkód eltávolítva a megrendelésből"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Soha"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Tulajdonságérték frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Csoport eltávolítása"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Megrendelés teljesítve"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Nincs szállítási cím"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "A lekérdezés-kiterjesztés érvénytelen GraphQL szintaxist tartalmaz"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Lekérdezés-kiterjesztési hiba"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Lekérdezés-kiterjesztési hiba:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "A lekérdezés-kiterjesztés érvénytelen: legalább egy felső szintű mezőt kell tartalmaznia"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Lekérdezés-kiterjesztési eltérés:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "nyilvános"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Adókategória sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Áthelyezés"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Meglévő címkék szerkesztése vagy törlése"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Ennek a szállítási módnak a jogosultsági feltételei nem teljesülnek az aktuális megrendelés és szállítási cím esetén."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Kuponkód hozzáadása"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Kuponkód beállítva a megrendeléshez"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Egyéni mezők"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Új szállítási mód"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Készlethelyek törlése"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "nagyobb vagy egyenlő mint"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Előnézet"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} / {1} teljesíthető"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Hónap elejétől"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Vásárlói kérés"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Szállítás során megsérült"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Nem elérhető"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Egyéb"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Téves termék"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Módosítások összefoglalása"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Visszatérítések ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Utoljára végrehajtva"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Fizetés részletei"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Keresési index újraépítése"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Futás alatt"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Minden 60 másodpercben"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Vásárlói csoport frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Fizetés metaadatai"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Módosítás megszakítása"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Ugyanabban az ablakban"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Alkalmazzon szűrőket a táblázatra, majd kattintson a „Nézet mentése\" gombra a kezdéshez."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Szerepkörök"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Pótlólagos fizetés szükséges"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Megrendelés frissítése sikertelen"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Kijelöltekkel..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Raktárhely létrehozása sikertelen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "kisebb vagy egyenlő"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "A(z) {customerGroupName} vásárlói csoport tagjai"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Állapot"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Ne kövesse nyomon"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "#{0} teljesítés létrehozva"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Függő keresési index frissítések futtatása"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Ez egy alapértelmezett szerepkör, és nem módosítható"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Saját mentett nézetek"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Állam / Tartomány"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Elemek oldalanként"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Tagok szerkesztése"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Aktuális készlet"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Szűrés: {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Értesítések"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Opcióértékek"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Módosítások előnézete"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Nem sikerült eltávolítani a(z) {entityType} elemet a csatornából"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Termékváltozat sikeresen törölve"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "A kiválasztott hivatkozás tulajdonságainak szerkesztése"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Értékesítés"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Célgyűjtemény kiválasztása"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Legújabb megrendelései"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Ütemezett feladatok"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Biztosan törli ezt az elemet? Ez a művelet nem vonható vissza."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Termékváltozatok"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Eladók"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Beállítások"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Beállítástár"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "3. fejléc"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Üdvözöljük a Vendure-ban"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Szállítási módok"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} visszatéríthető)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Azonosító"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Gyűjtemény frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Ár és adó"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Megrendelés nem található"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Hiba"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Megrendelés módosítva"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Jelszó-visszaállítás kérve"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "A lefoglalt fizetési összegnek egyenlőnek kell lennie a visszatérítés végösszegével"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "pl. Kis"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Biztosan eltávolítja a következőt: {0} {entityType} az aktuális csatornából?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Címkék hozzáadása..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Termékopció-csoport létrehozása sikertelen"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} elem kijelölve"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Nyelvek keresése..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Raktárhelyek"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Ugrás az előző oldalra"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Tartalom"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Globális nézet személyes nézetté alakítása sikertelen"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "A feladat eredménye"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Fizetés hozzáadása ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Rendszer"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Termékváltozat neve"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Eltávolítás"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Vásárló frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Opciócsoportok eltávolítása?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Ez a gyűjtemény tartalmának előnézete az aktuális szűrőbeállítások alapján. A gyűjtemény mentése után a tartalom frissül az új szűrőbeállításoknak megfelelően."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} ügyfél eltávolítva a csoportból} other {{count} ügyfél eltávolítva a csoportból}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Adókategóriák"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Adókulcsok"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Nem sikerült eltávolítani az ügyfeleket a csoportból"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Globális beállítások betöltése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Válassza ki a visszatérítendő elemeket, és szükség esetén adja vissza őket a készletbe"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Mentés"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} / {0} sor kiválasztva."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Megrendelés-módosítások előnézete"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Termékopció-csoport sikeresen frissítve"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Az oldal az alapértelmezett lekérdezéssel folytatódik."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Utca, házszám"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Nincs több tulajdonság"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "A keresési index újraépítése elindult"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Gyűjtemény pozíciója frissítve"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Opciócsoport neve"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "\"{newOptionInput}\" hozzáadása"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Új termékváltozat"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Visszatérítés állapota megváltozott"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Natív hitelesítési stratégia használata"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} csatornához rendelése sikertelen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Alapértelmezett nyelv"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Teljesítés folyamatban..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Opciócsoport hozzáadása a termékhez"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "{0} előnézete"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Eladó sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Megrendelés állapotváltása sikertelen"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Összes megjelenítése ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Adókulcs létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Elmentettem ezt az API key-t"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Konfigurálja az áruháza és csatornái számára elérhető nyelveket"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "A termék sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Termékváltozat hozzáadása"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Írjon, majd nyomjon Entert vagy vesszőt a hozzáadáshoz..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Megjegyzés szerkesztése"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Nem találhatók eszközök. Próbálja módosítani a szűrőket."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Opció hozzáadása"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Opciócsoport mentése"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "{createCount} termékváltozat létrehozása"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Kattintson a \"Teszt futtatása\" gombra a szállítási mód teszteléséhez."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Rendszergazda sikeresen frissítve"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Szűrők törlése"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "#{0} teljesítés: {1}-tól {2}-ig"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Globális nézet törlése sikertelen"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Alapértelmezett nyelv"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Státusz"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Nincs találat"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Bináris"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Opciócsoport sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Új szállítási mód"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Minden 10 másodpercben"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "adó nélkül:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Készlet hozzáadása helyszínhez"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Az opcióérték sikeresen hozzáadva"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Gyűjtemény áthelyezve új szülőelembe"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Opciócsoport eltávolítva"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Átváltás a kiválasztott állapotra"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Pótlólagos fizetés szükséges: {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Készlet nyomon követése alapértelmezetten"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{total} elemből {selected} kijelölve"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "A szállítási mód sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Új vásárlói csoport"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Vásárló számára látható"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Az opciócsoport sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Adókulcsok"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "A slug automatikusan generálódik..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Vásárló nem található"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "{0} kiválasztása"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Hozzáadandó új tulajdonságértékek:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Visszatérítés feldolgozása sikertelen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Keresztnév"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "tartalmaz"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Nem találhatók opciócsoportok"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Nem található elem"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Részösszeg"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Teljesített tételek ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Érték frissítve"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Nem ellenőrzött"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Mennyiség"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Szűrő hozzáadása"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Adókategória"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "A tesztadatok frissültek. Kattintson a \"Teszt futtatása\" gombra a frissített eredmények megtekintéséhez."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "nem szerepel"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Megrendeléssor frissítve"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Új fizetési mód"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "A(z) \"{trimmed}\" duplikált érték már létezik"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Ok"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Vásárlói csoportok"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} sikeresen eltávolítva a csatornából"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Opciócsoportok"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Felár hozzáadása"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Jelenlegi tulajdonságértékek"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "{page}. oldal / {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Előző hónap"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Ország hozzáadása"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Elem eltávolítása"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Videó"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "kisebb mint"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "A termékváltozat nem adható hozzá. Győződjön meg arról, hogy a szülő termék engedélyezett."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Ismeretlen hiba történt"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Mutatók"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Nyelv"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Új gyűjtemény"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Megrendelés visszatérítése és törlése"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "E-mail frissítés megerősítve"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "közötte van"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Visszatérítés és törlés"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Szállítási módok tesztelése folyamatban..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Szállítási mód létrehozása sikertelen"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} sikeresen hozzárendelve a csatornához"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Globális nyelvek"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Új rendszergazda"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Piszkozat törlése"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Forrás"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Nincs elérhető művelet"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Csatorna frissítése sikertelen"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Általános"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Termék eltávolítása a csatornából sikertelen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Új cím hozzáadása"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Tulajdonság sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zóna sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Érték"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Vásárló frissítve"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Árátváltási tényező"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Eladói megrendelés"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Új tulajdonság"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Biztosan el szeretné távolítani ezt az opciócsoportot a termékből?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Leírás (alt)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Nem található címke"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Alapértelmezett pénznem"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Ezekhez a módosításokhoz nem szükséges fizetés vagy visszatérítés."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Teljes bevétel"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Következő végrehajtás"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "A megjegyzés privát"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Közepes dátumformátum"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Érvénytelen szám"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Még nem mentett egyetlen nézetet sem."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Biztosan törli ezt a nézetet? Ez a művelet nem vonható vissza."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Rendelési folyamat megtekintése"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Nézet másolása sikertelen"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Használja alapértelmezett szállítási címként"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Slug manuális szerkesztése"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Adjon meg szűrőket a gyűjtemény tartalmának előnézetéhez."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Termékopció-csoport"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Részösszeg"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "kisebb mint"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "Visszatérítés ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "A megrendelés egyéni mezői frissítve"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Kalkulátor"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Nem sikerült eltávolítani az opciócsoportot a csatornából: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Feladat adatainak megtekintése"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Áthelyezés a legfelső szintre"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Törlés"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Megrendelések összesítése"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Eszközök keresése..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Új tulajdonság"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "{entityType} hozzárendelése csatornához"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Folytatás"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promóciók"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Hibaüzenet"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Készletszint hozzáadása másik helyszínhez"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Cím törlése"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Tulajdonság frissítése sikertelen"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "A useWidgetFilters csak WidgetFiltersProvider-en belül használható"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Cím szerkesztése"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Tulajdonság eltávolítása a csatornából sikertelen: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Hivatkozás beállítása"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Új eladó"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Kép szerkesztése"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Termékváltozatok kezelése"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Lefoglalt készlet"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "nagyobb vagy egyenlő"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Beállítja azt a készletszintet, amelynél ez a termékváltozat készleten kívülinek minősül. Negatív érték használata lehetővé teszi az utórendelés támogatását."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Termékopciók létrehozása"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Mentés..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Eredmény megtekintése"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Sorok oldalanként"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Gyűjtemények betöltése..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Tulajdonságérték sikeresen frissítve"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Média hozzáadása"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Vásárló hozzáadva a csoporthoz"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Eladói megrendelések"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Opcióérték hozzáadása sikertelen"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Opcióérték hozzáadása ehhez: {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} tétel visszatérítve"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Még nincsenek opciócsoportok megadva. Adjon hozzá opciócsoportokat a termék különböző változatainak létrehozásához (pl. Méret, Szín, Anyag)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Új e-mail:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Fizetési mód frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Elérhető:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Létrehozva"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Termékváltozat létrehozása sikertelen"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Nyelv: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Nincs jogosultsága a globális nyelvbeállítások megtekintéséhez"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Az adókulcs sikeresen létrehozva"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "6. fejléc"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Kuponkódok hozzáadva"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Aktív"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Adóalap"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Több betöltése"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Visszatérítés rendezve"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} sikeresen megkettőzve"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Új opciócsoport"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Még nincs eredmény"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Fizetés teljesítve"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Elérhető feltételek"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Aktív szűrők"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Összes törlése"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "nagyobb mint"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Bezárás"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Fizetés hozzáadása a megrendeléshez"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Betöltés..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "A token a csatorna megadására szolgál API kérések küldésekor."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Nem található cím"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "Teljesítés ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Válassza ki a visszatérítendő fizetéseket"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "{failed} {entityName} törlése sikertelen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Készlethiány küszöbértéke"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Termék sikeresen eltávolítva a csatornából"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Nem sikerült frissíteni az értéket"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Nem sikerült létrehozni az API key-t"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Visszatérítés rendezése"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Fizetési mód megadása kötelező"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Vásárló csoporthoz adása sikertelen"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Termékváltozatok kezelése"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "\"{viewName}\"  globális nézet alkalmazva"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Vásárló regisztrálva"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zónák"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Eladók keresése..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "A promóció sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Opció"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Rendelési folyamat"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Telefonszám"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privát"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Termékváltozat"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Általános beállítások sikeresen frissítve"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API key sikeresen frissítve"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Ezek a nyelvek minden csatorna számára elérhetők lesznek"

--- a/packages/dashboard/src/i18n/locales/it.po
+++ b/packages/dashboard/src/i18n/locales/it.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Nome completo"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Seleziona articoli"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Visualizza modifiche"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Codice di tracciamento"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "I permessi selezionati saranno applicati a questi canali."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Opzioni prodotto"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Nuova aliquota fiscale"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Assegna un gruppo di opzioni esistente o creane uno nuovo"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Nuovo ruolo"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Appartamento, suite, ecc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Nessun altro articolo"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Modifica link"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Aggiungi almeno un articolo all'ordine"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Aggiungi prodotti per creare un ordine di prova"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Impossibile creare indirizzo"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Attiva/Disattiva tutto"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Modifica valore JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Utilizzo strategia di autenticazione esterna: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Seleziona un motivo..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Intestazione 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Impossibile aggiungere pagamento"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Aggiornato"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Impossibile aggiornare impostazioni globali"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Ordine evaso con successo"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Sei sicuro di voler eliminare {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Soglia globale esaurimento scorte"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Gestisci lingue"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Duplicazione in corso... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Eliminato con successo"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Rimuovi dal canale corrente"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Eliminati {selectionLength} file"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Aliquota fiscale aggiornata con successo"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Inserisci un motivo personalizzato..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Tipo"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Seleziona {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Visualizza valori"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Elimina riga"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Condizioni"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Corrente"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Nessuna evasione"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Impossibile eliminare {1} ubicazione di magazzino: {messages}} other {Impossibile eliminare {2} ubicazioni di magazzino: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Quando abilitato, i prezzi inseriti nel catalogo prodotti includeranno l'IVA per la zona fiscale predefinita."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Crea varianti per il tuo prodotto"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Bozza ordine completata"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Aggiornamento automatico: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Controlli stato"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Eliminato {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Controlli di stato"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Venditori"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Opzioni"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} processo annullato correttamente} other {{fulfilled} processi annullati correttamente}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Venditore"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "Cod. Art.:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Aggiungi pagamento"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Testa questo metodo di spedizione simulando un ordine per vedere se è idoneo e quale sarebbe il costo di spedizione."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Esplora Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Ubicazioni stock"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Gestore evasione"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Ordini"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Seleziona ruoli"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Ruolo creato con successo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Sei sicuro di voler eliminare questa variante?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Tutte le risorse sono attive"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Creazione amministratore non riuscita"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "No"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Variante prodotto aggiornata con successo"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Impossibile eliminare {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Prodotto aggiornato con successo"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Impossibile aggiornare paese"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Digita almeno 2 caratteri per cercare..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Cognome"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Titolo link"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Gruppo clienti aggiornato con successo"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Campi personalizzati modificati"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Ubicazione magazzino creata con successo"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Errore sconosciuto"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Il totale del rimborso non può essere negativo"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Visualizza dettagli"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Seleziona un canale a cui assegnare {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Cliente creato con successo"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Ultimi 7 giorni"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Impossibile creare canale"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Modalità sviluppatore"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Nuovo ruolo"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Impossibile eliminare file: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Restituisci a magazzino"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Visibilità"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Varianti prodotto"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Nuovo gruppo clienti"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Crea \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Rinomina"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Scegli la tua lingua di visualizzazione e le impostazioni locali preferite"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} gruppi di opzioni rimossi dal canale con successo"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Il metodo di spedizione non è idoneo per questo ordine"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Impossibile aggiornare indirizzo"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Indirizzo eliminato con successo"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Aliquota fiscale"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "La bozza dell'ordine non è pronta per essere completata"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Nuova collezione"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Approfondimenti"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Esegui"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Impossibile aggiornare aliquota fiscale"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Questo è il contenuto della collezione <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privato"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Opzione prodotto creata con successo"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Prodotto principale"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Città"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Amministratori"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Prezzo lordo: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Vai alla pagina successiva"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Rimuovi link"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Questo campo è di sola lettura"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Numero di ordini"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Ordine aggiornato con successo"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Eredita filtri"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Gestisci le viste salvate globali visibili a tutti gli utenti"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Cerca metodi di pagamento..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Indirizzo di spedizione rimosso per l'ordine"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Crea {enabledCount} varianti"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Pagamento #{0} transitato a {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Errore caricamento cronologia cliente: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} rimossi dal canale con successo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Aggiungi valore opzione"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Impostazioni globali"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "è dopo"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Opzione prodotto aggiornata con successo"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Modifica valori attributo"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Aggiunta in corso..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Sposta collezioni"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Ruoli"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Vista a griglia"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Impossibile eliminare indirizzo"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Nessun metodo di spedizione disponibile"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Vista globale convertita in vista personale con successo"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Evasione transitata"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Sei sicuro di voler eliminare {selectionLength} file?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Accedi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Vista ad elenco"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Ordine di prova"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Seleziona un cliente per continuare"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Gruppo di opzioni assegnato con successo"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Esegui test"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Aliquota fiscale: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Aggiungi prodotti e completa l'indirizzo di spedizione per eseguire il test."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Attiva/Disattiva riga intestazione"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Seleziona indirizzo"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Controllo idoneità pagamento"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Zona fiscale predefinita"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "La bozza dell'ordine è pronta per essere completata"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadati"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtra..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Nuovo valore attributo"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Canale aggiornato con successo"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Mostra meno"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Data breve"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Valute disponibili"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Seleziona {0} articoli"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Effettuato il"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "La rotazione di questa chiave invaliderà immediatamente la chiave attuale. Qualsiasi integrazione che la utilizza smetterà di funzionare finché non verrà aggiornata con la nuova chiave."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "I dati che sono stati passati al lavoro"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Conferma navigazione"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Destinazione link"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Completa bozza"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Nome"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Impossibile evadere ordine"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Totale"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Inserisci l'ID transazione per questo completamento rimborso"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "La tua chiave API"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Sei sicuro di voler eliminare questa bozza di ordine?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Evasione creata"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Trovato/i {0} metodo/i di spedizione idoneo/i"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Dimensioni"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Mostra password"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(max: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Azienda"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Aggiungi colonna dopo"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Azioni"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Sconti"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Inserisci nota rimborso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Riga ordine rimossa"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Contenuto:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Chiave"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Conferma"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Impossibile creare collezione"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Vai alla prima pagina"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Impossibile creare prodotto"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Cliente"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Errore caricamento cronologia ordine: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Indirizzo di spedizione impostato per l'ordine"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Punto focale"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Variante singola, senza opzioni"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Seleziona lo stato successivo per l'ordine"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Locale"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Attività programmate"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Inserisci ID transazione"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Aggiorna dati"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Aggiungi o rimuovi valori attributo per {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Questi sono i valori attributo per l'attributo <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Pagamento aggiunto all'ordine con successo"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Indirizzo di fatturazione impostato per l'ordine"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Impossibile aggiornare zona"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Password"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Impossibile eliminare"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "L'attività pianificata sarà eseguita"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Nuova ubicazione magazzino"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Permessi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Indirizzo di spedizione modificato"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Nessun prodotto trovato"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Aggiungi riga prima"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Transizione a {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Questo mese"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Impossibile creare attributo"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Impossibile annullare gli articoli dell'ordine"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID transazione"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Allocato"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Aggiungi un altro gruppo di opzioni"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Seleziona cosa fare con le giacenze rimanenti"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Esplora Piattaforma e Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Ogni 5 secondi"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Collezione creata con successo"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Prezzo"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Bozza ordine"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Scope"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Aggiungi condizione"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Il metodo di spedizione è idoneo per questo ordine"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Amministratori"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Rimosso dal gruppo"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Larghezza"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Nessun pagamento o rimborso richiesto"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Scarica come file .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Quando abilitata, una promozione è disponibile nel negozio"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Quando tracciato, i livelli di scorta delle varianti prodotto saranno automaticamente adeguati quando venduti. Questa impostazione può essere sostituita dalle singole varianti prodotto."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Metodo di spedizione impostato per l'ordine"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Impossibile aggiornare promozione"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Immagini"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Cerca {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Modifica file"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Annulla pagamento"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Coda lavori"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Risorse"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Indirizzo email"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Rigenera slug dal campo sorgente"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Eredita da impostazioni globali"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Nessun risultato trovato"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Stato attuale"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Imposta un indirizzo di spedizione e seleziona un metodo di spedizione"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Disattivato"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Archivio impostazioni"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Coda"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Nuova aliquota fiscale"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Pagamento transitato"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Rimanente:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Nessun duplicatore trovato con codice \"{duplicatorCode}\" per {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "I prezzi includono l'IVA per la zona fiscale predefinita"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Rimborso totale:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Visualizza risultato lavoro"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Testa i tuoi metodi di spedizione simulando un nuovo ordine."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Nessun articolo selezionato"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} selezionati"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Nessun paese trovato"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Varianti create con successo"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Genera slug automaticamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Supplemento"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Metodi di pagamento"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Scorta"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Nessun cliente trovato"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Usa soglia globale esaurimento scorte"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Nuovo gruppo opzioni prodotto"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Stato pagamento aggiornato con successo"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Crea nuovo"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Totale rimborso"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Indirizzo eliminato"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Sono disponibili solo i ruoli assegnati al tuo account."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Articolo aggiunto all'ordine"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Modifica punto focale"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Nessun venditore trovato"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Risorsa"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Questo gruppo di opzioni è utilizzato da un altro prodotto. Qualsiasi modifica avrà effetto anche su di esso.} other {Questo gruppo di opzioni è condiviso tra # prodotti.  Qualsiasi modifica avrà effetto anche su di essi.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Le mie viste salvate"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Nuovo canale"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Impossibile creare venditore"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Configura le impostazioni di duplicazione per {0}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Nessuna variante corrisponde al filtro corrente."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Indirizzi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Aggiungi un nuovo valore di opzione al gruppo di opzioni {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Modifica ordine #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Aggiungi colonna prima"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Lingue canale"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Impossibile creare gruppo di opzioni"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Vero"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Seleziona cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Ordine transitato"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Questo prodotto ha varianti esistenti ma nessun gruppo di opzioni definito. Devi aggiungere gruppi di opzioni prima di creare nuove varianti."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "è prima"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Elimina bozza ordine"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Catalogo"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Nuovo metodo di pagamento"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promozione aggiornata con successo"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Impossibile annullare {rejected} processo} other {Impossibile annullare {rejected} processi}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Seleziona un canale"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Lingua di visualizzazione"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Dettagli evasione"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Scarta le giacenze rimanenti"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Adesso"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Canali"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Vista convertita in globale con successo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "prima"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Dimensione"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Nessuna traduzione trovata per {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Nuovo cliente"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Ultimi ordini"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} altri"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Usa come indirizzo di fatturazione predefinito"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Elimina"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Disabilita"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Collezioni"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Aggiungi variante"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Impossibile creare paese"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Paesi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Impossibile creare opzioni prodotto"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Impossibile rinominare vista"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Disponibile"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normale"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtri"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Gruppi clienti"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Clienti"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Formattazione di esempio"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nuova opzione"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Limite utilizzo"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Caricamento impostazioni globali..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Indirizzo aggiornato con successo"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Creato"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Caricamento indirizzi..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Seleziona una collezione di destinazione in cui spostare {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Dettagli cliente aggiornati"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "non in"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Applica"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nuova opzione prodotto"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Vai all'ultima pagina"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Annulla"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Variante prodotto creata con successo"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Rimborso da questo metodo"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Codice postale"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Aggiungi prima le opzioni prodotto"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Nuova categoria fiscale"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Aggiungi opzione"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Rimborso parziale completato"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Imposta campi personalizzati"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Collezioni"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Elimina variante"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Nessuna modifica effettuata"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Zona di spedizione predefinita"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Motivo:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Indirizzo di spedizione"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Transizione a {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Categorie fiscali"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Le collezioni private non sono visibili nel negozio"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Quando abilitato, un prodotto è disponibile nel negozio"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "L'attività pianificata non può essere eseguita"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Gruppi clienti"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Disabilitato"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Nuova promozione"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Indirizzo di spedizione predefinito"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Rimborso richiesto"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Evadi ordine"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Non hai il permesso di visualizzare le impostazioni del canale"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Ultimi 30 giorni"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Nessun valore attributo"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "È richiesto un motivo per il rimborso"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Impossibile rimuovere il gruppo di opzioni"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Impossibile aggiornare categoria fiscale"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Rimborso completato con successo"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Aggiorna"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Intestazione 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Ordine effettuato"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profilo aggiornato con successo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "fine"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Metodo di pagamento"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Modifica"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variante aggiornata con successo"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtra per nome collezione"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Nota aggiunta"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Seleziona le quantità da evadere e configura il gestore evasione"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Indirizzo di fatturazione rimosso dall'ordine"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Inizia il"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplica"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Nessun risultato"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Impostazioni colonne"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Impossibile eliminare {count} ubicazione di magazzino} other {Impossibile eliminare {count} ubicazioni di magazzino}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Codice"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Impossibile rimuovere i gruppi di opzioni"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Ordine consegnato"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Trasferisci a {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Giacenze rimanenti"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Rimuovi dalla zona"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Seleziona tra le lingue disponibili globalmente per questo canale"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Sei sicuro di voler eliminare questo indirizzo?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Impossibile assegnare il gruppo di opzioni"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Impossibile aggiornare file"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Ubicazione magazzino aggiornata con successo"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Conferma azione"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Paese aggiornato con successo"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Facette"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Impossibile aggiungere la nota"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Impossibile eliminare la nota"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Impossibile estendere il documento query"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Impossibile aggiornare la nota"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Rimborsa spedizione"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Sola lettura"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Impossibile duplicare vista globale"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Visualizzazione di {shown} su {total} • {selected} selezionate"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Testa metodo di spedizione"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Valori attributo"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "File aggiornato con successo"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Tema"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} clienti"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Seleziona una lingua"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Disconnetti"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Tentativi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Codici valuta disponibili"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Codici lingue disponibili"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Breadcrumb"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Categoria"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Canali"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Figli"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Codice"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Codice coupon"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Creato il"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Codice valuta"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Gruppo clienti"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Clienti"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Campi personalizzati"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Dati"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Codice valuta predefinito"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Codice lingua predefinito"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Zona di spedizione predefinita"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Zona fiscale predefinita"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Descrizione"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Durata"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Indirizzo email"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Abilitato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Termina il"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Errore"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "File in evidenza"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Nome"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Codice gestore evasione"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Predefinito"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Privato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Completato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Cognome"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Nome"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Ordine effettuato il"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID genitore"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Limite utilizzo per cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Permessi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Posizione"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Prezzo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "I prezzi includono l'IVA"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Prezzo con IVA"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Varianti prodotto"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Progresso"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Nome coda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Risultato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Nuovi tentativi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Venditore"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Liquidato il"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Righe spedizione"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Iniziato il"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Inizia il"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Stato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Livelli scorte"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Totale"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Totale con IVA"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Tipo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Aggiornato il"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Limite utilizzo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Utente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Valore"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Elenco valori"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zona"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Metodo"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Riepilogo fiscale"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Imposta le lingue disponibili per tutti i canali. I singoli canali possono quindi supportare un sottoinsieme di queste lingue."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Collezioni spostate con successo"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registrato"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Annulla lavoro"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Termina il"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Pagina {0} di {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Aliquota"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Taglia, colore, ecc."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Sfoglia facet"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Annullato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Creato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Consegnato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "In attesa"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Spedito"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Salva vista"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} selezionati"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Cerca gruppi di opzioni..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Modifica ordine"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Articoli selezionati"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Valori"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Cliente impostato per l'ordine"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Facette"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Sei sicuro di voler rimuovere {count} cliente da questo gruppo?} other {Sei sicuro di voler rimuovere {count} clienti da questo gruppo?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Scorta disponibile"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "La ricostruzione dell'indice di ricerca non può essere avviata"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Indirizzo di spedizione"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Nuova zona"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Nuova API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Elimina colonna"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Assegna esistente"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "è nullo"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Questi sono i clienti nel gruppo clienti <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Gestisci viste globali"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Canale predefinito"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Inserisci una nuova immagine con sorgente, titolo e dimensioni"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Impossibile creare valore attributo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Impossibile aggiornare l'opzione prodotto"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Password dimenticata?</0><1>Richiedi reimpostazione</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Codice coupon"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Cliente verificato"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Impostazioni globali"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Programmazione"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Non è possibile spostare una collezione in un suo discendente"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Nuova categoria fiscale"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Nessuna ubicazione magazzino disponibile sul canale corrente"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Canale creato con successo"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Cliente aggiornato con successo"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Visualizza dati"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Elimina vista"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Aggiungi un nuovo indirizzo al cliente."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Altre viste"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Modifica le proprietà dell'immagine selezionata"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Vista „{viewName}\" applicata"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} attributi rimossi dal canale con successo"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Nuovo prodotto"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Nuovo file"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Ricalcola spedizione"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Seleziona quali opzioni devono applicarsi alla variante esistente \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Risorse"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Questa azione rimuoverà tutti i gruppi di opzioni da questo prodotto e tornerai alla scelta di configurazione delle varianti."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Indirizzo di fatturazione"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Aggiungi valore attributo"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Seleziona una collezione di destinazione"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Rivedi le modifiche prima di applicarle all'ordine."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Seleziona un ruolo"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Ordine annullato"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Sconto"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Tutti i tipi"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Solo le bozze degli ordini possono essere completate"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Impossibile aggiornare prodotto"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Regolazione di {0} righe"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Aggiungi valori attributo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "dopo"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Canale"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Controlli di stato"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Importo"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Numero di telefono"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Nuovo cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Immagine"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Amministratore creato con successo"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Opzioni prodotto"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Seleziona paese"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Creazione in corso..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Sei sicuro di voler eliminare questa vista globale? Questa azione non può essere annullata e influenzerà tutti gli utenti."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Forza rimozione gruppo di opzioni"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Aggiunto"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Cronologia cliente"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Valori attributo aggiornati con successo per {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Impossibile rimuovere cliente dal gruppo"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Sistema"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Limite utilizzo per cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Indirizzo di fatturazione modificato"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Seleziona un'opzione"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Copia in personale"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Il totale del rimborso supera l'importo massimo rimborsabile di {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Elimina vista globale"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Crea"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Ogni 30 secondi"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Nuovo paese"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "Da {0} a {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Impossibile creare cliente"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Punto focale aggiornato"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Valori opzione"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Indirizzo di fatturazione predefinito"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Nessun cliente"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Impossibile rimuovere i paesi dalla zona"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Impossibile creare promozione"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Oggi"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Ieri"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Nome opzione"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Sei sicuro di voler rimuovere {0} {1} da questa zona?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Aggiunta di {0} supplemento/i"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "URL link"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Fallback: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Cronologia ordine"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Sovrascrivi"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "L'ID transazione è obbligatorio"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "corrisponde a regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Vista globale rinominata con successo"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Nessun tag selezionato"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Indietro"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Vista rinominata con successo"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Applica filtro"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Ultimo risultato"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Aggiunto al gruppo"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Analisi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Crea varianti"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Test metodo di spedizione in corso..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Scuro"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Risultati test"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Aggiungi cliente"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Salva modifiche"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Indirizzo aggiornato"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Rimborso elaborato con successo"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Nuova zona"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Impossibile aggiornare la posizione della collezione"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Rimborso"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Modifica"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Nessuna lingua globale configurata"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Rimozione di {0} articolo/i"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Traccia"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Crea variante"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Valori attributo per {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Salva layout"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Reset password verificato"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Impossibile eliminare vista"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Sei sicuro di voler uscire da questa pagina? Tutte le modifiche non salvate andranno perse."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Attiva/Disattiva colonna intestazione"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Nuova promozione"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Nome valore opzione"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Ultimo uso"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "È categoria fiscale predefinita"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Lo slug è impostato"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Impossibile aggiornare il punto focale"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zona aggiornata con successo"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Stato/Provincia"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Impossibile aggiornare il gruppo di opzioni"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Impostazioni predefinite canale"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Impossibile creare categoria fiscale"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Imposta criteri di filtro per la colonna {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Paese"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Prodotto semplice"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Coda lavori"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Conferma di aver salvato la chiave API prima di chiudere."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Conferma eliminazione"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Impossibile modificare ordine"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "IVA inclusa al {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Metriche degli ordini"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Seleziona lingua di visualizzazione"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Metodi di autenticazione"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "inizio"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Impossibile ruotare la chiave API"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "in"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Cerca ruoli..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Varianti prodotto"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Gestisci viste globali"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Elaborazione in corso..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} trovati"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Seleziona intervallo di date"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Prodotto"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Ruota API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Categoria"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Spostamento in corso..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Assegna"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Venditore creato con successo"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Metodo di spedizione aggiornato con successo"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Impossibile aggiornare variante prodotto"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Trascina per riordinare"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Scegli cosa fare con le giacenze rimanenti in {count, plural, one {# ubicazione di magazzino} other {# ubicazioni di magazzino}} che stai eliminando. Tutte le ubicazioni selezionate trasferiscono le giacenze rimanenti nell'unica ubicazione che scegli, oppure le scartano."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Cerca valori facet..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Nota"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Lingue disponibili"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Carica altri {0} ({remaining} rimanenti)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Valori attributo"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Impossibile riordinare gli articoli"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Totale ordini"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Nessun metodo di spedizione idoneo trovato per questo ordine."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Aggiungi opzione prodotto"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Spedizione"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions deve essere utilizzato all'interno di un DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Questo gruppo di opzioni è utilizzato da varianti esistenti. La rimozione forzata potrebbe influire su tali varianti. Sei sicuro?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Richiesto aggiornamento email"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Errore transizione allo stato"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Gruppo clienti creato con successo"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nuova finestra"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Pagamento autorizzato"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Ruolo aggiornato con successo"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Seleziona un paese"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Impossibile aggiornare il metodo di spedizione"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Eliminata {deleted} ubicazione di magazzino} other {Eliminate {deleted} ubicazioni di magazzino}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Metodi di spedizione"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Seleziona un indirizzo"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Sì"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Imposta punto focale"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "fine"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Seleziona una valuta"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Aggiorna il contenuto o la visibilità della nota"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget Ultimi Ordini"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Contenuti della collezione {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Metodo di spedizione modificato"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Descrizione imposta"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "è minore o uguale a"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "non è uguale a"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Aggiorna"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "es. Taglia"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Completa pagamento"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Canali"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Spedizione rimborsata"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Tipo di risorsa"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Nuova ubicazione magazzino"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} pagamento/i rimborsato/i prima dell'errore. Controlla la cronologia dell'ordine per i dettagli."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Seleziona articolo"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Nuovo prodotto"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gestisci tag"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Articoli rimborsati"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Aggiungi azione"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Assegna opzioni alla variante esistente"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Duplica {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Rimuovi dal gruppo"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Impossibile aggiornare stato evasione"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Crea una nuova variante prodotto con opzioni, prezzi e scorte"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Gli attributi privati non sono visibili nel negozio"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Seleziona una categoria fiscale"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Creato"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Non in esecuzione"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Assegnato"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Intestazione 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Seleziona lingue disponibili"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Aggiunta di {0} articolo/i"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Aggiungi riga dopo"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Totale IVA"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Stato della bozza dell'ordine"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Opzioni prodotto create con successo"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Caricamento ubicazioni…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Impossibile creare metodo di pagamento"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Valore attributo creato con successo"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Bozza ordine eliminata"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "maggiore di"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Widget Metriche"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Cerca valute..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Rimuovi dal canale"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Titolo"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Inserisci immagine"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Impossibile aggiornare venditore"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Paese creato con successo"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Seleziona venditore"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Caricamento tag..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Attributo creato con successo"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} varianti"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Impossibile completare pagamento"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Nessun indirizzo di fatturazione"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Impossibile eliminare {1} ubicazione di magazzino} other {Impossibile eliminare {2} ubicazioni di magazzino}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Attributo"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Non è possibile rimuovere dal canale attivo"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Non impostato"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Rimozione forzata"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Nuovo canale"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Nome gruppo opzioni"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "E"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Impossibile creare gruppo clienti"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Impossibile creare ruolo"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Nome prodotto"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Stato evasione aggiornato con successo"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Prodotti"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Indirizzo creato"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "Chiave API ruotata con successo"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Aggiungi gruppo di opzioni"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Rimborsa {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Inserisci slug manualmente"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Nessun widget disponibile"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Impossibile annullare pagamento"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Pagamento annullato con successo"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Vista globale duplicata con successo"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Creato da"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtra varianti..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Aggiungi un prezzo in un'altra valuta"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Indirizzo email o identificativo"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Rimborso #{0} transitato a {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Clienti"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Intestazione 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Impossibile aggiornare ubicazione magazzino"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Ordine spedito"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Salva indirizzo"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Rendi globale"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Seleziona stato successivo"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Nessun avviso"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Spostamento di {0} collezione/i in {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "tra"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Nota aggiunta con successo"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Nota eliminata con successo"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Nota aggiornata con successo"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Impossibile completare rimborso"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Livello scorta"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Aggiungi elemento"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "Chiave API creata con successo"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Caricamento anteprima..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Torna alla ricerca"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Vista duplicata con successo"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Rimuovi gruppo di opzioni"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Descrizione"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Paesi"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Indirizzo 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Vista globale eliminata con successo"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Modifica layout"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Assegna al canale"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Questa settimana"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Gruppo di opzioni prodotto creato con successo"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Aggiungi un pagamento manuale di {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "è in"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "Email"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Aggiornamento amministratore non riuscito"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Gestisci le tue viste salvate personali per questa tabella"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtra per tag"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Accedi per accedere al pannello di amministrazione"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Aggiungi pagamento all'ordine ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Falso"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Chiaro"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Reimposta"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "è uguale a"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Crea opzioni"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Password aggiornata"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "non contiene"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Gruppo di opzioni"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Modifica i dettagli dell'indirizzo di seguito."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Categoria fiscale creata con successo"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Impossibile spostare collezioni"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Impossibile aggiornare stato pagamento"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Riepilogo dei tuoi ordini"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Carica"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Prodotto con opzioni"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Visualizzazione di tutti i {0} risultati"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "ID di ricerca"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} altri"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Gruppi di opzioni"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Campi personalizzati"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Tutti i possibili stati dell'ordine e le loro transizioni. Lo stato attuale è evidenziato."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Ordini"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget Riepilogo Ordini"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Aggiunta articoli"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Organizzazione pagamento aggiuntivo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Organizzazione pagamento"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Annullato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Creato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Consegnato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Bozza"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "In modifica"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Parzialmente consegnato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Parzialmente spedito"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Pagamento autorizzato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Pagamento completato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Spedito"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Risorse monitorate"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Informazioni entità"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Totale ordine"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Visibile solo agli amministratori"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Qtà"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Tag"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super amministratore"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Alcune risorse non sono disponibili"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Azioni disponibili"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Inserisci link"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Se abilitato, i filtri saranno ereditati dalla collezione padre e combinati con i filtri impostati su questa collezione."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Seleziona una zona"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Testa metodi di spedizione"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Pagamento completato con successo"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} rimossi dalla zona"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Abilita"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Metodi di pagamento"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autorizzato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Annullato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Creato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Rifiutato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Errore"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Fallito"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "In attesa"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Liquidato"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Valore medio dell'ordine"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Impossibile creare zona"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Livelli scorta"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Impossibile aggiornare la chiave API"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Righe ordine"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Impossibile rinominare vista globale"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Inserisci un nuovo collegamento ipertestuale con URL e opzioni di destinazione"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Altezza"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "È richiesto un rimborso di {formattedDiff}. Seleziona gli importi dei pagamenti e inserisci una nota per procedere."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Prezzo unitario"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Schema programmazione"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Pagamento fallito"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Aggiungi canale"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Impossibile aggiornare il gruppo di opzioni prodotto"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Cerca canali..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Aggiungi gruppi clienti"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Lingue disponibili"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Reimposta selezione"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Nessun indirizzo"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Metodo di pagamento creato con successo"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Informazioni cliente aggiornate"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Impossibile convertire vista in globale"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Varianti prodotto"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Prodotti"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promozioni"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Impossibile creare l'opzione prodotto"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Vecchia email:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Salva una vista come \"Globale\" per renderla disponibile a tutti gli utenti."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Impossibile creare le varianti"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Imposta il livello di scorta al quale questa variante è considerata esaurita. L'utilizzo di un valore negativo abilita il supporto per ordini arretrati. Può essere sostituito dalle varianti prodotto."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Ruota chiave"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Impossibile creare le varianti del prodotto"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Nascondi password"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Nuovo venditore"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "es. Rosso, Grande, Cotone"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Impossibile aggiornare profilo"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Codici coupon rimossi"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Cancella filtro"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regioni"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Trascina i file qui per caricarli"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Attiva/disattiva tutte le varianti visibili"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verificato"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Nuovo gruppo di opzioni"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Ultimo aggiornamento {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Non sono ancora state create viste globali."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Impossibile aggiornare ruolo"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Questa è l'unica volta in cui la chiave API completa verrà visualizzata. Copiala o scaricala ora — non potrà essere recuperata in seguito."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Collezione aggiornata con successo"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Metodo di pagamento aggiornato con successo"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Vista eliminata con successo"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Gruppo opzioni {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "O"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Gestisci tag"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Codice coupon rimosso dall'ordine"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Mai"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Impossibile aggiornare valore attributo"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Rimuovi gruppo"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Ordine evaso"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Nessun indirizzo di spedizione"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "L'estensione query contiene sintassi GraphQL non valida"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Errore di estensione query"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Errore estensione query: "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "L'estensione query non è valida: deve avere almeno un campo di livello superiore"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Disallineamento estensione query: "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "pubblico"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Categoria fiscale aggiornata con successo"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Sposta"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Modifica o elimina tag esistenti"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Le condizioni di controllo idoneità di questo metodo di spedizione non sono soddisfatte per l'ordine corrente e l'indirizzo di spedizione."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Aggiungi codice coupon"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Codice coupon impostato per l'ordine"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Campi personalizzati"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Nuovo metodo di spedizione"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Elimina ubicazioni di magazzino"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "è maggiore o uguale a"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Anteprima"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} di {1} disponibili per l'evasione"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Mese corrente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Richiesta del cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Danneggiato durante la spedizione"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Non disponibile"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Altro"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Articolo errato"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Riepilogo modifiche"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Rimborsi ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Ultima esecuzione"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Dettagli pagamento"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Ricostruisci indice di ricerca"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "In esecuzione"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Ogni 60 secondi"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Impossibile aggiornare gruppo clienti"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Metadati pagamento"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Annulla modifica"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Stessa finestra"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Applica i filtri alla tabella e fai clic su \"Salva vista\" per iniziare."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Ruoli"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Pagamento aggiuntivo richiesto"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Impossibile aggiornare ordine"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Con selezionati..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Impossibile creare ubicazione magazzino"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "minore o uguale a"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Membri del gruppo clienti {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Stato"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Non tracciare"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Evasione #{0} creata"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Esecuzione degli aggiornamenti dell'indice di ricerca in sospeso"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Questo è un ruolo predefinito e non può essere modificato"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Le mie viste salvate"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Stato / Provincia"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Elementi per pagina"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Modifica membri"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Scorta disponibile"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtra per {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Avvisi"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Valori opzione"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Anteprima modifiche"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Impossibile rimuovere {entityType} dal canale"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variante eliminata con successo"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Modifica le proprietà del collegamento selezionato"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Vendite"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Seleziona una collezione di destinazione"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "I tuoi ultimi ordini"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Attività programmate"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Sei sicuro di voler eliminare questo articolo? Questa azione non può essere annullata."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Varianti"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Venditori"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Impostazioni"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Archivio impostazioni"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Intestazione 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Benvenuto su Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Metodi di spedizione"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} rimborsabile)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identificativo"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Impossibile aggiornare collezione"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Prezzo e IVA"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Ordine non trovato"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Errore"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Ordine modificato"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Richiesto reset password"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "L'importo del pagamento allocato deve essere uguale al totale del rimborso"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "es. Piccolo"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Sei sicuro di voler rimuovere {0} {entityType} dal canale corrente?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Aggiungi tag..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Impossibile creare il gruppo di opzioni prodotto"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} articoli selezionati"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Cerca lingue..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Ubicazioni stock"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Vai alla pagina precedente"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Contenuti"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Impossibile convertire vista globale in vista personale"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Il risultato del lavoro"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Aggiungi pagamento ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Sistema"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Nome variante"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Impossibile aggiornare cliente"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Rimuovere i gruppi di opzioni?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Questa è un'anteprima dei contenuti della collezione basata sulle impostazioni di filtro correnti. Una volta salvata la collezione, i contenuti verranno aggiornati per riflettere le nuove impostazioni di filtro."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} cliente rimosso dal gruppo} other {{count} clienti rimossi dal gruppo}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Categorie fiscali"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Aliquote fiscali"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Impossibile rimuovere i clienti dal gruppo"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Impossibile caricare impostazioni globali"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Seleziona gli articoli da rimborsare e facoltativamente restituire a magazzino"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Salva"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} di {0} riga/righe selezionata/e."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Anteprima modifiche ordine"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Gruppo di opzioni prodotto aggiornato con successo"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "La pagina continuerà con la query predefinita."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Indirizzo"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Nessun altro facet"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Ricostruzione indice di ricerca avviata"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Posizione della collezione aggiornata"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Nome gruppo opzioni"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Aggiungi \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Nuova variante prodotto"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Rimborso transitato"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Utilizzo strategia di autenticazione nativa"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Impossibile assegnare {entityIdsLength} {entityType} al canale"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Lingua predefinita"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Evasione in corso..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Aggiungi gruppo di opzioni al prodotto"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Anteprima di {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Venditore aggiornato con successo"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Impossibile effettuare transizione ordine allo stato"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Mostra tutto ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Impossibile creare aliquota fiscale"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Ho salvato questa chiave API"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Configura le lingue disponibili per il tuo negozio e i canali"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Prodotto creato con successo"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Aggiungi variante prodotto"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Digita e premi Invio o virgola per aggiungere..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Modifica nota"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Nessuna risorsa trovata. Prova a modificare i filtri."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Aggiungi opzione"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Salva gruppo opzioni"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Crea {createCount} varianti"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Fai clic su \"Esegui test\" per testare questo metodo di spedizione."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Amministratore aggiornato con successo"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Cancella filtri"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Evasione #{0} da {1} a {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Impossibile eliminare vista globale"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Lingua predefinita"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Stato"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Nessuna opzione trovata"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binario"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Gruppo di opzioni aggiornato con successo"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Nuovo metodo di spedizione"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Ogni 10 secondi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "IVA escl.:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Aggiungi scorta all'ubicazione"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Valore opzione aggiunto con successo"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Collezione spostata al nuovo genitore"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Gruppo opzioni rimosso"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Transizione allo stato selezionato"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Sarà richiesto un pagamento aggiuntivo di {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Traccia inventario per impostazione predefinita"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} di {total} selezionate"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Metodo di spedizione creato con successo"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nuovo gruppo clienti"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Visibile al cliente"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Gruppo opzioni creato con successo"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Aliquote fiscali"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Lo slug sarà generato automaticamente..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Cliente non trovato"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Seleziona {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Nuovi valori attributo da aggiungere:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Impossibile elaborare il rimborso"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Nome"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "contiene"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Nessun gruppo di opzioni trovato"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Nessun articolo trovato"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Subtotale"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Articoli evasi ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Valore aggiornato"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Non verificato"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Quantità"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Categoria fiscale"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profilo"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "I dati del test sono stati aggiornati. Fai clic su \"Esegui test\" per vedere i risultati aggiornati."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "non è in"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Riga ordine aggiornata"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Nuovo metodo di pagamento"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Il valore duplicato \"{trimmed}\" esiste già"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Motivo"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Gruppi clienti"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} rimosso dal canale con successo"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Gruppi opzioni"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Aggiungi supplemento"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Valori attributo attuali"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Pagina {page} di {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Mese scorso"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Aggiungi paese"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Rimuovi articolo"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "minore di"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Impossibile aggiungere la variante. Assicurati che il prodotto principale sia abilitato."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Si è verificato un errore sconosciuto"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Metriche"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Lingua"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Nuova collezione"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Rimborsa e annulla ordine"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Aggiornamento email verificato"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "è tra"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Rimborsa e annulla"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Test metodi di spedizione in corso..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Impossibile creare il metodo di spedizione"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} assegnati al canale con successo"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Lingue globali"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Nuovo amministratore"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Elimina bozza"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Sorgente"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Nessuna azione disponibile"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Impossibile aggiornare canale"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Generale"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Impossibile rimuovere il prodotto dal canale"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Aggiungi nuovo indirizzo"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Attributo aggiornato con successo"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zona creata con successo"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Valore"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Cliente aggiornato"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Fattore conversione prezzo"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Ordine venditore"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Nuovo attributo"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Sei sicuro di voler rimuovere questo gruppo di opzioni dal prodotto?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Descrizione (testo alternativo)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Nessun tag trovato"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Valuta predefinita"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Nessun pagamento o rimborso è richiesto per queste modifiche."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Ricavi totali"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Prossima esecuzione"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "La nota è privata"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Data media"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Numero non valido"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Non hai ancora salvato nessuna vista."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Sei sicuro di voler eliminare questa vista? Questa azione non può essere annullata."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Visualizza processo ordine"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Impossibile duplicare vista"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Usa come indirizzo di spedizione predefinito"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Modifica slug manualmente"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Aggiungi filtri per visualizzare in anteprima i contenuti della collezione."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Gruppo opzioni prodotto"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Subtotale"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "è minore di"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID rimborso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Campi personalizzati ordine aggiornati"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Calcolatrice"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Impossibile rimuovere il gruppo di opzioni dal canale: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Visualizza dati lavoro"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Sposta al livello superiore"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Cancella"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Riepilogo ordini"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Cerca risorse..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Nuovo attributo"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Assegna {entityType} al canale"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Continua"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promozioni"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Messaggio di errore"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Aggiungi livello di stock per un'altra posizione"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Elimina indirizzo"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Impossibile aggiornare attributo"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters deve essere utilizzato all'interno di un WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Modifica indirizzo"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Impossibile rimuovere attributo dal canale: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Imposta link"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Nuovo venditore"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Modifica immagine"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Gestisci varianti"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Scorta allocata"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "maggiore o uguale a"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Imposta il livello di scorta al quale questa variante è considerata esaurita. L'utilizzo di un valore negativo abilita il supporto per ordini arretrati."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Crea opzioni prodotto"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Salvataggio in corso..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Visualizza risultato"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Righe per pagina"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Caricamento collezioni..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Valore attributo aggiornato con successo"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Aggiungi file"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Salva modifiche"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Cliente aggiunto al gruppo"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Ordini venditore"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Impossibile aggiungere valore opzione"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Aggiungi valore opzione a {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} articolo/i rimborsato/i"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Nessun gruppo di opzioni ancora definito. Aggiungi gruppi di opzioni per creare diverse varianti del tuo prodotto (es. Taglia, Colore, Materiale)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Nuova email:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Impossibile aggiornare metodo di pagamento"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Disponibile:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Creato il"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Impossibile creare variante prodotto"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Lingua: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Non hai il permesso di visualizzare le impostazioni linguistiche globali"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Aliquota fiscale creata con successo"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Intestazione 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Codici coupon aggiunti"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Attivo"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Base imponibile"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Carica altro"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Rimborso completato"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} duplicati con successo"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Nuovo gruppo di opzioni"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Nessun risultato ancora"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Pagamento completato"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Condizioni disponibili"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Filtri attivi"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Cancella tutto"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "è maggiore di"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Chiudi"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Aggiungi pagamento all'ordine"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Caricamento..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Il token viene utilizzato per specificare il canale quando si effettuano richieste API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Nessun indirizzo trovato"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID evasione"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Seleziona i pagamenti da rimborsare"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Impossibile eliminare {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Soglia esaurimento scorte"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Prodotto rimosso dal canale con successo"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Impossibile aggiornare il valore"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Impossibile creare la chiave API"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Completa rimborso"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Il metodo di pagamento è obbligatorio"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Impossibile aggiungere cliente al gruppo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Gestisci varianti"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Vista globale „{viewName}\" applicata"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Cliente registrato"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zone"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Cerca venditori..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Promozione creata con successo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Opzione"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Processo ordine"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Numero di telefono"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privato"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variante"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Impostazioni globali aggiornate con successo"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "Chiave API aggiornata con successo"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Queste lingue saranno disponibili per l'uso di tutti i canali"

--- a/packages/dashboard/src/i18n/locales/ja.po
+++ b/packages/dashboard/src/i18n/locales/ja.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "氏名"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "アイテムを選択"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "変更を表示"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "追跡コード"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "選択された権限がこれらのチャネルに適用されます。"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "商品オプション"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "新しい税率"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "既存のオプショングループを割り当てるか、新しいグループを作成します"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "新しいロール"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "マンション、スイートなど"
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "これ以上のアイテムはありません"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "リンクを編集"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "注文に少なくとも1つの商品を追加してください"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "テスト注文を作成するために商品を追加"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "住所の作成に失敗しました"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "すべて切り替え"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "JSON 値を編集"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "外部認証戦略を使用：{strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "理由を選択..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "見出し5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "支払いの追加に失敗しました"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "更新日時"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "グローバル設定の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "注文をフルフィルメントしました"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "{0}{entityName}を削除してもよろしいですか？"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "グローバル在庫切れしきい値"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "言語を管理"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "複製中...（{0}/{1}）"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "削除しました"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "現在のチャネルから削除"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength}個のアセットを削除しました"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "税率を更新しました"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "カスタム理由を入力..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "タイプ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "{0}を選択"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "値を表示"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "行を削除"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "条件"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "現在"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "フルフィルメントなし"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, other {{2}件の在庫ロケーションを削除できませんでした: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "これを有効にすると、商品カタログに入力された価格には、デフォルト税ゾーンの税が含まれます。"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "商品のバリエーションを作成"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "下書き注文を完了しました"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "自動更新：{0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "ヘルスチェック"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted}{entityName}を削除しました"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "ヘルスチェック"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "販売者"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "オプション"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, other {{fulfilled} 件のジョブをキャンセルしました}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "販売者"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "支払いを追加"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "注文をシミュレートしてこの配送方法が適格かどうか、配送料がいくらになるかをテストします。"
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Enterprise Editionを見る"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "在庫ロケーション"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "フルフィルメントハンドラー"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "注文"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "ロールを選択"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "ロールを作成しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "このバリエーションを削除してもよろしいですか？"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "すべてのリソースが稼働中です"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "管理者の作成に失敗しました"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "いいえ"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "商品バリエーションを更新しました"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "{failed}{entityName}の削除に失敗しました：{allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "商品を更新しました"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "国の更新に失敗しました"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "検索するには少なくとも2文字を入力してください..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "姓"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "リンクタイトル"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "顧客グループを更新しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "カスタムフィールドを変更しました"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "在庫ロケーションを作成しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "不明なエラー"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "返金合計はマイナスにできません"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "詳細を表示"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "{0}{entityType}を割り当てるチャネルを選択"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "顧客を作成しました"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "過去7日間"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "チャネルの作成に失敗しました"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "開発モード"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "新しいロール"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "アセットの削除に失敗しました：{message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "在庫に戻す"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "公開設定"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "商品バリエーション"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "新しい顧客グループ"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "「{0}」を作成"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "名前を変更"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "表示言語とロケール設定を選択してください"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "チャネルから {successCount} 件のオプショングループを削除しました"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "この配送方法はこの注文に適格ではありません"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "住所の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "住所を削除しました"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "税率"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "注文の下書きは完了準備ができていません"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "新しいコレクション"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "インサイト"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "実行"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "税率の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "これは<0>{collectionName}</0>コレクションの内容です。"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "非公開"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "商品オプションを正常に作成しました"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "親商品"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "市区町村"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "管理者"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "総額：<0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "次のページへ"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "リンクを削除"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "このフィールドは読み取り専用です"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "注文数"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "注文を更新しました"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "フィルターを継承"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "すべてのユーザーに表示されるグローバル保存ビューを管理"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "支払い方法を検索..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "注文の配送先住所が解除されました"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "{enabledCount} 件のバリエーションを作成"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "支払い#{0}を{1}に遷移しました"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "顧客履歴の読み込みエラー：{0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "チャネルから{selectionLength}個の{entityType}を削除しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "オプション値を追加"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "グローバル設定"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "より後"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "商品オプションを正常に更新しました"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "ファセット値を編集"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "追加中..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "コレクションを移動"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "ロール"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "グリッド表示"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "住所の削除に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "利用可能な配送方法がありません"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "グローバルビューを個人ビューに変換しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "フルフィルメントを遷移しました"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "{selectionLength}個のアセットを削除してもよろしいですか？"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "ログイン"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "リスト表示"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "テスト注文"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "続行するには顧客を選択してください"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "オプショングループの割り当てに成功しました"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "テストを実行"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "税率：{taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "テストを実行するには、商品を追加して配送先住所を入力してください。"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "ヘッダー行を切り替え"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "住所を選択"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "支払い適格性チェッカー"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "デフォルト税ゾーン"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "注文の下書きは完了準備ができています"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "メタデータ"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "フィルター..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "新しいファセット値"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "チャネルを更新しました"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "表示を減らす"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "短い日付"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "利用可能な通貨"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "{0}個のアイテムを選択"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "注文日時"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "このキーをローテーションすると、現在のキーは直ちに無効になります。このキーを使用しているすべての連携は、新しいキーに更新されるまで動作を停止します。"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "ジョブに渡されたデータ"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "ナビゲーションを確認"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "リンクターゲット"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "下書きを完了"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "名前"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "注文のフルフィルメントに失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "合計"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "この返金決済の取引IDを入力してください"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "あなたの API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "この下書き注文を削除してもよろしいですか？"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "フルフィルメントを作成しました"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "{0}個の適格な配送方法が見つかりました"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "サイズ"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "パスワードを表示"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(最大: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "会社名"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "後に列を追加"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "アクション"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "割引"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "返金メモを入力"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "注文ラインを削除しました"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "内容:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "キー"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "確認"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "コレクションの作成に失敗しました"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "最初のページへ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "商品の作成に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "顧客"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "注文履歴の読み込みエラー：{0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "注文の配送先住所が設定されました"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "フォーカルポイント"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "単一バリエーション、オプションなし"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "注文の次の状態を選択"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "ロケール"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "スケジュールされたタスク"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "取引IDを入力"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "データを更新"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "{0}{entityType}のファセット値を追加または削除"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "<0>{facetName}</0>ファセットのファセット値です。"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "注文に支払いを追加しました"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "注文の請求先住所が設定されました"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "ゾーンの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "パスワード"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "削除に失敗しました"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "スケジュールされたタスクが実行されます"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "新しい在庫ロケーション"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "権限"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "配送先住所を変更しました"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "商品が見つかりません"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "前に行を追加"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "{suggestedState}に遷移"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "今月"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "ファセットの作成に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "注文アイテムのキャンセルに失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "取引ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "割り当て済み"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "別のオプショングループを追加"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "残りの在庫の扱いを選択してください"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Platform & Cloud を探索"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "5秒ごと"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "コレクションを作成しました"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "価格"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "下書き注文"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "スコープ"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "条件を追加"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "この配送方法はこの注文に適格です"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "管理者"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "グループから削除しました"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "幅"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "支払いまたは返金は不要"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr ".env ファイルとしてダウンロード"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "有効にすると、プロモーションがショップで利用可能になります"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "追跡すると、商品バリエーションの在庫レベルは販売時に自動的に調整されます。この設定は個々の商品バリエーションで上書きできます。"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "注文の配送方法が設定されました"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "プロモーションの更新に失敗しました"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "画像"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "{name}を検索..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "アセットを編集"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "支払いをキャンセル"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "ジョブキュー"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "アセット"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "メールアドレス"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "ソースフィールドからスラッグを再生成"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "グローバル設定から継承"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "結果が見つかりません"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "現在のステータス"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "配送先住所を設定し、配送方法を選択してください"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "オフ"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "設定ストア"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "キュー"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "新しい税率"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "支払いを遷移しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "残り："
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "{entityName}用のコード「{duplicatorCode}」を持つ複製ツールが見つかりません"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "価格はデフォルト税ゾーンの税を含みます"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "返金合計："
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "ジョブ結果を表示"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "新しい注文をシミュレートして配送方法をテストします。"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "アイテムが選択されていません"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr "、{0} 件選択中"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "国が見つかりません"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "バリエーションの作成に成功しました"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "スラッグを自動生成"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "追加料金"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "支払い方法"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "在庫"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "顧客が見つかりません"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "グローバル在庫切れしきい値を使用"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "新しい商品オプショングループ"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "支払い状態を更新しました"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "新規作成"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "返金合計"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "住所を削除しました"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "アカウントに割り当てられたロールのみ使用可能です。"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "注文にアイテムを追加しました"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "フォーカルポイントを編集"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "販売者が見つかりません"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "アセット"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {このオプショングループは他の1つの商品で使用されています。変更はその商品にも影響します。} other {このオプショングループは # 個の商品で共有されています。変更はすべての商品に影響します。}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "保存したビュー"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "新しいチャネル"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "販売者の作成に失敗しました"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "{0}の複製設定を構成"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "現在のフィルターに一致するバリアントはありません。"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "住所"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "{groupName} オプショングループに新しいオプション値を追加"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "注文変更#{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "前に列を追加"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "チャネル言語"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "オプショングループの作成に失敗しました"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "真"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "顧客を選択"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "注文を遷移しました"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "この商品には既存のバリエーションがありますが、オプショングループが定義されていません。新しいバリエーションを作成する前に、オプショングループを追加する必要があります。"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "より前"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "下書き注文を削除"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "カタログ"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "新しい支払い方法"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "プロモーションを更新しました"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, other {{rejected} 件のジョブのキャンセルに失敗しました}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "チャネルを選択"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "表示言語"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "フルフィルメント詳細"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "残りの在庫を破棄"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "現在"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "チャネル"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "ビューをグローバルに変換しました"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "以前"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "サイズ"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "{0}の翻訳が見つかりません"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "新しい顧客"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "最新の注文"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} 件"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "デフォルトの請求先住所として使用"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "削除"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "無効化"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "コレクション"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "バリエーションを追加"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "国の作成に失敗しました"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "国"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "商品オプションの作成に失敗しました"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "ビューの名前変更に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "利用可能"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "通常"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "フィルター"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "顧客グループ"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "顧客"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "サンプル書式"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "新しいオプション"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "使用制限"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "グローバル設定を読み込み中..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "住所を更新しました"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "作成日時"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "住所を読み込み中..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "{0}を移動するターゲットコレクションを選択してください。"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "顧客の詳細を更新しました"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "に含まれない"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "適用"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "新しい商品オプション"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "最後のページへ"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "キャンセル"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "商品バリエーションを作成しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "この方法から返金"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "郵便番号"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "まず商品オプションを追加してください"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "新しい税カテゴリ"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "オプションを追加"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "一部返金が完了しました"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "カスタムフィールドを設定"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "コレクション"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "バリエーションを削除"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "変更は行われませんでした"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "デフォルト配送ゾーン"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "理由:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "配送先住所"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "{0}に遷移"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "税カテゴリ"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "非公開コレクションはショップに表示されません"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "有効にすると、商品がショップで利用可能になります"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "スケジュールされたタスクを実行できませんでした"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "顧客グループ"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "無効"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "新しいプロモーション"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "デフォルト配送先住所"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "返金が必要です"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "注文をフルフィルメント"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "チャネル設定を表示する権限がありません"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "過去30日間"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "ファセット値なし"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "返金理由が必要です"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "オプショングループを削除できませんでした"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "税カテゴリの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "返金を決済しました"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "更新"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "見出し2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "注文を確定しました"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "プロフィールを更新しました"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "終了"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "支払い方法"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "編集"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "バリエーションを更新しました"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "コレクション名でフィルター"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "メモを追加しました"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "フルフィルメントする数量を選択し、フルフィルメントハンドラーを設定"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "注文の請求先住所が削除されました"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "開始日時"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "複製"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "結果なし"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "列の設定"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, other {{count}件の在庫ロケーションを削除できませんでした}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "コード"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "オプショングループの削除に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "注文を配達しました"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "{name} へ移動"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "残りの在庫"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "ゾーンから削除"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "このチャネルでグローバルに利用可能な言語から選択"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "この住所を削除してもよろしいですか？"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "オプショングループの割り当てに失敗しました"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "アセットの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "在庫ロケーションを更新しました"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "アクションを確認"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "国を更新しました"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "ファセット"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "メモの追加に失敗しました"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "メモの削除に失敗しました"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "クエリドキュメントの拡張に失敗しました"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "メモの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "送料を返金"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "読み取り専用"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "グローバルビューの複製に失敗しました"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "{total} 件中 {shown} 件を表示 • {selected} 件選択中"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "配送方法をテスト"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "ファセット値"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "アセットを更新しました"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "テーマ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} 人の顧客"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "言語を選択"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "ログアウト"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "試行回数"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "利用可能通貨コード"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "利用可能な言語コード"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "パンくずリスト"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "カテゴリ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "チャネル"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "子要素"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "コード"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "クーポンコード"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "作成日時"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "通貨コード"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "顧客"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "顧客グループ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "顧客"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "カスタムフィールド"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "データ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "デフォルト通貨コード"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "デフォルト言語コード"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "デフォルト配送ゾーン"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "デフォルト税ゾーン"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "説明"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "期間"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "メールアドレス"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "有効"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "終了日時"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "エラー"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "注目アセット"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "名"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "フルフィルメントハンドラーコード"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "デフォルト"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "プライベート"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "決済済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "姓"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "名前"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "注文日時"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "親ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "顧客ごとの使用制限"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "権限"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "位置"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "価格"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "税込価格"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "税込価格"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "商品バリエーション"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "進捗"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "キュー名"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "結果"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "再試行"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "販売者"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "決済日時"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "配送ライン"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "スラッグ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "開始日時"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "開始日時"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "状態"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "在庫レベル"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "トークン"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "合計"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "税込合計"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "種類"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "更新日時"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "使用制限"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "ユーザー"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "値"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "値リスト"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "ゾーン"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "メソッド"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "税の概要"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "すべてのチャネルで利用可能な言語を設定します。個々のチャネルは、これらの言語のサブセットをサポートできます。"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "コレクションの移動が完了しました"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "登録済み"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "ジョブをキャンセル"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "終了日時"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "ページ {0} / {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "率"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "サイズ、カラーなど"
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "ファセットを参照"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "ゾーン"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "キャンセル済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "作成済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "配達完了"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "保留中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "発送済み"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "ビューを保存"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} 件選択中"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "オプショングループを検索..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "注文を変更"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "選択されたアイテム"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "値"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "注文に顧客を設定しました"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "ファセット"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, other {このグループから{count}人の顧客を削除してもよろしいですか？}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "手持ち在庫"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "検索インデックスの再構築を開始できませんでした"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "配送先住所"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "新しいゾーン"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "新しい API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "列を削除"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "既存を割り当て"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "NULL である"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "<0>{customerGroupName}</0>顧客グループの顧客です。"
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "グローバルビューを管理"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "デフォルトチャネル"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "ソース、タイトル、サイズを指定して新しい画像を挿入"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "ファセット値の作成に失敗しました"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "商品オプションの更新に失敗しました"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>パスワードをお忘れですか？</0><1>リセットをリクエスト</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "クーポンコード"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "顧客を確認しました"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "グローバル設定"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "スケジュール"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "コレクションを自身の子孫に移動することはできません"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "新しい税カテゴリ"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "現在のチャネルで利用可能な在庫ロケーションがありません"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "チャネルを作成しました"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "顧客を更新しました"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "データを表示"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "ビューを削除"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "顧客に新しい住所を追加します。"
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "その他のビュー"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "選択した画像のプロパティを編集"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "ビュー「{viewName}」を適用しました"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "チャネルから{successCount}個のファセットを削除しました"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "新しい商品"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "新しいアセット"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "送料を再計算"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "既存のバリエーション「{0}」に適用するオプションを選択"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "アセット"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "この商品からすべてのオプショングループが削除され、バリエーション設定の選択に戻ります。"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "請求先住所"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "ファセット値を追加"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "ターゲットコレクションを選択してください"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "注文に適用する前に変更を確認してください。"
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "ロールを選択"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "注文をキャンセルしました"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "割引"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "すべてのタイプ"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "下書き注文のみ完了できます"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "商品の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "{0}行を調整中"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "ファセット値を追加"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "以降"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "チャネル"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "ヘルスチェック"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "金額"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "電話番号"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "新しい顧客"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "画像"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "管理者を正常に作成しました"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "商品オプション"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "国を選択"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "作成中..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "このグローバルビューを削除してもよろしいですか？この操作は取り消せず、すべてのユーザーに影響します。"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "オプショングループを強制削除"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "追加済み"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "顧客履歴"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "{entityIdsLength}個の{entityType}のファセット値を更新しました"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "グループからの顧客の削除に失敗しました"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "システム"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "顧客ごとの使用制限"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "請求先住所を変更しました"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "オプションを選択"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "個人用にコピー"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "返金合計が最大返金可能額{0}を超えています"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "グローバルビューを削除"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "作成"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "30秒ごと"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "新しい国"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "{0}から{1}まで"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "顧客の作成に失敗しました"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "フォーカルポイントを更新しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "オプション値"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "デフォルト請求先住所"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "顧客なし"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "ゾーンから国を削除できませんでした"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "プロモーションの作成に失敗しました"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "今日"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "昨日"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "オプション名"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "このゾーンから{0} {1}を削除してもよろしいですか？"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "{0}件の追加料金を追加中"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "リンクURL"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "フォールバック: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "注文履歴"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "上書き"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "取引IDは必須です"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "正規表現に一致"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "グローバルビューの名前を変更しました"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "タグが選択されていません"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "戻る"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "ビューの名前を変更しました"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "フィルターを適用"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "最終結果"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "グループに追加しました"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "インサイト"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "バリエーションを作成"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "配送方法をテスト中..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "ダーク"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "テスト結果"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "顧客を追加"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "変更を保存"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "住所を更新しました"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "返金が正常に処理されました"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "新しいゾーン"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "コレクションの位置の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "返金"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "変更"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "グローバル言語が設定されていません"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "{0}個のアイテムを削除中"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "追跡"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "バリエーションを作成"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "{facetName}のファセット値"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "レイアウトを保存"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "パスワードリセットを確認しました"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "ビューの削除に失敗しました"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "このページから移動してもよろしいですか？保存されていない変更は失われます。"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "ヘッダー列を切り替え"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "新しいプロモーション"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "オプション値名"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "最終使用日"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "デフォルト税カテゴリ"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "スラッグが設定されています"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "フォーカルポイントの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "ゾーンを更新しました"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "都道府県"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "オプショングループの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "チャネルのデフォルト設定"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "税カテゴリの作成に失敗しました"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "{columnId} 列のフィルター条件を設定"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "国"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "シンプル商品"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "ジョブキュー"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "閉じる前に API Key を保存したことを確認してください。"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "削除を確認"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "注文の変更に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "{taxRate}%の税込み"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "注文指標"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "表示言語を選択"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "認証方法"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "開始"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "API Key のローテーションに失敗しました"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "内"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "ロールを検索..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "商品バリエーション"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "グローバルビューを管理"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "処理中..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} 件の{0}が見つかりました"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "期間を選択"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "商品"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "API Key をローテーション"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "カテゴリ"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "移動中..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "割り当て"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "販売者を作成しました"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "配送方法を正常に更新しました"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "商品バリエーションの更新に失敗しました"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "ドラッグして並べ替え"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "ゾーン"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "削除する{count, plural, other {#件の在庫ロケーション}}に残っている在庫の扱いを選択してください。選択したすべてのロケーションは、残りの在庫を選んだ1つのロケーションに移動するか、破棄します。"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "ファセット値を検索..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "メモ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "利用可能な言語"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "さらに{0}件読み込む (残り{remaining}件)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "ファセット値"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "アイテムの並び替えに失敗しました"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "総注文数"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "この注文に適格な配送方法が見つかりません。"
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "商品オプションを追加"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "配送"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensionsはDashboardBaseWidget内で使用する必要があります"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "このオプショングループは既存のバリエーションで使用されています。強制削除するとそれらのバリエーションに影響する可能性があります。よろしいですか？"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "メールアドレスの更新をリクエストしました"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "ステートへの遷移エラー"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "顧客グループを作成しました"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "新しいウィンドウ"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "支払いを承認しました"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "ロールを更新しました"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "国を選択"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "配送方法の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, other {{deleted}件の在庫ロケーションを削除しました}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "配送方法"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "住所を選択"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "はい"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "スラッグ"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "フォーカルポイントを設定"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "終了"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "通貨を選択"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "メモの内容または公開設定を更新"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "最新注文ウィジェット"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "{collectionName}のコレクション内容"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "配送方法を変更しました"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "税の説明"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "以下"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "と等しくない"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "更新"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "例：サイズ"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "支払いを決済"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "チャネル"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "送料返金済み"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "アセットタイプ"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "新しい在庫ロケーション"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "失敗前に{successfulRefundCount}件の支払いが返金されました。詳細は注文履歴をご確認ください。"
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "アイテムを選択"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "新しい商品"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "タグを管理"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "返金済み商品"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "アクションを追加"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "既存のバリエーションにオプションを割り当て"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "{0}を複製"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "グループから削除"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "フルフィルメント状態の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "オプション、価格、在庫を指定して新しい商品バリエーションを作成"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "非公開ファセットはショップに表示されません"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "税カテゴリを選択"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "作成済み"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "実行されていません"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "割り当て済み"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "見出し1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "利用可能な言語を選択"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "{0}個のアイテムを追加中"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "後に行を追加"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "税合計"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "下書き注文のステータス"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "商品オプションを作成しました"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "ロケーションを読み込み中…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "支払い方法の作成に失敗しました"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "ファセット値を作成しました"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "マーケティング"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "下書き注文を削除しました"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "より大きい"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "メトリクスウィジェット"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "通貨を検索..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "チャネルから削除"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "タイトル"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "画像を挿入"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "販売者の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "国を作成しました"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "販売者を選択"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "タグを読み込み中..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "ファセットを作成しました"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} 件のバリエーション"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "支払いの決済に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "請求先住所なし"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, other {{2}件の在庫ロケーションを削除できませんでした}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "ファセット"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "アクティブなチャネルからは削除できません"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "設定されていません"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "強制削除"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "新しいチャネル"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "オプショングループ名"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "AND"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "顧客グループの作成に失敗しました"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "ロールの作成に失敗しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "商品名"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "フルフィルメント状態を更新しました"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "商品"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "住所を作成しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key のローテーションに成功しました"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "オプショングループを追加"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "{0}を返金"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "スラッグを手動で入力"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "利用可能なウィジェットがありません"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "支払いのキャンセルに失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "支払いをキャンセルしました"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "グローバルビューを複製しました"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "作成者"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "バリアントを絞り込む..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "別の通貨で価格を追加"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "メールアドレスまたは識別子"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "返金#{0}を{1}に遷移しました"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "顧客"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "見出し4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "在庫ロケーションの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "注文を発送しました"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "住所を保存"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "グローバルにする"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "次の状態を選択"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "アラートなし"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "{0}個のコレクションを{2}に移動中"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "テスト"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "の間"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "メモを追加しました"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "メモを削除しました"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "メモを更新しました"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "返金の決済に失敗しました"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "在庫レベル"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "アイテムを追加"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key の作成に成功しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "プレビューを読み込み中..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "検索に戻る"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "ビューを複製しました"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "オプショングループを削除"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "説明"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "国"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "番地2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "グローバルビューを削除しました"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "レイアウトを編集"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "チャネルに割り当て"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "今週"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "商品オプショングループを正常に作成しました"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "{0} の手動支払いを追加"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "に含まれる"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "メールアドレス"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "管理者の更新に失敗しました"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "このテーブルの個人用保存ビューを管理"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "タグでフィルター"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "管理ダッシュボードにアクセスするにはログインしてください"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "注文に支払いを追加（{0}）"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "偽"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "ライト"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "リセット"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "と等しい"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "オプションを作成"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "パスワードを更新しました"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "を含まない"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "オプショングループ"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "以下の住所の詳細を編集してください。"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "税カテゴリを作成しました"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "コレクションの移動に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "支払い状態の更新に失敗しました"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "注文サマリー"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "アップロード"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "オプション付き商品"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "{0}件の結果をすべて表示"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "ルックアップ ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} 件"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "オプショングループ"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "カスタムフィールド"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "すべての注文ステータスとその遷移。現在のステータスがハイライトされています。"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "注文"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "注文サマリーウィジェット"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "商品追加中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "追加支払い調整中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "支払い手配中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "キャンセル済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "作成済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "配達完了"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "下書き"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "変更中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "一部配達完了"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "一部発送済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "支払い承認済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "支払い完了"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "発送済み"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "監視対象リソース"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "エンティティ情報"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "注文合計"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "管理者にのみ表示"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "数量"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "タグ"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "スーパー管理者"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "一部のリソースが停止しています"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "利用可能なアクション"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "リンクを挿入"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "有効にすると、親コレクションからフィルターが継承され、このコレクションに設定されたフィルターと組み合わされます。"
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "ゾーンを選択"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "配送方法をテスト"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "支払いを決済しました"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "ゾーンから{0} {1}を削除しました"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "有効化"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "支払い方法"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "承認済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "キャンセル済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "作成済み"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "拒否"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "エラー"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "失敗"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "保留中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "決済完了"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "平均注文額"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "ゾーンの作成に失敗しました"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "在庫レベル"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "API Key の更新に失敗しました"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "注文ライン"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "グローバルビューの名前変更に失敗しました"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "URL とターゲットオプションを指定して新しいハイパーリンクを挿入"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "高さ"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} の返金が必要です。支払い金額を選択し、メモを入力して続行してください。"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "単価"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "スケジュールパターン"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "支払いに失敗しました"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "チャネルを追加"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "商品オプショングループの更新に失敗しました"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "チャネルを検索..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "顧客グループを追加"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "利用可能な言語"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "選択をリセット"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "住所なし"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "支払い方法を作成しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "顧客情報を更新しました"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "ビューのグローバル化に失敗しました"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "商品バリエーション"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "商品"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "プロモーション"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "商品オプションの作成に失敗しました"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "古いメールアドレス："
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "すべてのユーザーが利用できるように、ビューを「グローバル」として保存してください。"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "バリエーションの作成に失敗しました"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "このバリエーションが在庫切れと見なされる在庫レベルを設定します。負の値を使用すると、バックオーダーサポートが有効になります。商品バリエーションで上書きできます。"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "キーをローテーション"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "商品バリエーションの作成に失敗しました"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "パスワードを非表示"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "新しい販売者"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "例：赤、L、コットン"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "プロフィールの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "クーポンコードを削除しました"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "フィルターをクリア"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "地域"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "ここにファイルをドロップしてアップロード"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "表示中のすべてのバリアントを切り替え"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "確認済み"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "新しいオプショングループ"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "最終更新{0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "グローバルビューはまだ作成されていません。"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "ロールの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "完全な API Key が表示されるのはこの1回のみです。今すぐコピーまたはダウンロードしてください。後から取得することはできません。"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "コレクションを更新しました"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "支払い方法を更新しました"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "ビューを削除しました"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "オプショングループ{0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "OR"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "タグを管理"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "クーポンコードが注文から削除されました"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "なし"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "ファセット値の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "グループを削除"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "注文をフルフィルメントしました"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "配送先住所なし"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "クエリ拡張に無効なGraphQL構文が含まれています"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "クエリ拡張エラー"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "クエリ拡張エラー："
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "クエリ拡張が無効です：少なくとも1つのトップレベルフィールドが必要です"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "クエリ拡張の不一致："
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "公開"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "税カテゴリを更新しました"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "移動"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "既存のタグを編集または削除"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "この配送方法の適格性チェッカー条件は、現在の注文と配送先住所では満たされていません。"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "クーポンコードを追加"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "クーポンコードが注文に設定されました"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "カスタムフィールド"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "新しい配送方法"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "在庫ロケーションを削除"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "以上"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "プレビュー"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{1} 件中 {0} 件が処理可能"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "今月の累計"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "顧客によるリクエスト"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "配送中の破損"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "在庫なし"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "その他"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "誤った商品"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "変更の概要"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "返金（{0}）"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "最終実行"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "支払い詳細"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "検索インデックスを再構築"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "実行中"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "60秒ごと"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "顧客グループの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "支払いメタデータ"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "変更をキャンセル"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "同じウィンドウ"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "テーブルにフィルターを適用し、「ビューを保存」をクリックして開始してください。"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "ロール"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "追加の支払いが必要です"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "注文の更新に失敗しました"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "選択した項目で..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "在庫ロケーションの作成に失敗しました"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "以下"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "{customerGroupName}の顧客グループメンバー"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "状態"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "追跡しない"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "フルフィルメント#{0}を作成しました"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "保留中の検索インデックス更新を実行中"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "これはデフォルトのロールであり、変更できません"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "保存したビュー"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "都道府県"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "有効"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "ページあたりの件数"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "メンバーを編集"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "手持ち在庫"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "{columnId}でフィルター"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "アラート"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "オプション値"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "変更をプレビュー"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "チャネルから {entityType} の削除に失敗しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "バリエーションを削除しました"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "選択したリンクのプロパティを編集"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "販売"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "移動先のコレクションを選択"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "最新の注文"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "スケジュールされたタスク"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "このアイテムを削除してもよろしいですか？この操作は取り消せません。"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "バリエーション"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "販売者"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "設定"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "設定ストア"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "見出し3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Vendureへようこそ"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "配送方法"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} 返金可能)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "識別子"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "コレクションの更新に失敗しました"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "価格と税"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "注文が見つかりません"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "エラー"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "注文を変更しました"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "パスワードリセットをリクエストしました"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "割り当てられた支払い金額は返金合計と等しくなければなりません"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "例：S"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "現在のチャネルから{0}{entityType}を削除してもよろしいですか？"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "タグを追加..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "商品オプショングループの作成に失敗しました"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} 件選択中"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "言語を検索..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "在庫ロケーション"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "前のページへ"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "内容"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "グローバルビューから個人ビューへの変換に失敗しました"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "ジョブの結果"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "支払いを追加（{0}）"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "システム"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "バリエーション名"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "削除"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "顧客の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "オプショングループを削除しますか？"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "これは現在のフィルタ設定に基づくコレクション内容のプレビューです。コレクションを保存すると、新しいフィルタ設定を反映するように内容が更新されます。"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, other {{count}人の顧客をグループから削除しました}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "税カテゴリ"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "税率"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "グループからの顧客の削除に失敗しました"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "グローバル設定の読み込みに失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "返金するアイテムを選択し、必要に応じて在庫に戻す"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "保存"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{0} 行中 {selectedRowCount} 行を選択中"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "注文の変更をプレビュー"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "商品オプショングループを正常に更新しました"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "ページはデフォルトのクエリで続行されます。"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "番地"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "これ以上ファセットはありません"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "検索インデックスの再構築を開始しました"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "コレクションの位置を更新しました"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "オプショングループ名"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "「{newOptionInput}」を追加"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "新しい商品バリエーション"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "返金を遷移しました"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "ネイティブ認証戦略を使用"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength}件の{entityType}をチャネルに割り当てられませんでした"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "デフォルト言語"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "トークン"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "フルフィルメント中..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "商品にオプショングループを追加"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "{0} のプレビュー"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "販売者を更新しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "注文のステート遷移に失敗しました"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "すべて表示 ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "税率の作成に失敗しました"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "この API Key を保存しました"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "ストアとチャネルで利用可能な言語を設定"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "商品を作成しました"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "商品バリエーションを追加"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "入力してEnterまたはカンマで追加..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "メモを編集"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "アセットが見つかりません。フィルターを調整してみてください。"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "オプションを追加"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "オプショングループを保存"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "{createCount}個のバリエーションを作成"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "「テストを実行」をクリックして、この配送方法をテストしてください。"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "管理者を正常に更新しました"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "フィルターをクリア"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "{1}から{2}へのフルフィルメント#{0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "グローバルビューの削除に失敗しました"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "デフォルト言語"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "ステータス"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "オプションが見つかりません"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "バイナリ"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "オプショングループの更新に成功しました"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "新しい配送方法"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "10秒ごと"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "税抜："
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "ロケーションに在庫を追加"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "オプション値を追加しました"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "コレクションを新しい親に移動しました"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "オプショングループを削除しました"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "選択した状態に遷移"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "{formattedDiff}の追加支払いが必要です。"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "デフォルトで在庫を追跡"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{total} 件中 {selected} 件を選択"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "配送方法を正常に作成しました"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "新しい顧客グループ"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "顧客に表示"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "オプショングループを作成しました"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "税率"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "スラッグは自動的に生成されます..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "顧客が見つかりません"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "{0}を選択"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "追加する新しいファセット値："
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "返金の処理に失敗しました"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "名"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "を含む"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "オプショングループが見つかりません"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "アイテムが見つかりません"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "小計"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "フルフィルメント済みアイテム（{0}）"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "値が更新されました"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "未確認"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "数量"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "フィルターを追加"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "税カテゴリ"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "プロフィール"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "テストデータが更新されました。「テストを実行」をクリックして更新された結果を確認してください。"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "に含まれない"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "注文ラインを更新しました"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "新しい支払い方法"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "重複する値「{trimmed}」はすでに存在します"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "理由"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "顧客グループ"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "チャネルから {entityType} を削除しました"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "オプショングループ"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "追加料金を追加"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "現在のファセット値"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "{totalPages} ページ中 {page} ページ"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "先月"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "国を追加"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "アイテムを削除"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "動画"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "より小さい"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "バリアントを追加できませんでした。親製品が有効になっていることを確認してください。"
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "不明なエラーが発生しました"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "指標"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "言語"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "新しいコレクション"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "返金して注文をキャンセル"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "メールアドレスの更新を確認しました"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "の間"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "返金とキャンセル"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "配送方法をテスト中..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "配送方法の作成に失敗しました"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength}個の{entityType}をチャネルに割り当てました"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "グローバル言語"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "新しい管理者"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "下書きを削除"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "ソース"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "利用可能なアクションがありません"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "チャネルの更新に失敗しました"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "一般"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "チャネルから商品を削除できませんでした"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "新しい住所を追加"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "ファセットを更新しました"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "ゾーンを作成しました"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "値"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "顧客を更新しました"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "価格換算係数"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "販売者注文"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "新しいファセット"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "この商品からオプショングループを削除してもよろしいですか？"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "説明（代替テキスト）"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "タグが見つかりません"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "デフォルト通貨"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "これらの変更には支払いまたは返金は必要ありません。"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "総収益"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "次回実行"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "メモは非公開です"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "中程度の日付"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "無効な数値"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "まだビューを保存していません。"
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "このビューを削除してもよろしいですか？この操作は取り消せません。"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "注文プロセスを表示"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "ビューの複製に失敗しました"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "デフォルトの配送先住所として使用"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "スラッグを手動で編集"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "コレクションの内容をプレビューするにはフィルタを追加してください。"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "商品オプショングループ"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "小計"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "より小さい"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "返金ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "注文カスタムフィールドが更新されました"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "計算機"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "チャネルからオプショングループの削除に失敗しました: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "ジョブデータを表示"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "トップレベルに移動"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "クリア"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "注文サマリー"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "アセットを検索..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "新しいファセット"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "チャネルに{entityType}を割り当て"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "続行"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "プロモーション"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "エラーメッセージ"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "別のロケーションの在庫レベルを追加"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "住所を削除"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "ファセットの更新に失敗しました"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFiltersはWidgetFiltersProvider内で使用する必要があります"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "住所を編集"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "チャネルからのファセットの削除に失敗しました：{message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "リンクを設定"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "新しい販売者"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "画像を編集"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "バリエーションを管理"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "在庫割り当て済み"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "以上"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "このバリエーションが在庫切れと見なされる在庫レベルを設定します。負の値を使用すると、バックオーダーサポートが有効になります。"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "商品オプションを作成"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "保存中..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "結果を表示"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "ページあたりの行数"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "コレクションを読み込み中..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "ファセット値を更新しました"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "アセットを追加"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "変更を保存"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "顧客をグループに追加しました"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "販売者注文"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "オプション値の追加に失敗しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "{groupName}にオプション値を追加"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity}点返金済み"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "オプショングループがまだ定義されていません。商品の異なるバリエーションを作成するためにオプショングループを追加してください（例：サイズ、色、素材）"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "新しいメールアドレス："
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "支払い方法の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "利用可能："
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "作成日時"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "商品バリエーションの作成に失敗しました"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "言語: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "グローバル言語設定を表示する権限がありません"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "税率を作成しました"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "見出し6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "クーポンコードを追加しました"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "アクティブ"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "課税標準"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "さらに読み込む"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "返金を決済しました"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count}個の{entityName}を複製しました"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "新しいオプショングループ"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "まだ結果がありません"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "支払いを決済しました"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "利用可能な条件"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "アクティブなフィルター"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "すべてクリア"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "より大きい"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "閉じる"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "注文に支払いを追加"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "読み込み中..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "トークンは、APIリクエストを行う際にチャネルを指定するために使用されます。"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "住所が見つかりません"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "フルフィルメントID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "返金する支払いを選択"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "{failed}{entityName}の削除に失敗しました"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "在庫切れしきい値"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "チャネルから商品を正常に削除しました"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "値の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "API Key の作成に失敗しました"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "返金を決済"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "支払い方法は必須です"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "顧客のグループへの追加に失敗しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "バリエーションを管理"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "グローバルビュー「{viewName}」を適用しました"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "顧客を登録しました"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "ゾーン"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "販売者を検索..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "プロモーションを作成しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "オプション"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "注文プロセス"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "電話番号"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "非公開"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "バリエーション"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "グローバル設定を更新しました"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key の更新に成功しました"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "これらの言語は、すべてのチャネルで使用できます"

--- a/packages/dashboard/src/i18n/locales/nb.po
+++ b/packages/dashboard/src/i18n/locales/nb.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Fullt navn"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Velg varer"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Vis endringer"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Sporingskode"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "De valgte tillatelsene vil bli brukt på disse kanalene."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Produktopsjoner"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Ny skattesats"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Tilordne en eksisterende opsjonsgruppe eller opprett en ny"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Ny rolle"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Leilighet, suite, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Ingen flere varer"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Rediger lenke"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Legg til minst én vare i bestillingen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Legg til produkter for å opprette en testbestilling"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Kunne ikke opprette adresse"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Veksle alle"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Rediger JSON-verdi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Bruker ekstern autentiseringsstrategi: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Velg en grunn..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Overskrift 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Kunne ikke legge til betaling"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Oppdatert"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Kunne ikke oppdatere globale innstillinger"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Bestilling oppfylt"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Er du sikker på at du vil slette {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Global utsolgt-terskel"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Administrer språk"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Dupliserer... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Slettet"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Fjern fra gjeldende kanal"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Slettet {selectionLength} ressurser"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Skattesats oppdatert"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Skriv inn egendefinert grunn..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Type"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Velg {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Vis verdier"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Slett rad"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Betingelser"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Gjeldende"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Ingen oppfyllelser"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Kunne ikke slette {1} lagerplassering: {messages}} other {Kunne ikke slette {2} lagerplasseringer: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Når dette er aktivert, vil prisene som er angitt i produktkatalogen inkludere mva for standard skattesone."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Opprett varianter for produktet ditt"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Utkastbestilling fullført"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Auto-oppdatering: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Helsesjekker"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Slettet {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Helsesjekker"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Selgere"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Alternativer"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} jobb ble avbrutt} other {{fulfilled} jobber ble avbrutt}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Selger"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "Varenr.:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Legg til betaling"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Test denne fraktmetoden ved å simulere en bestilling for å se om den er kvalifisert og hva fraktkostnaden ville være."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Utforsk Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Lagerlokasjoner"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Oppfyllelsesbehandler"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Bestillinger"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Velg roller"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Rolle opprettet"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Er du sikker på at du vil slette denne varianten?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Alle ressurser er oppe og kjører"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Kunne ikke opprette administrator"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Nei"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Produktvariant oppdatert"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Kunne ikke slette {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Produkt oppdatert"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Kunne ikke oppdatere land"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Skriv minst 2 tegn for å søke..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Etternavn"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Lenketittel"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Kundegruppe oppdatert"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Egendefinerte felt endret"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Lagerlokasjon opprettet"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Ukjent feil"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Total refusjon kan ikke være negativ"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Vis detaljer"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Velg en kanal å tildele {0} {entityType} til"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Kunde opprettet"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Siste 7 dager"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Kunne ikke opprette kanal"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Utviklermodus"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Ny rolle"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Kunne ikke slette ressurser: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Returner til lager"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Synlighet"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Produktvarianter"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Ny kundegruppe"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Opprett \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Gi nytt navn"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Velg foretrukket visningsspråk og lokale innstillinger"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} opsjonsgrupper ble fjernet fra kanalen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Fraktmetode er ikke kvalifisert for denne bestillingen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Kunne ikke oppdatere adresse"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adresse slettet"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Skattesats"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Ordreutkastet er ikke klart til å fullføres"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Ny samling"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Innsikt"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Kjør"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Kunne ikke oppdatere skattesats"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Dette er innholdet i samlingen <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privat"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Produktalternativ opprettet"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Overordnet produkt"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "By"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administratorer"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Bruttopris: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Gå til neste side"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Fjern lenke"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Dette feltet er skrivebeskyttet"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Antall bestillinger"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Bestilling oppdatert"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Arv filtre"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Administrer globale lagrede visninger som er synlige for alle brukere"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Søk betalingsmetoder..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Leveringsadresse fjernet for bestilling"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Opprett {enabledCount} varianter"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Betaling #{0} endret til {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Feil ved lasting av kundehistorikk: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "Fjernet {selectionLength} {entityType} fra kanal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Legg til opsjonsverdi"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Globale innstillinger"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "er etter"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Produktalternativ oppdatert"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Rediger fasettverdier"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Legger til..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Flytt samlinger"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Roller"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Rutenettvisning"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Kunne ikke slette adresse"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Ingen fraktmetoder tilgjengelig"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Global visning konvertert til personlig visning"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Oppfyllelse endret"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Er du sikker på at du vil slette {selectionLength} ressurser?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Logg inn"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Listevisning"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Testbestilling"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Velg en kunde for å fortsette"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Opsjonsgruppen ble tilordnet"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Kjør test"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Skattesats: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Vennligst legg til produkter og fullfør leveringsadressen for å kjøre testen."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Veksle overskriftsrad"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Velg adresse"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Betalingsberettigelsessjekker"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Standard skattesone"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Ordreutkastet er klart til å fullføres"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadata"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrer..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Ny fasettverdi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Kanal oppdatert"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Vis mindre"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Kort dato"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Tilgjengelige valutaer"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Velg {0} varer"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Plassert"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Rotering av denne nøkkelen vil umiddelbart ugyldiggjøre den gjeldende nøkkelen. Alle integrasjoner som bruker den vil slutte å fungere inntil de oppdateres med den nye nøkkelen."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Dataene som har blitt sendt til jobben"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Bekreft navigering"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Lenkemål"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Fullfør utkast"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Navn"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Kunne ikke oppfylle bestilling"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Totalt"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Skriv inn transaksjons-ID for denne refusjonsoppgjøret"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Din API-nøkkel"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Er du sikker på at du vil slette denne utkastbestillingen?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Oppfyllelse opprettet"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Fant {0} kvalifiserte fraktmetode(r)"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Dimensjoner"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Vis passord"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(maks: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Firma"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Legg til kolonne etter"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Handlinger"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Rabatter"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Skriv inn refusjonsnotat"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Bestillingslinje fjernet"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Innhold:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Nøkkel"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Bekreft"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Kunne ikke opprette samling"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Gå til første side"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Kunne ikke opprette produkt"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Kunde"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Feil ved lasting av bestillingshistorikk: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Leveringsadresse satt for bestilling"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Fokuspunkt"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Enkel variant, ingen opsjoner"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Velg neste tilstand for bestillingen"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Lokalitet"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Planlagte oppgaver"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Skriv inn transaksjons-ID"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Oppdater data"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Legg til eller fjern fasettverdier for {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Dette er fasettverdiene for fasetten <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Betaling lagt til bestilling"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Fakturaadresse satt for bestilling"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Kunne ikke oppdatere sone"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Passord"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Kunne ikke slette"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Planlagt oppgave vil bli utført"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Ny lagerlokasjon"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Tillatelser"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Leveringsadresse endret"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Ingen produkter funnet"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Legg til rad før"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Gå over til {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Denne måneden"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Kunne ikke opprette fasett"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Kunne ikke kansellere ordrevarer"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "Transaksjons-ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Allokert"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Legg til en annen opsjonsgruppe"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Velg hva som skal skje med gjenværende beholdning"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Utforsk Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Hvert 5. sekund"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Samling opprettet"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Pris"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Utkastbestilling"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Omfang"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Legg til betingelse"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Fraktmetode er kvalifisert for denne bestillingen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administratorer"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Fjernet fra gruppe"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Bredde"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Ingen betaling eller refusjon nødvendig"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Last ned som .env-fil"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Når aktivert, er en kampanje tilgjengelig i butikken"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Når sporet, vil produktvariantens lagernivåer automatisk justeres ved salg. Denne innstillingen kan overstyres av individuelle produktvarianter."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Leveringsmetode satt for bestilling"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Kunne ikke oppdatere kampanje"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Bilder"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Søk {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Rediger ressurs"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Avbryt betaling"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Jobbkø"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Ressurser"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "E-postadresse"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Regenerer slug fra kildefelt"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Arv fra globale innstillinger"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Ingen resultater funnet"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Gjeldende status"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Angi en leveringsadresse og velg en fraktmetode"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Av"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Innstillingslager"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Kø"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Ny skattesats"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Betaling endret"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Gjenstående:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Ingen duplikator funnet med kode \"{duplicatorCode}\" for {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Priser inkluderer mva for standard skattesone"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Total refusjon:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Vis jobbresultat"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Test fraktmetodene dine ved å simulere en ny bestilling."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Ingen varer valgt"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} valgt"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Ingen land funnet"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Variantene ble opprettet"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Generer slug automatisk"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Tilleggsgebyr"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Betalingsmetoder"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Lager"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Ingen kunder funnet"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Bruk global utsolgt-terskel"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Ny produktopsjonsgruppe"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Betalingstilstand oppdatert"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Opprett ny"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Total refusjon"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adresse slettet"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Bare roller tilordnet din konto er tilgjengelige."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Vare lagt til bestilling"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Rediger fokuspunkt"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Ingen selgere funnet"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Ressurs"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Denne opsjonsgruppen brukes av ett annet produkt. Endringer vil også påvirke det.} other {Denne opsjonsgruppen er delt mellom # produkter. Endringer vil påvirke alle.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Mine lagrede visninger"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Ny kanal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Kunne ikke opprette selger"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Konfigurer duplikeringsinnstillinger for {0}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Ingen varianter samsvarer med gjeldende filter."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adresser"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Legg til en ny opsjonsverdi i opsjonsgruppen {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Bestillingsendring #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Legg til kolonne før"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Kanalspråk"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Kunne ikke opprette opsjonsgruppe"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Sann"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Velg kunde"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Bestilling endret"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Dette produktet har eksisterende varianter, men ingen opsjonsgrupper definert. Du må legge til opsjonsgrupper før du oppretter nye varianter."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "er før"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Slett utkastbestilling"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Katalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Ny betalingsmetode"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Kampanje oppdatert"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Kunne ikke avbryte {rejected} jobb} other {Kunne ikke avbryte {rejected} jobber}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Velg en kanal"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Visningsspråk"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Oppfyllelsesdetaljer"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Forkast gjenværende beholdning"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Nå"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Kanaler"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Visning konvertert til global"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "før"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Størrelse"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Ingen oversettelse funnet for {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Ny kunde"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Siste bestillinger"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} flere"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Bruk som standard fakturaadresse"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Slett"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Deaktiver"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Samlinger"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Legg til variant"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Kunne ikke opprette land"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Land"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Kunne ikke opprette produktopsjoner"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Kunne ikke gi nytt navn til visning"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Tilgjengelig"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtre"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Kundegrupper"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Kunder"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Eksempel på formatering"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Ny opsjon"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Bruksgrense"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Laster globale innstillinger..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adresse oppdatert"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Opprettet"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Laster adresser..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Velg en målsamling å flytte {0} til."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Kundedetaljer oppdatert"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "ikke i"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Bruk"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Ny produktopsjon"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Gå til siste side"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Avbryt"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Produktvariant opprettet"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Refusjon fra denne metoden"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Postnummer"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Legg til produktopsjoner først"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Ny skattekategori"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Legg til opsjon"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Delvis refusjon fullført"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Sett egendefinerte felt"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Samlinger"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Slett variant"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Ingen endringer gjort"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Standard fraktsone"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Årsak:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Leveringsadresse"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Gå over til {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Skattekategorier"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Private samlinger er ikke synlige i butikken"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Når aktivert, er et produkt tilgjengelig i butikken"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Planlagt oppgave kunne ikke utføres"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Kundegrupper"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Deaktivert"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Ny kampanje"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Standard leveringsadresse"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Refusjon nødvendig"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Oppfyll bestilling"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Du har ikke tillatelse til å se kanalinnstillinger"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Siste 30 dager"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Ingen fasettverdier"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "En grunn for refusjonen er påkrevd"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Kunne ikke fjerne opsjonsgruppen"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Kunne ikke oppdatere skattekategori"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Refusjon gjennomført"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Oppdater"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Overskrift 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Bestilling lagt inn"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profil oppdatert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "slutt"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Betalingsmetode"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Rediger"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variant oppdatert"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtrer etter samlingsnavn"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Notat lagt til"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Velg antall å oppfylle og konfigurer oppfyllelsesbehandleren"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Fakturaadresse fjernet fra bestilling"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Starter"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Dupliser"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Ingen resultater"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Kolonneinnstillinger"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Kunne ikke slette {count} lagerplassering} other {Kunne ikke slette {count} lagerplasseringer}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Kode"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Kunne ikke fjerne opsjonsgruppene"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Bestilling levert"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Overfør til {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Gjenværende beholdning"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Fjern fra sone"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Velg fra globalt tilgjengelige språk for denne kanalen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Er du sikker på at du vil slette denne adressen?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Kunne ikke tilordne opsjonsgruppen"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Kunne ikke oppdatere ressurs"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Lagerlokasjon oppdatert"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Bekreft handling"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Land oppdatert"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Fasetter"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Kunne ikke legge til notat"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Kunne ikke slette notat"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Kunne ikke utvide spørringsdokument"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Kunne ikke oppdatere notat"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Refunder frakt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Skrivebeskyttet"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Kunne ikke duplisere global visning"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Viser {shown} av {total} • {selected} valgt"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Test fraktmetode"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Fasettverdier"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Ressurs oppdatert"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Tema"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} kunder"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Velg et språk"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Logg ut"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Forsøk"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Tilgjengelige valutakoder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Tilgjengelige språkkoder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Brødsmuler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Kategori"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Kanaler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Underelementer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Kode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Kupongkode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Opprettet"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Valutakode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Kunde"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Kundegruppe"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Kunder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Egendefinerte felt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Data"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Standard valutakode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Standard språkkode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Standard fraktsone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Standard skattesone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Beskrivelse"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Varighet"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "E-postadresse"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Aktivert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Slutter"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Feil"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Fremhevet ressurs"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Fornavn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Oppfyllelsesbehandlerkode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Standard"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Privat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Gjennomført"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Etternavn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Navn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Bestilling lagt inn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "Overordnet ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Bruksgrense per kunde"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Tillatelser"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Posisjon"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Pris"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Priser inkluderer mva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Pris inkl. mva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Produktvarianter"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Fremgang"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Kønavn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Resultat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Nye forsøk"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Selger"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Gjort opp"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Fraktlinjer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Startet"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Starter"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Tilstand"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Lagernivåer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Total"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Total inkl. mva"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Type"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Oppdatert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Bruksgrense"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Bruker"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Verdi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Verdiliste"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Sone"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Metode"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Skatteoppsummering"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Setter språkene som er tilgjengelige for alle kanaler. Individuelle kanaler kan deretter støtte en delmengde av disse språkene."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Samlinger flyttet vellykket"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registrert"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Avbryt jobb"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Slutter"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Side {0} av {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Sats"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Størrelse, farge, osv."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Bla gjennom fasetter"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Sone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Avbrutt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Opprettet"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Levert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Venter"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Sendt"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Lagre visning"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} valgt"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Søk etter opsjonsgrupper..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Endre bestilling"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Valgte varer"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Verdier"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Kunde satt for bestilling"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Fasetter"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Er du sikker på at du vil fjerne {count} kunde fra denne gruppen?} other {Er du sikker på at du vil fjerne {count} kunder fra denne gruppen?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Lager på hånd"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Gjenoppbygging av søkeindeks kunne ikke startes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Leveringsadresse"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Ny sone"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Ny API-nøkkel"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Slett kolonne"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Tilordne eksisterende"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "er null"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Dette er kundene i kundegruppen <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Administrer globale visninger"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Standardkanal"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Sett inn et nytt bilde med kilde, tittel og dimensjoner"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Kunne ikke opprette fasettverdi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Kunne ikke oppdatere produktalternativ"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Glemt passord?</0><1>Be om tilbakestilling</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Kupongkode"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Kunde verifisert"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Globale innstillinger"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Tidsplan"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Kan ikke flytte en samling til sin egen undergruppe"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Ny skattekategori"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Ingen lagerlokasjoner tilgjengelig på gjeldende kanal"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Kanal opprettet"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Kunde oppdatert"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Vis data"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Slett visning"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Legg til en ny adresse til kunden."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Flere visninger"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Rediger egenskapene for det valgte bildet"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Brukte visning \"{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Fjernet {successCount} fasetter fra kanal"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Nytt produkt"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Ny ressurs"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Beregn frakt på nytt"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Velg hvilke opsjoner som skal gjelde for eksisterende variant \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Ressurser"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Dette vil fjerne alle opsjonsgrupper fra dette produktet og returnere til variantoppsettsvalget."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Fakturaadresse"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Legg til fasettverdi"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Vennligst velg en målsamling"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Gjennomgå endringene før du bruker dem på bestillingen."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Velg en rolle"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Bestilling kansellert"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Rabatt"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Alle typer"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Kun ordreutkast kan fullføres"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Kunne ikke oppdatere produkt"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Justerer {0} linjer"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Legg til fasettverdier"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "etter"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Kanal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Helsesjekker"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Beløp"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Ny kunde"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Bilde"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administrator opprettet"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Produktopsjoner"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Velg land"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Oppretter..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Er du sikker på at du vil slette denne globale visningen? Denne handlingen kan ikke angres og vil påvirke alle brukere."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Tving fjerning av alternativgruppe"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Lagt til"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Kundehistorikk"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Fasettverdier oppdatert for {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Kunne ikke fjerne kunde fra gruppe"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Bruksgrense per kunde"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Fakturaadresse endret"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Velg en opsjon"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Kopier til personlig"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Total refusjon overstiger maksimalt refunderbart beløp på {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Slett global visning"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Opprett"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Hvert 30. sekund"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Nytt land"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "Fra {0} til {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Kunne ikke opprette kunde"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Fokuspunkt oppdatert"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Opsjonsverdier"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Standard fakturaadresse"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Ingen kunde"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Kunne ikke fjerne land fra sonen"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Kunne ikke opprette kampanje"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "I dag"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "I går"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Opsjonsnavn"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Er du sikker på at du vil fjerne {0} {1} fra denne sonen?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Legger til {0} tillegg"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Lenke-href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Reserveverdi: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Bestillingshistorikk"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Overstyr"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "Transaksjons-ID er påkrevd"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "samsvarer med regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Global visning omdøpt"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Ingen tagger valgt"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Tilbake"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Visning omdøpt"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Bruk filter"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Siste resultat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Lagt til gruppe"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Innsikt"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Opprett varianter"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Tester fraktmetode..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Mørk"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Testresultater"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Legg til kunde"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Lagre endringer"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adresse oppdatert"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Refusjon behandlet vellykket"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Ny sone"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Kunne ikke oppdatere samlingsposisjon"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Refusjon"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Endre"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Ingen globale språk konfigurert"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Fjerner {0} vare(r)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Spor"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Opprett variant"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Fasettverdier for {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Lagre layout"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Tilbakestilling av passord verifisert"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Kunne ikke slette visning"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Er du sikker på at du vil forlate denne siden? Alle ulagrede endringer vil gå tapt."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Veksle overskriftskolonne"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Ny kampanje"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Opsjonsverdinavn"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Sist brukt"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Er standard skattekategori"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug er satt"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Kunne ikke oppdatere fokuspunkt"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Sone oppdatert"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Stat/Fylke"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Kunne ikke oppdatere opsjonsgruppen"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Kanalstandarder"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Kunne ikke opprette skattekategori"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Angi filterkriterier for kolonnen {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Land"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Enkelt produkt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Jobbkø"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Bekreft at du har lagret API-nøkkelen før du lukker."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Bekreft sletting"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Kunne ikke endre bestilling"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Inkluderer mva. på {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Bestillingsberegninger"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Velg visningsspråk"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Autentiseringsmetoder"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "start"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Kunne ikke rotere API-nøkkelen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "i"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Søk roller..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Produktvarianter"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Administrer globale visninger"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Behandler..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} funnet"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Velg datoperiode"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Produkt"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Roter API-nøkkel"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Kategori"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Flytter..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Tildel"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Selger opprettet"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Fraktmetode oppdatert"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Kunne ikke oppdatere produktvariant"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Dra for å endre rekkefølge"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Soner"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Velg hva som skal skje med lagerbeholdningen som er igjen på {count, plural, one {# lagerplassering} other {# lagerplasseringer}} du sletter. Alle valgte plasseringer overfører den gjenværende beholdningen til den ene plasseringen du velger, eller den forkastes."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Søk i fasetverdier..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Notat"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Tilgjengelige språk"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Last {0} flere ({remaining} gjenstår)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Fasettverdier"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Kunne ikke omorganisere varer"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Totalt antall bestillinger"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Ingen kvalifiserte fraktmetoder funnet for denne bestillingen."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Legg til produktopsjon"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Frakt"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions må brukes innenfor en DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Denne alternativgruppen er i bruk av eksisterende varianter. Tvungen fjerning kan påvirke disse variantene. Er du sikker?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "E-postoppdatering forespurt"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Feil ved overgang til tilstand"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Kundegruppe opprettet"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nytt vindu"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Betaling autorisert"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Rolle oppdatert"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Velg et land"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Kunne ikke oppdatere fraktmetode"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Slettet {deleted} lagerplassering} other {Slettet {deleted} lagerplasseringer}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Fraktmetoder"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Velg en adresse"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Ja"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Sett fokuspunkt"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "slutt"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Velg en valuta"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Oppdater notatinnhold eller synlighet"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Siste bestillinger-widget"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Samlingens innhold for {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Fraktmetode endret"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Avgiftsbeskrivelse"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "er mindre enn eller lik"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "er ikke lik"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Oppdater"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "f.eks. Størrelse"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Gjennomfør betaling"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Kanaler"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Frakt refundert"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Ressurstype"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Ny lagerlokasjon"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} betaling(er) refundert før feil. Sjekk ordrehistorikk for detaljer."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Velg vare"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Nytt produkt"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Administrer tagger"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Varer refundert"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Legg til handling"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Tildel opsjoner til eksisterende variant"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Dupliser {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Fjern fra gruppe"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Kunne ikke oppdatere oppfyllelsestilstand"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Opprett en ny produktvariant med opsjoner, pris og lager"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Private fasetter er ikke synlige i butikken"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Velg en skattekategori"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Opprettet"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Kjører ikke"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Tilordnet"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Overskrift 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Velg tilgjengelige språk"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Legger til {0} vare(r)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Legg til rad etter"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Mva totalt"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Utkast til ordrestatus"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Produktopsjoner opprettet"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Laster plasseringer…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Kunne ikke opprette betalingsmetode"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Fasettverdi opprettet"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Markedsføring"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Utkastbestilling slettet"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "større enn"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Metrikk-widget"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Søk valutaer..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Fjern fra kanal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Tittel"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Sett inn bilde"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Kunne ikke oppdatere selger"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Land opprettet"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Velg selger"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Laster tagger..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Fasett opprettet"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} varianter"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Kunne ikke gjennomføre betaling"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Ingen fakturaadresse"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Kunne ikke slette {1} lagerplassering} other {Kunne ikke slette {2} lagerplasseringer}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Fasett"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Kan ikke fjerne fra aktiv kanal"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Ikke angitt"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Tving fjerning"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Ny kanal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Opsjonsgruppens navn"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "OG"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Kunne ikke opprette kundegruppe"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Kunne ikke opprette rolle"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Produktnavn"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Oppfyllelsestilstand oppdatert"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Produkter"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adresse opprettet"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API-nøkkelen ble rotert"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Legg til opsjonsgruppe"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Refunder {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Skriv inn slug manuelt"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Ingen widgeter tilgjengelig"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Kunne ikke kansellere betaling"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Betaling kansellert"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Global visning duplisert"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Opprettet av"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtrer varianter..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Legg til en pris i en annen valuta"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "E-postadresse eller identifikator"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Refusjon #{0} endret til {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Kunder"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Overskrift 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Kunne ikke oppdatere lagerlokasjon"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Bestilling sendt"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Lagre adresse"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Gjør global"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Velg neste tilstand"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Ingen varsler"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Flytter {0} samling(er) til {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "mellom"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Notat lagt til"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Notat slettet"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Notat oppdatert"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Kunne ikke gjennomføre refusjon"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Lagernivå"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Legg til vare"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API-nøkkelen ble opprettet"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Laster forhåndsvisning..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Tilbake til søk"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Visning duplisert"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Fjern alternativgruppe"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Land"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Gateadresse 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Global visning slettet"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Rediger layout"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Tildel til kanal"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Denne uken"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Produktalternativgruppe opprettet"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Legg til manuell betaling på {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "er i"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-post"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Kunne ikke oppdatere administrator"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Administrer dine personlige lagrede visninger for denne tabellen"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtrer etter tagger"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Logg inn for å få tilgang til administrasjonspanelet"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Legg til betaling til bestilling ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Usann"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Lys"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Tilbakestill"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "er lik"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Opprett opsjoner"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Passord oppdatert"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "inneholder ikke"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Opsjonsgruppe"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Rediger adressedetaljene nedenfor."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Skattekategori opprettet"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Kunne ikke flytte samlinger"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Kunne ikke oppdatere betalingstilstand"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Oversikt over dine bestillinger"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Last opp"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Produkt med opsjoner"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Viser alle {0} resultater"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Oppslags-ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} flere"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Opsjonsgrupper"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Egendefinerte felt"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Alle mulige ordretilstander og deres overganger. Gjeldende tilstand er uthevet."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Bestillinger"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Bestillingsoversikt-widget"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Legger til varer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Ordner tilleggsbetaling"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Arrangerer betaling"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Kansellert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Opprettet"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Levert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Utkast"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Endrer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Delvis levert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Delvis sendt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Betaling autorisert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Betaling gjennomført"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Sendt"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Overvåkede ressurser"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Enhetsinformasjon"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Totalt bestilling"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Synlig kun for administratorer"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Ant."
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Tagger"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Superadministrator"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Noen ressurser er nede"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Tilgjengelige handlinger"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Sett inn lenke"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Hvis aktivert, vil filtrene arves fra overordnet samling og kombineres med filtrene satt på denne samlingen."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Velg en sone"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Test fraktmetoder"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Betaling gjennomført"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "Fjernet {0} {1} fra sonen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Aktiver"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Betalingsmetoder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autorisert"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Avbrutt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Opprettet"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Avvist"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Feil"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Mislyktes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Venter"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Gjort opp"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Gjennomsnittlig ordreverdi"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Kunne ikke opprette sone"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Lagernivåer"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Kunne ikke oppdatere API-nøkkelen"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Bestillingslinjer"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Kunne ikke gi nytt navn til global visning"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Sett inn en ny hyperlenke med URL og målalternativer"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Høyde"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "En refusjon på {formattedDiff} er nødvendig. Velg betalingsbeløp og skriv inn en merknad for å fortsette."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Enhetspris"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Tidsplanmønster"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Betaling mislyktes"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Legg til kanal"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Kunne ikke oppdatere produktalternativgruppe"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Søk kanaler..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Legg til kundegrupper"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Tilgjengelige språk"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Tilbakestill valg"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Ingen adresse"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Betalingsmetode opprettet"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Kundeinformasjon oppdatert"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Kunne ikke konvertere visning til global"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Produktvarianter"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Produkter"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Kampanjer"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Kunne ikke opprette produktalternativ"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Gammel e-post:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Lagre en visning som \"Global\" for å gjøre den tilgjengelig for alle brukere."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Kunne ikke opprette variantene"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Setter lagernivået der denne varianten anses som utsolgt. Bruk av en negativ verdi aktiverer restordrestøtte. Kan overstyres av produktvarianter."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Roter nøkkel"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Kunne ikke opprette produktvarianter"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Skjul passord"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Ny selger"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "f.eks. Rød, Stor, Bomull"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Kunne ikke oppdatere profil"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Kupongkoder fjernet"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Tøm filter"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regioner"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Slipp filer her for å laste opp"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Veksle alle synlige varianter"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verifisert"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Ny opsjonsgruppe"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Sist oppdatert {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Ingen globale visninger er opprettet ennå."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Kunne ikke oppdatere rolle"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Dette er den eneste gangen den fullstendige API-nøkkelen vil vises. Kopier eller last den ned nå — den kan ikke hentes frem igjen senere."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Samling oppdatert"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Betalingsmetode oppdatert"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Visning slettet"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Opsjonsgruppe {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "ELLER"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Administrer tagger"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Kupongkode fjernet fra bestilling"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Aldri"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Kunne ikke oppdatere fasettverdi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Fjern gruppe"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Bestilling oppfylt"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Ingen leveringsadresse"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Spørringsutvidelse inneholder ugyldig GraphQL-syntaks"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Feil ved spørringsutvidelse"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Feil ved spørringsutvidelse:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Spørringsutvidelse er ugyldig: må ha minst ett toppnivåfelt"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Uoverensstemmelse i spørringsutvidelse:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "offentlig"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Skattekategori oppdatert"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Flytt"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Rediger eller slett eksisterende tagger"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Denne fraktmetodens berettigelsesbetingelser er ikke oppfylt for gjeldende bestilling og leveringsadresse."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Legg til kupongkode"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Kupongkode satt for bestilling"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Egendefinerte felt"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Ny fraktmetode"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Slett lagerplasseringer"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "er større enn eller lik"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Forhåndsvisning"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} av {1} tilgjengelig for leveranse"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Måned til dags dato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Kundeønske"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Skadet under frakt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Ikke tilgjengelig"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Annet"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Feil vare"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Oppsummering av endringer"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Refusjoner ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Sist utført"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Betalingsdetaljer"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Bygg søkeindeks på nytt"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Kjører"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Hvert 60. sekund"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Kunne ikke oppdatere kundegruppe"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Betalingsmetadata"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Avbryt endring"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Samme vindu"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Bruk filtre på tabellen og klikk \"Lagre visning\" for å komme i gang."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Roller"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Ekstra betaling påkrevd"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Kunne ikke oppdatere bestilling"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Med valgte..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Kunne ikke opprette lagerlokasjon"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "mindre enn eller lik"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Kundegruppemedlemmer for {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Tilstand"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Ikke spor"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Oppfyllelse #{0} opprettet"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Kjører ventende søkeindeksoppdateringer"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Dette er en standardrolle og kan ikke endres"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Mine lagrede visninger"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Stat / Fylke"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Aktivert"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Elementer per side"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Rediger medlemmer"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Lager på hånd"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtrer etter {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Varsler"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Opsjonsverdier"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Forhåndsvis endringer"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Kunne ikke fjerne {entityType} fra kanalen"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variant slettet"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Rediger egenskapene for den valgte lenken"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Salg"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Velg en målsamling"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Dine siste bestillinger"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Planlagte oppgaver"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Er du sikker på at du vil slette denne varen? Denne handlingen kan ikke angres."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Varianter"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Selgere"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Innstillinger"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Innstillingslager"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Overskrift 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Velkommen til Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Fraktmetoder"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} refunderbart)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identifikator"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Kunne ikke oppdatere samling"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Pris og mva"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Bestilling ikke funnet"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Feil"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Bestilling endret"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Tilbakestilling av passord forespurt"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Tildelt betalingsbeløp må være lik total refusjon"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "f.eks. Liten"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Er du sikker på at du vil fjerne {0} {entityType} fra gjeldende kanal?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Legg til tagger..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Kunne ikke opprette produktalternativgruppe"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} elementer valgt"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Søk språk..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Lagerlokasjoner"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Gå til forrige side"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Innhold"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Kunne ikke konvertere global visning til personlig visning"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Resultatet av jobben"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Legg til betaling ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Variantnavn"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Fjern"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Kunne ikke oppdatere kunde"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Fjerne opsjonsgrupper?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Dette er en forhåndsvisning av samlingens innhold basert på gjeldende filterinnstillinger. Når du lagrer samlingen, vil innholdet bli oppdatert for å gjenspeile de nye filterinnstillingene."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {Fjernet {count} kunde fra gruppen} other {Fjernet {count} kunder fra gruppen}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Skattekategorier"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Skattesatser"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Kunne ikke fjerne kunder fra gruppen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Kunne ikke laste globale innstillinger"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Velg varer å refundere og eventuelt returnere til lager"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Lagre"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} av {0} rad(er) valgt."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Forhåndsvis bestillingsendringer"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Produktalternativgruppe oppdatert"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Siden vil fortsette med standardspørringen."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Gateadresse"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Ingen flere fasetter"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Gjenoppbygging av søkeindeks startet"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Samlingsposisjon oppdatert"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Opsjonsgruppens navn"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Legg til \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Ny produktvariant"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Refusjon endret"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Bruker innebygd autentiseringsstrategi"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Kunne ikke tilordne {entityIdsLength} {entityType} til kanal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Standardspråk"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Oppfyller..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Legg til opsjonsgruppe til produkt"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Forhåndsvisning av {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Selger oppdatert"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Kunne ikke endre bestilling til tilstand"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Vis alle ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Kunne ikke opprette skattesats"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Jeg har lagret denne API-nøkkelen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Konfigurer tilgjengelige språk for butikken og kanalene dine"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Produkt opprettet"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Legg til produktvariant"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Skriv og trykk Enter eller komma for å legge til..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Rediger notat"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Ingen ressurser funnet. Prøv å justere filtrene dine."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Legg til opsjon"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Lagre opsjonsgruppe"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Opprett {createCount} varianter"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Klikk \"Kjør test\" for å teste denne fraktmetoden."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administrator oppdatert"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Tøm filtre"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Oppfyllelse #{0} fra {1} til {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Kunne ikke slette global visning"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Standardspråk"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Ingen alternativer funnet"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binær"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Opsjonsgruppen ble oppdatert"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Ny fraktmetode"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Hvert 10. sekund"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "ekskl. mva:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Legg til lager til lokasjon"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Opsjonsverdi lagt til"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Samling flyttet til ny overordnet"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Opsjonsgruppe fjernet"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Gå over til valgt tilstand"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "En ekstra betaling på {formattedDiff} vil være nødvendig."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Spor lager som standard"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} av {total} valgt"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Fraktmetode opprettet"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Ny kundegruppe"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Synlig for kunde"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Opsjonsgruppe opprettet"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Skattesatser"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug vil bli generert automatisk..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Kunde ikke funnet"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Velg {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Nye fasettverdier å legge til:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Kunne ikke behandle refusjon"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Fornavn"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "inneholder"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Ingen opsjonsgrupper funnet"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Ingen varer funnet"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Delsum"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Oppfylte varer ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Verdi oppdatert"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Uverifisert"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Antall"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Legg til filter"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Skattekategori"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Testdata har blitt oppdatert. Klikk \"Kjør test\" for å se oppdaterte resultater."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "er ikke i"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Bestillingslinje oppdatert"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Ny betalingsmetode"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Duplikatverdien \"{trimmed}\" finnes allerede"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Årsak"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Kundegrupper"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} ble fjernet fra kanalen"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Opsjonsgrupper"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Legg til tillegg"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Gjeldende fasettverdier"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Side {page} av {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Forrige måned"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Legg til land"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Fjern vare"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "mindre enn"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Varianten kunne ikke legges til. Sørg for at foreldreproduktet er aktivert."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "En ukjent feil oppstod"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Beregninger"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Språk"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Ny samling"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Refunder og kanseller ordre"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "E-postoppdatering verifisert"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "er mellom"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Refunder og kanseller"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Tester fraktmetoder..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Kunne ikke opprette fraktmetode"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "Tildelte {entityIdsLength} {entityType} til kanal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Globale språk"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Ny administrator"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Slett utkast"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Kilde"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Ingen tilgjengelige handlinger"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Kunne ikke oppdatere kanal"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Generelt"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Kunne ikke fjerne produkt fra kanal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Legg til ny adresse"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Fasett oppdatert"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Sone opprettet"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Verdi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Kunde oppdatert"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Priskonverteringsfaktor"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Selgerbestilling"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Ny fasett"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Er du sikker på at du vil fjerne denne alternativgruppen fra produktet?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Beskrivelse (alt-tekst)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Ingen tagger funnet"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Standardvaluta"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Ingen betaling eller refusjon er nødvendig for disse endringene."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Totale inntekter"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Neste utførelse"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Notat er privat"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Medium dato"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Ugyldig tall"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Du har ikke lagret noen visninger ennå."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Er du sikker på at du vil slette denne visningen? Denne handlingen kan ikke angres."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Vis ordreprosess"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Kunne ikke duplisere visning"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Bruk som standard leveringsadresse"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Rediger slug manuelt"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Legg til filtre for å forhåndsvise samlingens innhold."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Produktopsjonsgruppe"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Delsum"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "er mindre enn"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "Refusjons-ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Egendefinerte ordrefelt oppdatert"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Kalkulator"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Kunne ikke fjerne opsjonsgruppen fra kanalen: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Vis jobbdata"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Flytt til toppnivå"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Tøm"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Bestillingsoversikt"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Søk etter ressurser..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Ny fasett"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Tildel {entityType} til kanal"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Fortsett"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Kampanjer"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Feilmelding"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Legg til lagernivå for en annen lokasjon"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Slett adresse"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Kunne ikke oppdatere fasett"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters må brukes innenfor en WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Rediger adresse"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Kunne ikke fjerne fasett fra kanal: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Sett lenke"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Ny selger"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Rediger bilde"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Administrer varianter"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Lager allokert"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "større enn eller lik"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Setter lagernivået der denne varianten anses som utsolgt. Bruk av en negativ verdi aktiverer restordrestøtte."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Opprett produktopsjoner"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Lagrer..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Vis resultat"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Rader per side"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Laster samlinger..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Fasettverdi oppdatert"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Legg til ressurs"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Lagre endringer"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Kunde lagt til gruppe"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Selgerbestillinger"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Kunne ikke legge til opsjonsverdi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Legg til opsjonsverdi til {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} vare(r) refundert"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Ingen opsjonsgrupper definert ennå. Legg til opsjonsgrupper for å opprette ulike varianter av produktet ditt (f.eks. Størrelse, Farge, Materiale)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Ny e-post:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Kunne ikke oppdatere betalingsmetode"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Tilgjengelig:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Opprettet"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Kunne ikke opprette produktvariant"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Språk: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Du har ikke tillatelse til å se globale språkinnstillinger"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Skattesats opprettet"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Overskrift 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Kupongkoder lagt til"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Aktiv"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Skattegrunnlag"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Last mer"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Refusjon gjennomført"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "Dupliserte {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Ny opsjonsgruppe"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Ingen resultat ennå"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Betaling gjennomført"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Tilgjengelige betingelser"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Aktive filtre"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Tøm alle"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "er større enn"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Lukk"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Legg til betaling til bestilling"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Laster..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Token brukes til å spesifisere kanalen ved API-forespørsler."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Ingen adresser funnet"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "Oppfyllelse-ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Velg betalinger å refundere"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Kunne ikke slette {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Utsolgt-terskel"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt fjernet fra kanal"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Kunne ikke oppdatere verdi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Kunne ikke opprette API-nøkkelen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Gjennomfør refusjon"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Betalingsmetode er påkrevd"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Kunne ikke legge til kunde i gruppe"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Administrer varianter"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Brukte global visning \"{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Kunde registrert"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Soner"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Søk etter selgere..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Kampanje opprettet"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Opsjon"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Ordreprosess"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privat"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variant"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Globale innstillinger oppdatert"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API-nøkkelen ble oppdatert"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Disse språkene vil være tilgjengelige for alle kanaler å bruke"

--- a/packages/dashboard/src/i18n/locales/ne.po
+++ b/packages/dashboard/src/i18n/locales/ne.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "पूरा नाम"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "वस्तुहरू चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "परिवर्तनहरू हेर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "ट्र्याकिङ कोड"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "चयन गरिएका अनुमतिहरू यी च्यानलहरूमा लागू गरिनेछन्।"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "उत्पादन विकल्पहरू"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "नयाँ कर दर"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "अवस्थित विकल्प समूह तोक्नुहोस् वा नयाँ सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "नयाँ भूमिका"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "अपार्टमेन्ट, सुइट, आदि"
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "थप वस्तुहरू छैनन्"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "लिङ्क सम्पादन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "अर्डरमा कम्तिमा एउटा वस्तु थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "परीक्षण अर्डर सिर्जना गर्न उत्पादनहरू थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "ठेगाना सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "सबै टगल गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "JSON मान सम्पादन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "बाह्य प्रमाणीकरण रणनीति प्रयोग गर्दै: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "कारण छान्नुहोस्..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "शीर्षक ५"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "भुक्तानी थप्न असफल"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "अपडेट गरिएको"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "ग्लोबल सेटिङहरू अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "अर्डर सफलतापूर्वक पूरा गरियो"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं {0} {entityName} मेट्न चाहनुहुन्छ?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "ग्लोबल स्टक बाहिर थ्रेसहोल्ड"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "भाषाहरू व्यवस्थापन गर्नुहोस्"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "नक्कल गर्दै... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "सफलतापूर्वक मेटियो"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "हालको च्यानलबाट हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} सम्पत्तिहरू मेटियो"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "कर दर सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "अनुकूलित कारण लेख्नुहोस्..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "प्रकार"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "{0} चयन गर्नुहोस्"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "मानहरू हेर्नुहोस्"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "पङ्क्ति मेट्नुहोस्"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "शर्तहरू"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "हालको"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "कुनै पूर्तिहरू छैनन्"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {{1} स्टक स्थान मेट्न सकिएन: {messages}} other {{2} स्टक स्थानहरू मेट्न सकिएन: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "यो सक्षम पारिएको बेला, उत्पादन सूचीमा प्रविष्ट गरिएका मूल्यहरू पूर्वनिर्धारित कर क्षेत्रको लागि करमा समावेश हुनेछन्।"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "तपाईंको उत्पादनको लागि भेरियन्टहरू सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "मस्यौदा अर्डर पूरा भयो"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "स्वत: रिफ्रेस: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "स्वास्थ्य जाँचहरू"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} मेटियो"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "स्वास्थ्य जाँच"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "विक्रेताहरू"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "विकल्पहरू"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} कार्य सफलतापूर्वक रद्द गरियो} other {{fulfilled} कार्यहरू सफलतापूर्वक रद्द गरियो}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "विक्रेता"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "भुक्तानी थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "यो ढुवानी विधि योग्य छ कि छैन र ढुवानी लागत के हुनेछ भनेर हेर्न अर्डर सिमुलेट गरेर परीक्षण गर्नुहोस्।"
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Enterprise Edition अन्वेषण गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "स्टक स्थानहरू"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "पूर्ति ह्यान्डलर"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "अर्डरहरू"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "भूमिकाहरू चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "भूमिका सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं यो भेरियन्ट मेट्न चाहनुहुन्छ?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "सबै स्रोतहरू चलिरहेका छन्"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "प्रशासक सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "होइन"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "उत्पादन भेरियन्ट सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "{failed} {entityName} मेट्न असफल: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "उत्पादन सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "देश अपडेट गर्न असफल"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "खोज्न कम्तिमा २ वर्णहरू टाइप गर्नुहोस्..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "थर"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "लिङ्क शीर्षक"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "ग्राहक समूह सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "कस्टम फिल्डहरू परिवर्तन भयो"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "स्टक स्थान सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "अज्ञात त्रुटि"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "फिर्ता कुल नकारात्मक हुन सक्दैन"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "विवरणहरू हेर्नुहोस्"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "{0} {entityType} असाइन गर्न च्यानल चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "ग्राहक सफलतापूर्वक सिर्जना गरियो"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "पछिल्लो 7 दिन"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "च्यानल सिर्जना गर्न असफल"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "विकास मोड"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "नयाँ भूमिका"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "सम्पत्तिहरू मेट्न असफल: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "स्टकमा फिर्ता"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "दृश्यता"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "उत्पादन भेरियन्टहरू"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "नयाँ ग्राहक समूह"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "\"{0}\" सिर्जना गर्नुहोस्"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "पुन: नामकरण गर्नुहोस्"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "आफ्नो मनपर्ने प्रदर्शन भाषा र लोकेल सेटिङहरू छनोट गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "च्यानलबाट {successCount} विकल्प समूहहरू सफलतापूर्वक हटाइयो"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "यो ढुवानी विधि यो अर्डरको लागि योग्य छैन"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "ठेगाना अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "ठेगाना सफलतापूर्वक मेटियो"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "कर दर"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "अर्डर ड्राफ्ट पूरा गर्न तयार छैन"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "नयाँ संग्रह"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "अन्तर्दृष्टि"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "चलाउनुहोस्"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "कर दर अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "यो <0>{collectionName}</0> संग्रहको सामग्री हो।"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "निजी"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "उत्पादन विकल्प सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "मुख्य उत्पादन"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "शहर"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "प्रशासकहरू"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "सकल मूल्य: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "अर्को पृष्ठमा जानुहोस्"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "लिङ्क हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "यो फिल्ड पढ्न मात्र हो"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "अर्डर संख्या"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "अर्डर सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "फिल्टरहरू विरासतमा प्राप्त गर्नुहोस्"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "सबै प्रयोगकर्ताहरूलाई देखिने ग्लोबल सुरक्षित दृश्यहरू व्यवस्थापन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "भुक्तानी विधिहरू खोज्नुहोस्..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "अर्डरको लागि ढुवानी ठेगाना हटाइयो"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "{enabledCount} भेरियन्टहरू सिर्जना गर्नुहोस्"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "भुक्तानी #{0} {1} मा संक्रमण भयो"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "ग्राहक इतिहास लोड गर्न त्रुटि: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "च्यानलबाट {selectionLength} {entityType} सफलतापूर्वक हटाइयो"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "विकल्प मान थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "ग्लोबल सेटिङहरू"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "पछि छ"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "उत्पादन विकल्प सफलतापूर्वक अद्यावधिक गरियो"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "विशेषता मानहरू सम्पादन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "थप्दै..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "संग्रहहरू सार्नुहोस्"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "भूमिकाहरू"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "ग्रिड दृश्य"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "ठेगाना मेट्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "कुनै ढुवानी विधिहरू उपलब्ध छैनन्"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "ग्लोबल दृश्य सफलतापूर्वक व्यक्तिगत दृश्यमा रूपान्तरण गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "पूर्ति संक्रमण भयो"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं {selectionLength} सम्पत्तिहरू मेट्न चाहनुहुन्छ?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "साइन इन गर्नुहोस्"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "सूची दृश्य"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "परीक्षण अर्डर"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "जारी राख्न ग्राहक चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "विकल्प समूह सफलतापूर्वक तोकियो"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "परीक्षण चलाउनुहोस्"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "कर दर: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "कृपया परीक्षण चलाउन उत्पादनहरू थप्नुहोस् र ढुवानी ठेगाना पूरा गर्नुहोस्।"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "हेडर पङ्क्ति टगल गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "ठेगाना चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "भुक्तानी योग्यता जाँचकर्ता"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "पूर्वनिर्धारित कर क्षेत्र"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "अर्डर ड्राफ्ट पूरा गर्न तयार छ"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "मेटाडेटा"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "फिल्टर..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "नयाँ विशेषता मान"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "च्यानल सफलतापूर्वक अपडेट गरियो"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "कम देखाउनुहोस्"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "छोटो मिति"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "उपलब्ध मुद्राहरू"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "{0} वस्तुहरू चयन गर्नुहोस्"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "राखिएको मिति"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "यो कुञ्जी घुमाउँदा हालको कुञ्जी तुरुन्तै अमान्य हुनेछ। यसलाई प्रयोग गर्ने सबै एकीकरणहरू नयाँ कुञ्जीमा अपडेट नभएसम्म काम गर्न बन्द हुनेछन्।"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "कार्यमा पास गरिएको डेटा"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "नेभिगेसन पुष्टि गर्नुहोस्"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "लिङ्क लक्ष्य"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "मस्यौदा पूरा गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "नाम"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "अर्डर पूरा गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "कुल"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "यो रिफन्ड सेटलमेन्टको लागि लेनदेन ID प्रविष्ट गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "तपाईंको API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं यो मस्यौदा अर्डर मेट्न चाहनुहुन्छ?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "पूर्ति सिर्जना गरियो"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "{0} योग्य ढुवानी विधि फेला पर्यो"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "आयाम"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "पासवर्ड देखाउनुहोस्"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(अधिकतम: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "कम्पनी"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "पछि स्तम्भ थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "कार्यहरू"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "छुटहरू"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "रिफन्ड टिप्पणी प्रविष्ट गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "अर्डर लाइन हटाइयो"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "सामग्री:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "कुञ्जी"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "पुष्टि गर्नुहोस्"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "संग्रह सिर्जना गर्न असफल"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "पहिलो पृष्ठमा जानुहोस्"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "उत्पादन सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "ग्राहक"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "अर्डर इतिहास लोड गर्न त्रुटि: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "अर्डरको लागि ढुवानी ठेगाना सेट गरियो"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "फोकल पोइन्ट"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "एकल भेरियन्ट, विकल्पहरू छैनन्"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "अर्डरको लागि अर्को स्थिति चयन गर्नुहोस्"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "स्थानीय"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "अनुसूचित कार्यहरू"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "लेनदेन ID प्रविष्ट गर्नुहोस्"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "डेटा रिफ्रेस गर्नुहोस्"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "{0} {entityType} को लागि विशेषता मानहरू थप्नुहोस् वा हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "यी <0>{facetName}</0> विशेषताका विशेषता मानहरू हुन्।"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "अर्डरमा भुक्तानी सफलतापूर्वक थपियो"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "अर्डरको लागि बिलिङ ठेगाना सेट गरिएको"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "क्षेत्र अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "पासवर्ड"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "मेट्न असफल"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "अनुसूचित कार्य कार्यान्वयन गरिनेछ"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "नयाँ स्टक स्थान"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "अनुमतिहरू"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "ढुवानी ठेगाना परिवर्तन भयो"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "कुनै उत्पादन भेटिएन"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "अघि पङ्क्ति थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "{suggestedState} मा संक्रमण गर्नुहोस्"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "यो महिना"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "विशेषता सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "अर्डर वस्तुहरू रद्द गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "लेनदेन ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "आवंटित"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "अर्को विकल्प समूह थप्नुहोस्"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "बाँकी स्टकको के गर्ने भन्ने छान्नुहोस्"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Platform & Cloud अन्वेषण गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "प्रत्येक ५ सेकेन्ड"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "संग्रह सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "मूल्य"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "मस्यौदा अर्डर"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "दायरा"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "सर्त थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "यो ढुवानी विधि यो अर्डरको लागि योग्य छ"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "प्रशासकहरू"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "समूहबाट हटाइयो"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "चौडाइ"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "कुनै भुक्तानी वा रिफन्ड आवश्यक छैन"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr ".env फाइलको रूपमा डाउनलोड गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "सक्षम पारिएको बेला, प्रमोशन पसलमा उपलब्ध हुन्छ"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "ट्र्याक गर्दा, उत्पादन भेरियन्ट स्टक स्तरहरू बिक्री हुँदा स्वचालित रूपमा समायोजन गरिनेछ। यो सेटिङ व्यक्तिगत उत्पादन भेरियन्टहरूद्वारा ओभरराइड गर्न सकिन्छ।"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "अर्डरको लागि ढुवानी विधि सेट गरियो"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "प्रमोशन अपडेट गर्न असफल"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "छविहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "{name} खोज्नुहोस्..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "सम्पत्ति सम्पादन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "भुक्तानी रद्द गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "कार्य पंक्ति"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "सम्पत्तिहरू"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "इमेल ठेगाना"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "स्रोत फिल्डबाट स्लग पुन: उत्पन्न गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "ग्लोबल सेटिङहरूबाट विरासतमा प्राप्त गर्नुहोस्"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "कुनै परिणामहरू फेला परेन"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "वर्तमान स्थिति"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "शिपिङ ठेगाना सेट गर्नुहोस् र शिपिङ विधि चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "बन्द"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "सेटिङ स्टोर"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "पंक्ति"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "नयाँ कर दर"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "भुक्तानी संक्रमण भयो"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "बाँकी:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "{entityName} को लागि कोड \"{duplicatorCode}\" सँग कुनै डुप्लिकेटर फेला परेन"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "मूल्यहरूमा पूर्वनिर्धारित कर क्षेत्रको लागि कर समावेश छ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "कुल रिफन्ड:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "कार्य परिणाम हेर्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "नयाँ अर्डर सिमुलेट गरेर तपाईंको ढुवानी विधिहरू परीक्षण गर्नुहोस्।"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "कुनै वस्तुहरू चयन गरिएको छैन"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} चयन गरिएको"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "कुनै देशहरू फेला परेन"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "भेरियन्टहरू सफलतापूर्वक सिर्जना गरियो"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "स्लग स्वचालित रूपमा उत्पन्न गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "अधिभार"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "भुक्तानी विधिहरू"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "स्टक"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "कुनै ग्राहकहरू फेला परेन"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "ग्लोबल स्टक बाहिर थ्रेसहोल्ड प्रयोग गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "नयाँ उत्पादन विकल्प समूह"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "भुक्तानी स्थिति सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "नयाँ सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "फिर्ता कुल"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "ठेगाना मेटियो"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "तपाईंको खातामा तोकिएका भूमिकाहरू मात्र उपलब्ध छन्।"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "अर्डरमा वस्तु थपियो"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "फोकल पोइन्ट सम्पादन गर्नुहोस्"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "कुनै विक्रेताहरू फेला परेन"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "सम्पत्ति"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {यो विकल्प समूह अर्को एउटा उत्पादनले प्रयोग गर्दछ। परिवर्तनहरूले त्यसलाई पनि असर गर्नेछ।} other {यो विकल्प समूह # उत्पादनहरूमा साझा गरिएको छ। परिवर्तनहरूले ती सबैलाई असर गर्नेछ।}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "मेरो सुरक्षित दृश्यहरू"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "नयाँ च्यानल"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "विक्रेता सिर्जना गर्न असफल"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "{0} को नक्कल सेटिङहरू कन्फिगर गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "हालको फिल्टरसँग मिल्ने कुनै भेरियन्ट छैन।"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "ठेगानाहरू"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "{groupName} विकल्प समूहमा नयाँ विकल्प मान थप्नुहोस्"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "अर्डर परिमार्जन #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "अघि स्तम्भ थप्नुहोस्"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "च्यानल भाषाहरू"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "विकल्प समूह सिर्जना गर्न असफल"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "सत्य"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "ग्राहक चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "अर्डर संक्रमण भयो"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "यो उत्पादनमा अवस्थित भेरियन्टहरू छन् तर कुनै विकल्प समूहहरू परिभाषित छैनन्। नयाँ भेरियन्टहरू सिर्जना गर्नु अघि तपाईंले विकल्प समूहहरू थप्नुपर्छ।"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "अघि छ"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "मस्यौदा अर्डर मेट्नुहोस्"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "सूची"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "नयाँ भुक्तानी विधि"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "प्रमोशन सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {{rejected} कार्य रद्द गर्न असफल भयो} other {{rejected} कार्यहरू रद्द गर्न असफल भयो}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "च्यानल चयन गर्नुहोस्"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "प्रदर्शन भाषा"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "पूर्ति विवरणहरू"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "बाँकी स्टक हटाउनुहोस्"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "अहिले"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "च्यानलहरू"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "दृश्य सफलतापूर्वक ग्लोबलमा रूपान्तरण गरियो"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "अघि"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "आकार"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "{0} को लागि कुनै अनुवाद फेला परेन"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "नयाँ ग्राहक"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "नवीनतम अर्डरहरू"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} थप"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "पूर्वनिर्धारित बिलिङ ठेगानाको रूपमा प्रयोग गर्नुहोस्"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "मेट्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "असक्षम पार्नुहोस्"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "संग्रहहरू"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "भेरियन्ट थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "देश सिर्जना गर्न असफल"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "देशहरू"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "उत्पादन विकल्पहरू सिर्जना गर्न असफल"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "दृश्य पुन: नामकरण गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "उपलब्ध"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "सामान्य"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "फिल्टरहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "ग्राहक समूहहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "ग्राहकहरू"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "नमूना ढाँचा"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "नयाँ विकल्प"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "प्रयोग सीमा"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "ग्लोबल सेटिङहरू लोड गर्दै..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "ठेगाना सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "सिर्जना गरिएको"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "ठेगानाहरू लोड गर्दै..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "{0} सार्न लक्ष्य संग्रह चयन गर्नुहोस्।"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "ग्राहक विवरण अपडेट गरियो"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "मा छैन"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "लागू गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "नयाँ उत्पादन विकल्प"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "अन्तिम पृष्ठमा जानुहोस्"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "रद्द गर्नुहोस्"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "उत्पादन भेरियन्ट सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "यो विधिबाट रिफन्ड"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "हुलाक कोड"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "पहिले उत्पादन विकल्पहरू थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "नयाँ कर वर्ग"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "विकल्प थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "आंशिक फिर्ता सम्पन्न"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "कस्टम फिल्डहरू सेट गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "संग्रहहरू"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "भेरियन्ट मेटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "कुनै परिमार्जन गरिएको छैन"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "पूर्वनिर्धारित ढुवानी क्षेत्र"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "कारण:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "ढुवानी ठेगाना"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "{0} मा संक्रमण गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "कर वर्गहरू"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "निजी संग्रहहरू पसलमा देखिँदैनन्"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "सक्षम पारिएको बेला, उत्पादन पसलमा उपलब्ध हुन्छ"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "अनुसूचित कार्य कार्यान्वयन गर्न सकिएन"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "ग्राहक समूहहरू"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "असक्षम"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "नयाँ प्रमोशन"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "पूर्वनिर्धारित ढुवानी ठेगाना"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "रिफन्ड आवश्यक"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "अर्डर पूरा गर्नुहोस्"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "तपाईंसँग च्यानल सेटिङहरू हेर्ने अनुमति छैन"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "पछिल्लो 30 दिन"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "कुनै विशेषता मानहरू छैनन्"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "फिर्ताको लागि कारण आवश्यक छ"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "विकल्प समूह हटाउन सकिएन"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "कर वर्ग अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "रिफन्ड सफलतापूर्वक सम्पन्न भयो"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "अपडेट गर्नुहोस्"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "शीर्षक २"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "अर्डर राखियो"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "प्रोफाइल सफलतापूर्वक अपडेट गरियो"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "अन्त्य"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "भुक्तानी विधि"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "सम्पादन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "भेरियन्ट सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "संग्रह नामद्वारा फिल्टर गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "टिप्पणी थपियो"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "पूरा गर्न मात्राहरू चयन गर्नुहोस् र पूर्ति ह्यान्डलर कन्फिगर गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "अर्डरबाट बिलिङ ठेगाना हटाइएको"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "सुरु हुन्छ"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "नक्कल गर्नुहोस्"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "कुनै परिणामहरू छैनन्"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "स्तम्भ सेटिङहरू"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {{count} स्टक स्थान मेट्न सकिएन} other {{count} स्टक स्थानहरू मेट्न सकिएन}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "कोड"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "विकल्प समूहहरू हटाउन असफल भयो"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "अर्डर वितरण गरियो"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "{name} मा सार्नुहोस्"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "बाँकी स्टक"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "क्षेत्रबाट हटाउनुहोस्"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "यस च्यानलको लागि विश्वव्यापी रूपमा उपलब्ध भाषाहरूबाट चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं यो ठेगाना मेट्न चाहनुहुन्छ?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "विकल्प समूह तोक्न असफल भयो"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "सम्पत्ति अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "स्टक स्थान सफलतापूर्वक अपडेट गरियो"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "कार्य पुष्टि गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "देश सफलतापूर्वक अपडेट गरियो"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "विशेषताहरू"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "टिप्पणी थप्न असफल"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "टिप्पणी मेट्न असफल"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "क्वेरी कागजात विस्तार गर्न असफल"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "टिप्पणी अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "ढुवानी फिर्ता"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "पढ्न मात्र"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "ग्लोबल दृश्य नक्कल गर्न असफल"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "{total} मध्ये {shown} देखाइँदै • {selected} चयन गरिएको"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "ढुवानी विधि परीक्षण गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "विशेषता मानहरू"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "सम्पत्ति सफलतापूर्वक अपडेट गरियो"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "थीम"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} ग्राहकहरू"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "भाषा चयन गर्नुहोस्"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "लग आउट"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "प्रयासहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "उपलब्ध मुद्रा कोडहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "उपलब्ध भाषा कोडहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "ब्रेडक्रम्ब्स"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "वर्ग"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "च्यानलहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "बालबालिका"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "कोड"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "कुपन कोड"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "सिर्जना मिति"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "मुद्रा कोड"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "ग्राहक"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "ग्राहक समूह"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "ग्राहकहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "कस्टम फिल्डहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "डेटा"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "पूर्वनिर्धारित मुद्रा कोड"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "पूर्वनिर्धारित भाषा कोड"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "पूर्वनिर्धारित ढुवानी क्षेत्र"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "पूर्वनिर्धारित कर क्षेत्र"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "विवरण"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "अवधि"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "इमेल ठेगाना"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "सक्षम"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "समाप्त हुन्छ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "त्रुटि"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "प्रमुख सम्पत्ति"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "पहिलो नाम"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "पूर्ति ह्यान्डलर कोड"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "पूर्वनिर्धारित"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "निजी"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "सम्पन्न"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "थर"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "नाम"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "अर्डर राखिएको मिति"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "अभिभावक ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "प्रति ग्राहक प्रयोग सीमा"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "अनुमतिहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "स्थिति"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "मूल्य"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "मूल्यमा कर समावेश छ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "कर सहितको मूल्य"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "उत्पादन भेरियन्टहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "प्रगति"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "लाइन नाम"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "परिणाम"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "पुनः प्रयासहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "विक्रेता"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "मिलान मिति"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "ढुवानी लाइनहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "स्लग"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "सुरु मिति"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "सुरु हुन्छ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "अवस्था"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "स्टक स्तरहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "टोकन"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "कुल"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "कर सहितको कुल"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "प्रकार"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "अपडेट मिति"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "प्रयोग सीमा"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "प्रयोगकर्ता"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "मान"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "मान सूची"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "क्षेत्र"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "विधि"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "कर सारांश"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "सबै च्यानलहरूको लागि उपलब्ध भाषाहरू सेट गर्दछ। व्यक्तिगत च्यानलहरूले त्यसपछि यी भाषाहरूको उपसमूहलाई समर्थन गर्न सक्छन्।"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "संग्रहहरू सफलतापूर्वक सारिएको"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "दर्ता गरिएको"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "कार्य रद्द गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "समाप्त हुन्छ"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "पृष्ठ {0} को {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "दर"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "आकार, रङ, आदि"
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "फासेटहरू ब्राउज गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "क्षेत्र"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "रद्द गरिएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "सिर्जना गरियो"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "डेलिभर गरिएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "पेन्डिङमा"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "पठाइएको"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "दृश्य सुरक्षित गर्नुहोस्"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} चयन गरियो"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "विकल्प समूहहरू खोज्नुहोस्..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "अर्डर परिमार्जन गर्नुहोस्"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "चयन गरिएका वस्तुहरू"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "मानहरू"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "अर्डरको लागि ग्राहक सेट गरियो"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "विशेषताहरू"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {के तपाईं यो समूहबाट {count} ग्राहक हटाउन निश्चित हुनुहुन्छ?} other {के तपाईं यो समूहबाट {count} ग्राहकहरू हटाउन निश्चित हुनुहुन्छ?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "हातमा स्टक"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "खोज सूचकांक पुनर्निर्माण सुरु गर्न सकिएन"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "ढुवानी ठेगाना"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "नयाँ क्षेत्र"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "नयाँ API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "स्तम्भ मेट्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "अवस्थित तोक्नुहोस्"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "शून्य छ"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "यी <0>{customerGroupName}</0> ग्राहक समूहका ग्राहकहरू हुन्।"
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "ग्लोबल दृश्यहरू व्यवस्थापन गर्नुहोस्"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "पूर्वनिर्धारित च्यानल"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "स्रोत, शीर्षक, र आयामसहित नयाँ छवि सम्मिलित गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "विशेषता मान सिर्जना गर्न असफल"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "उत्पादन विकल्प अद्यावधिक गर्न असफल"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>पासवर्ड बिर्सनुभयो?</0><1>रिसेट अनुरोध गर्नुहोस्</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "कुपन कोड"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "ग्राहक प्रमाणित गरियो"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "ग्लोबल सेटिङहरू"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "तालिका"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "संग्रहलाई आफ्नै उत्तराधिकारीमा सार्न सकिँदैन"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "नयाँ कर वर्ग"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "हालको च्यानलमा कुनै स्टक स्थानहरू उपलब्ध छैनन्"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "च्यानल सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "ग्राहक सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "डेटा हेर्नुहोस्"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "दृश्य मेट्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "ग्राहकमा नयाँ ठेगाना थप्नुहोस्।"
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "थप दृश्यहरू"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "चयन गरिएको छविको गुणहरू सम्पादन गर्नुहोस्"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "दृश्य \"{viewName}\" लागू गरियो"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "च्यानलबाट {successCount} विशेषताहरू सफलतापूर्वक हटाइयो"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "नयाँ उत्पादन"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "नयाँ सम्पत्ति"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "ढुवानी पुन: गणना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "अवस्थित भेरियन्ट \"{0}\" मा कुन विकल्पहरू लागू हुनुपर्छ चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "सम्पत्तिहरू"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "यसले यो उत्पादनबाट सबै विकल्प समूहहरू हटाउनेछ र भेरियन्ट सेटअप छनोटमा फर्काउनेछ।"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "बिलिङ ठेगाना"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "विशेषता मान थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "कृपया लक्ष्य संग्रह चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "अर्डरमा लागू गर्नु अघि परिवर्तनहरू समीक्षा गर्नुहोस्।"
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "भूमिका चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "अर्डर रद्द गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "छुट"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "सबै प्रकारहरू"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "ड्राफ्ट अर्डरहरू मात्र पूरा गर्न सकिन्छ"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "उत्पादन अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "{0} लाइनहरू समायोजन गर्दै"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "विशेषता मानहरू थप्नुहोस्"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "पछि"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "च्यानल"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "स्वास्थ्य जाँच"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "रकम"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "फोन नम्बर"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "नयाँ ग्राहक"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "छवि"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "प्रशासक सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "उत्पादन विकल्पहरू"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "देश चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "सिर्जना गर्दै..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं यो ग्लोबल दृश्य मेट्न चाहनुहुन्छ? यो कार्य पूर्ववत गर्न सकिँदैन र सबै प्रयोगकर्ताहरूलाई असर गर्नेछ।"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "विकल्प समूह बलपूर्वक हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "थपियो"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "ग्राहक इतिहास"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "{entityIdsLength} {entityType} को लागि विशेषता मानहरू सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "समूहबाट ग्राहक हटाउन असफल"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "प्रणाली"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "प्रति ग्राहक प्रयोग सीमा"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "बिलिङ ठेगाना परिवर्तन भयो"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "विकल्प चयन गर्नुहोस्"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "व्यक्तिगतमा प्रतिलिपि गर्नुहोस्"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "फिर्ता कुल अधिकतम फिर्ता योग्य रकम {0} भन्दा बढी छ"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "ग्लोबल दृश्य मेट्नुहोस्"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "प्रत्येक ३० सेकेन्ड"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "नयाँ देश"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "{0} बाट {1} सम्म"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "ग्राहक सिर्जना गर्न असफल"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "फोकल पोइन्ट अद्यावधिक गरियो"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "विकल्प मानहरू"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "पूर्वनिर्धारित बिलिङ ठेगाना"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "कुनै ग्राहक छैन"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "क्षेत्रबाट देशहरू हटाउन असफल"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "प्रमोशन सिर्जना गर्न असफल"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "आज"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "हिजो"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "विकल्प नाम"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "के तपाईं यस क्षेत्रबाट {0} {1} हटाउन चाहनुहुन्छ?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "{0} अतिरिक्त शुल्क(हरू) थप्दै"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "लिङ्क href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "फलब्याक: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "अर्डर इतिहास"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "ओभरराइड"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "लेनदेन ID आवश्यक छ"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "regex सँग मेल खान्छ"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "ग्लोबल दृश्य सफलतापूर्वक पुन: नामकरण गरियो"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "कुनै ट्यागहरू चयन गरिएको छैन"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "पछाडि"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "दृश्य सफलतापूर्वक पुन: नामकरण गरियो"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "फिल्टर लागू गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "अन्तिम परिणाम"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "समूहमा थपियो"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "अन्तर्दृष्टि"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "भेरियन्टहरू सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "ढुवानी विधि परीक्षण गर्दै..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "अँध्यारो"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "परीक्षण परिणामहरू"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "ग्राहक थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "परिवर्तनहरू सुरक्षित गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "ठेगाना अपडेट गरियो"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "फिर्ता सफलतापूर्वक प्रशोधन गरियो"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "नयाँ क्षेत्र"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "संग्रह स्थिति अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "फिर्ता"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "परिमार्जन गर्नुहोस्"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "कुनै ग्लोबल भाषाहरू कन्फिगर गरिएको छैन"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "{0} वस्तु(हरू) हटाउँदै"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "ट्र्याक गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "भेरियन्ट सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "{facetName} को विशेषता मानहरू"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "लेआउट सुरक्षित गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "पासवर्ड रिसेट प्रमाणित गरियो"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "दृश्य मेट्न असफल"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं यो पृष्ठबाट बाहिर जान चाहनुहुन्छ? कुनै पनि असुरक्षित परिवर्तनहरू हराउनेछन्।"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "हेडर स्तम्भ टगल गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "नयाँ प्रमोशन"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "विकल्प मान नाम"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "अन्तिम पटक प्रयोग गरिएको"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "पूर्वनिर्धारित कर वर्ग हो"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "स्लग सेट गरिएको छ"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "फोकल पोइन्ट अद्यावधिक गर्न असफल भयो"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "क्षेत्र सफलतापूर्वक अपडेट गरियो"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "राज्य/प्रान्त"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "विकल्प समूह अपडेट गर्न असफल भयो"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "च्यानल पूर्वनिर्धारित"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "कर वर्ग सिर्जना गर्न असफल"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "{columnId} स्तम्भको लागि फिल्टर मापदण्ड सेट गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "देश"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "साधारण उत्पादन"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "कार्य पंक्ति"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "कृपया बन्द गर्नुअघि API Key सुरक्षित गरिसकेको पुष्टि गर्नुहोस्।"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "मेटाउने पुष्टि गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "अर्डर परिमार्जन गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "{taxRate}% कर समावेश"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "अर्डर मेट्रिक्स"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "प्रदर्शन भाषा चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "प्रमाणीकरण विधिहरू"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "सुरु"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "API Key घुमाउन असफल भयो"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "मा"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "भूमिकाहरू खोज्नुहोस्..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "उत्पादन भेरियन्टहरू"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "ग्लोबल दृश्यहरू व्यवस्थापन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "प्रशोधन गर्दै..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} भेटियो"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "मिति दायरा चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "उत्पादन"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "API Key घुमाउनुहोस्"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "श्रेणी"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "सार्दै..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "असाइन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "विक्रेता सफलतापूर्वक सिर्जना गरियो"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "ढुवानी विधि सफलतापूर्वक अद्यावधिक गरियो"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "उत्पादन भेरियन्ट अपडेट गर्न असफल"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "पुनः क्रम गर्न तान्नुहोस्"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "क्षेत्रहरू"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "तपाईंले मेट्न लाग्नुभएको {count, plural, one {# स्टक स्थान} other {# स्टक स्थानहरू}} मा बाँकी रहेको स्टकको के गर्ने भन्ने छान्नुहोस्। चयन गरिएका सबै स्थानहरूले आफ्नो बाँकी स्टक तपाईंले छान्नुभएको एउटै स्थानमा सार्छन्, वा त्यसलाई हटाउँछन्।"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "फासेट मानहरू खोज्नुहोस्..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "नोट"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "उपलब्ध भाषाहरू"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "थप {0} लोड गर्नुहोस् ({remaining} बाँकी)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "विशेषता मानहरू"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "वस्तुहरू पुनः क्रमबद्ध गर्न असफल"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "कुल अर्डरहरू"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "यो अर्डरको लागि कुनै योग्य ढुवानी विधिहरू फेला परेन।"
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "उत्पादन विकल्प थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "ढुवानी"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions लाई DashboardBaseWidget भित्र प्रयोग गर्नुपर्छ"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "यो विकल्प समूह अवस्थित भेरियन्टहरूमा प्रयोगमा छ। बलपूर्वक हटाउँदा ती भेरियन्टहरूमा असर पर्न सक्छ। के तपाईं निश्चित हुनुहुन्छ?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "इमेल अपडेट अनुरोध गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "स्थितिमा संक्रमण गर्न त्रुटि"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "ग्राहक समूह सफलतापूर्वक सिर्जना गरियो"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "नयाँ विन्डो"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "भुक्तानी अधिकृत गरियो"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "भूमिका सफलतापूर्वक अपडेट गरियो"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "देश चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "ढुवानी विधि अद्यावधिक गर्न असफल"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} स्टक स्थान मेटियो} other {{deleted} स्टक स्थानहरू मेटिए}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "ढुवानी विधिहरू"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "ठेगाना चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "हो"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "स्लग"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "फोकल पोइन्ट सेट गर्नुहोस्"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "अन्त्य"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "मुद्रा चयन गर्नुहोस्"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "टिप्पणी सामग्री वा दृश्यता अपडेट गर्नुहोस्"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "पछिल्लो अर्डरहरू विजेट"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "{collectionName} को संग्रह सामग्री"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "ढुवानी विधि परिवर्तन भयो"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "कर विवरण"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "बराबर वा कम छ"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "बराबर छैन"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "रिफ्रेस गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "जस्तै साइज"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "भुक्तानी सम्पन्न गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "च्यानलहरू"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "शिपिङ फिर्ता गरियो"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "एसेट प्रकार"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "नयाँ स्टक स्थान"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "असफलता अघि {successfulRefundCount} भुक्तानी(हरू) फिर्ता गरियो। विवरणको लागि अर्डर इतिहास जाँच गर्नुहोस्।"
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "वस्तु चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "नयाँ उत्पादन"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "ट्यागहरू व्यवस्थापन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "वस्तुहरू फिर्ता गरियो"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "कार्य थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "अवस्थित भेरियन्टमा विकल्पहरू असाइन गर्नुहोस्"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "{0} नक्कल गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "समूहबाट हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "पूर्ति स्थिति अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "विकल्पहरू, मूल्य निर्धारण, र स्टकसहित नयाँ उत्पादन भेरियन्ट सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "निजी विशेषताहरू पसलमा देखिँदैनन्"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "कर वर्ग चयन गर्नुहोस्"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "सिर्जना गरिएको"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "चलिरहेको छैन"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "तोकिएको"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "शीर्षक १"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "उपलब्ध भाषाहरू चयन गर्नुहोस्"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "{0} वस्तु(हरू) थप्दै"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "पछि पङ्क्ति थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "कर कुल"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "ड्राफ्ट अर्डर स्थिति"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "उत्पादन विकल्पहरू सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "स्थानहरू लोड हुँदै छन्…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "भुक्तानी विधि सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "विशेषता मान सफलतापूर्वक सिर्जना गरियो"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "मार्केटिङ"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "मस्यौदा अर्डर मेटियो"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "भन्दा ठूलो"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "मेट्रिक्स विजेट"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "मुद्राहरू खोज्नुहोस्..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "च्यानलबाट हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "शीर्षक"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "छवि घुसाउनुहोस्"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "विक्रेता अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "देश सफलतापूर्वक सिर्जना गरियो"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "विक्रेता चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "ट्यागहरू लोड गर्दै..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "विशेषता सफलतापूर्वक सिर्जना गरियो"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} प्रकारहरू"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "भुक्तानी सम्पन्न गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "कुनै बिलिङ ठेगाना छैन"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {{1} स्टक स्थान मेट्न सकिएन} other {{2} स्टक स्थानहरू मेट्न सकिएन}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "विशेषता"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "सक्रिय च्यानलबाट हटाउन सकिँदैन"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "सेट गरिएको छैन"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "बलपूर्वक हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "नयाँ च्यानल"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "विकल्प समूह नाम"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "र"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "ग्राहक समूह सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "भूमिका सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "उत्पादन नाम"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "पूर्ति स्थिति सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "उत्पादनहरू"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "ठेगाना सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key सफलतापूर्वक घुमाइयो"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "विकल्प समूह थप्नुहोस्"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "{0} फिर्ता"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "स्लग म्यानुअल रूपमा प्रविष्ट गर्नुहोस्"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "कुनै विजेटहरू उपलब्ध छैनन्"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "भुक्तानी रद्द गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "भुक्तानी सफलतापूर्वक रद्द गरियो"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "ग्लोबल दृश्य सफलतापूर्वक नक्कल गरियो"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "द्वारा सिर्जित"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "भेरियन्टहरू फिल्टर गर्नुहोस्..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "अर्को मुद्रामा मूल्य थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "इमेल ठेगाना वा पहिचानकर्ता"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "रिफन्ड #{0} {1} मा संक्रमण भयो"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "ग्राहकहरू"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "शीर्षक ४"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "स्टक स्थान अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "अर्डर पठाइयो"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "ठेगाना सुरक्षित गर्नुहोस्"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "ग्लोबल बनाउनुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "अर्को स्थिति चयन गर्नुहोस्"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "कुनै सतर्कता छैन"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "{0} संग्रह(हरू) {2} मा सार्दै"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "परीक्षण"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "बीच"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "टिप्पणी सफलतापूर्वक थपियो"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "टिप्पणी सफलतापूर्वक मेटियो"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "टिप्पणी सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "रिफन्ड सम्पन्न गर्न असफल"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "स्टक स्तर"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "वस्तु थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "पूर्वावलोकन लोड गर्दै..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "खोजीमा फर्कनुहोस्"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "दृश्य सफलतापूर्वक नक्कल गरियो"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "विकल्प समूह हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "विवरण"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "देशहरू"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "सडक ठेगाना २"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "ग्लोबल दृश्य सफलतापूर्वक मेटियो"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "लेआउट सम्पादन गर्नुहोस्"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "च्यानलमा असाइन गर्नुहोस्"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "यो हप्ता"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "उत्पादन विकल्प समूह सफलतापूर्वक सिर्जना गरियो"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "{0} को म्यानुअल भुक्तानी थप्नुहोस्"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "मा छ"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "इमेल"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "प्रशासक अपडेट गर्न असफल"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "यस तालिकाको लागि तपाईंको व्यक्तिगत सुरक्षित दृश्यहरू व्यवस्थापन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "ट्यागद्वारा फिल्टर गर्नुहोस्"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "प्रशासक ड्यासबोर्ड पहुँच गर्न साइन इन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "अर्डरमा भुक्तानी थप्नुहोस् ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "गलत"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "उज्यालो"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "रिसेट गर्नुहोस्"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "बराबर छ"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "विकल्पहरू सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "पासवर्ड अपडेट गरियो"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "समावेश गर्दैन"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "विकल्प समूह"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "तलको ठेगाना विवरणहरू सम्पादन गर्नुहोस्।"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "कर वर्ग सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "संग्रहहरू सार्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "भुक्तानी स्थिति अपडेट गर्न असफल"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "तपाईंको अर्डर सारांश"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "अपलोड गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "विकल्पहरू सहितको उत्पादन"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "सबै {0} परिणामहरू देखाउँदै"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "लुकअप ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} थप"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "विकल्प समूहहरू"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "कस्टम फिल्डहरू"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "सबै सम्भावित अर्डर अवस्थाहरू र तिनीहरूको संक्रमणहरू। हालको अवस्था हाइलाइट गरिएको छ।"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "अर्डरहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "अर्डर सारांश विजेट"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "वस्तुहरू थप्दै"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "अतिरिक्त भुक्तानीको व्यवस्था गर्दै"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "भुक्तानी व्यवस्था गर्दै"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "रद्द गरिएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "सिर्जना गरिएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "डेलिभर गरिएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "मस्यौदा"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "परिमार्जन गर्दै"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "आंशिक रूपमा डेलिभर गरिएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "आंशिक रूपमा पठाइएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "भुक्तानी अधिकृत"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "भुक्तानी सम्पन्न"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "पठाइएको"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "निगरानी गरिएका स्रोतहरू"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "निकाय जानकारी"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "कुल अर्डर"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "प्रशासकहरूलाई मात्र देखिने"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "मात्रा"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "ट्यागहरू"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "सुपर प्रशासक"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "केही स्रोतहरू डाउन छन्"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "उपलब्ध कार्यहरू"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "लिङ्क घुसाउनुहोस्"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "यदि सक्षम गरिएको छ भने, फिल्टरहरू अभिभावक संग्रहबाट विरासतमा प्राप्त हुनेछन् र यो संग्रहमा सेट गरिएका फिल्टरहरूसँग संयुक्त हुनेछन्।"
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "क्षेत्र चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "ढुवानी विधिहरू परीक्षण गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "भुक्तानी सफलतापूर्वक सम्पन्न भयो"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "क्षेत्रबाट {0} {1} हटाइयो"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "सक्षम पार्नुहोस्"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "भुक्तानी विधिहरू"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "अधिकृत"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "रद्द गरिएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "सिर्जना गरिएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "अस्वीकार गरिएको"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "त्रुटि"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "असफल"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "पेन्डिङमा"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "मिलान गरिएको"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "औसत अर्डर मूल्य"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "क्षेत्र सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "स्टक स्तरहरू"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "API Key अपडेट गर्न असफल भयो"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "अर्डर लाइनहरू"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "ग्लोबल दृश्य पुन: नामकरण गर्न असफल"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "URL र लक्ष्य विकल्पहरूसहित नयाँ हाइपरलिंक सम्मिलित गर्नुहोस्"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "उचाइ"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} को फिर्ता आवश्यक छ। भुक्तानी रकम चयन गर्नुहोस् र जारी राख्न टिप्पणी प्रविष्ट गर्नुहोस्।"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "एकाइ मूल्य"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "तालिका ढाँचा"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "भुक्तानी असफल भयो"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "च्यानल थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "उत्पादन विकल्प समूह अद्यावधिक गर्न असफल"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "च्यानलहरू खोज्नुहोस्..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "ग्राहक समूहहरू थप्नुहोस्"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "उपलब्ध भाषाहरू"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "चयन रिसेट गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "कुनै ठेगाना छैन"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "भुक्तानी विधि सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "ग्राहक जानकारी अपडेट गरियो"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "दृश्यलाई ग्लोबलमा रूपान्तरण गर्न असफल"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "उत्पादन भेरियन्टहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "उत्पादनहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "प्रमोशनहरू"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "उत्पादन विकल्प सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "पुरानो इमेल:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "सबै प्रयोगकर्ताहरूलाई उपलब्ध गराउन दृश्यलाई \"ग्लोबल\" को रूपमा सुरक्षित गर्नुहोस्।"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "भेरियन्टहरू सिर्जना गर्न असफल भयो"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "यो भेरियन्ट स्टक बाहिर मानिने स्टक स्तर सेट गर्दछ। नकारात्मक मान प्रयोग गर्दा ब्याकअर्डर समर्थन सक्षम हुन्छ। उत्पादन भेरियन्टहरूद्वारा ओभरराइड गर्न सकिन्छ।"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "कुञ्जी घुमाउनुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "उत्पादन भेरियन्टहरू सिर्जना गर्न असफल"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "पासवर्ड लुकाउनुहोस्"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "नयाँ विक्रेता"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "जस्तै रातो, ठूलो, कपास"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "प्रोफाइल अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "कुपन कोडहरू हटाइयो"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "फिल्टर खाली गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "क्षेत्रहरू"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "अपलोड गर्न यहाँ फाइलहरू छोड्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "सबै देखिने भेरियन्टहरू टगल गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "प्रमाणित गरिएको"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "नयाँ विकल्प समूह"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "अन्तिम अपडेट {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "अझै कुनै ग्लोबल दृश्यहरू सिर्जना गरिएको छैन।"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "भूमिका अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "पूर्ण API Key प्रदर्शन हुने यो एक मात्र पटक हो। अहिले नै कपी वा डाउनलोड गर्नुहोस् — पछि पुनःप्राप्त गर्न सकिँदैन।"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "संग्रह सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "भुक्तानी विधि सफलतापूर्वक अपडेट गरियो"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "दृश्य सफलतापूर्वक मेटियो"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "विकल्प समूह {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "वा"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "ट्यागहरू व्यवस्थापन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "अर्डरबाट कुपन कोड हटाइएको"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "कहिल्यै पनि"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "विशेषता मान अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "समूह हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "अर्डर पूरा गरियो"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "कुनै ढुवानी ठेगाना छैन"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "क्वेरी विस्तारमा अवैध GraphQL सिन्ट्याक्स छ"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "क्वेरी विस्तार त्रुटि"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "क्वेरी विस्तार त्रुटि:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "क्वेरी विस्तार अवैध छ: कम्तिमा एक शीर्ष-स्तर फिल्ड हुनुपर्छ"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "क्वेरी विस्तार बेमेल:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "सार्वजनिक"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "कर वर्ग सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "सार्नुहोस्"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "अवस्थित ट्यागहरू सम्पादन वा मेट्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "यो ढुवानी विधिको योग्यता जाँचकर्ता शर्तहरू हालको अर्डर र ढुवानी ठेगानाको लागि पूरा भएका छैनन्।"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "कुपन कोड थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "अर्डरको लागि कुपन कोड सेट गरिएको"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "कस्टम फिल्डहरू"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "नयाँ ढुवानी विधि"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "स्टक स्थानहरू मेट्नुहोस्"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "बराबर वा बढी छ"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "पूर्वावलोकन"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{1} मध्ये {0} पूर्ति गर्न उपलब्ध"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "महिनाको सुरुदेखि आजसम्म"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "ग्राहकको अनुरोध"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "ढुवानीमा क्षति"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "उपलब्ध छैन"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "अन्य"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "गलत सामान"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "परिमार्जनहरूको सारांश"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "रिफन्डहरू ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "अन्तिम कार्यान्वयन"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "भुक्तानी विवरणहरू"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "खोज सूचकांक पुनर्निर्माण गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "चलिरहेको"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "प्रत्येक ६० सेकेन्ड"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "ग्राहक समूह अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "भुक्तानी मेटाडेटा"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "परिमार्जन रद्द गर्नुहोस्"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "एउटै विन्डो"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "तालिकामा फिल्टरहरू लागू गर्नुहोस् र सुरु गर्न \"दृश्य सुरक्षित गर्नुहोस्\" क्लिक गर्नुहोस्।"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "भूमिकाहरू"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "थप भुक्तानी आवश्यक"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "अर्डर अपडेट गर्न असफल"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "चयन गरिएकासँग..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "स्टक स्थान सिर्जना गर्न असफल"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "बराबर वा कम"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "{customerGroupName} को ग्राहक समूह सदस्यहरू"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "राज्य"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "ट्र्याक नगर्नुहोस्"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "पूर्ति #{0} सिर्जना गरियो"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "पेन्डिङ खोज अनुक्रमणिका अद्यावधिकहरू चलाइँदै"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "यो पूर्वनिर्धारित भूमिका हो र परिमार्जन गर्न सकिँदैन"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "मेरो सुरक्षित दृश्यहरू"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "राज्य / प्रान्त"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "सक्षम"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "प्रति पृष्ठ वस्तुहरू"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "सदस्यहरू सम्पादन गर्नुहोस्"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "हातमा स्टक"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "{columnId} द्वारा फिल्टर गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "सूचनाहरू"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "विकल्प मानहरू"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "परिवर्तनहरू पूर्वावलोकन गर्नुहोस्"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "च्यानलबाट {entityType} हटाउन असफल भयो"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "भेरियन्ट सफलतापूर्वक मेटियो"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "चयन गरिएको लिंकको गुणहरू सम्पादन गर्नुहोस्"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "बिक्री"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "गन्तव्य संग्रह चयन गर्नुहोस्"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "तपाईंको नवीनतम अर्डरहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "अनुसूचित कार्यहरू"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं यो वस्तु मेट्न चाहनुहुन्छ? यो कार्य पूर्ववत गर्न सकिँदैन।"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "भेरियन्टहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "विक्रेताहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "सेटिङहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "सेटिङ स्टोर"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "शीर्षक ३"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Vendure मा स्वागत छ"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "ढुवानी विधिहरू"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} फिर्ता गर्न मिल्ने)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "पहिचानकर्ता"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "संग्रह अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "मूल्य र कर"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "अर्डर फेला परेन"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "त्रुटि"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "अर्डर परिमार्जन गरियो"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "पासवर्ड रिसेट अनुरोध गरियो"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "तोकिएको भुक्तानी रकम फिर्ता कुल बराबर हुनुपर्छ"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "जस्तै सानो"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं हालको च्यानलबाट {0} {entityType} हटाउन चाहनुहुन्छ?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "ट्यागहरू थप्नुहोस्..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "उत्पादन विकल्प समूह सिर्जना गर्न असफल"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} वस्तुहरू चयन गरियो"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "भाषाहरू खोज्नुहोस्..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "स्टक स्थानहरू"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "अघिल्लो पृष्ठमा जानुहोस्"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "सामग्रीहरू"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "ग्लोबल दृश्यलाई व्यक्तिगत दृश्यमा रूपान्तरण गर्न असफल"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "कार्यको परिणाम"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "भुक्तानी थप्नुहोस् ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "प्रणाली"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "भिन्नता नाम"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "हटाउनुहोस्"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "ग्राहक अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "विकल्प समूहहरू हटाउने हो?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "यो हालको फिल्टर सेटिङहरूमा आधारित सङ्ग्रह सामग्रीहरूको पूर्वावलोकन हो। तपाईंले सङ्ग्रह सुरक्षित गरेपछि, नयाँ फिल्टर सेटिङहरू प्रतिबिम्बित गर्न सामग्रीहरू अपडेट गरिनेछ।"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {समूहबाट {count} ग्राहक हटाइयो} other {समूहबाट {count} ग्राहकहरू हटाइयो}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "कर वर्गहरू"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "कर दरहरू"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "समूहबाट ग्राहकहरू हटाउन असफल भयो"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "ग्लोबल सेटिङहरू लोड गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "फिर्ताको लागि वस्तुहरू छान्नुहोस् र वैकल्पिक रूपमा स्टकमा फिर्ता गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "सुरक्षित गर्नुहोस्"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{0} पङ्क्ति(हरू) मध्ये {selectedRowCount} चयन गरिएको।"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "अर्डर परिमार्जनहरू पूर्वावलोकन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "उत्पादन विकल्प समूह सफलतापूर्वक अद्यावधिक गरियो"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "पृष्ठ पूर्वनिर्धारित क्वेरीसँग जारी रहनेछ।"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "सडक ठेगाना"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "थप फासेटहरू छैनन्"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "खोज सूचकांक पुनर्निर्माण सुरु भयो"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "संग्रह स्थिति अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "विकल्प समूह नाम"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "「{newOptionInput}」थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "नयाँ उत्पादन भेरियन्ट"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "रिफन्ड संक्रमण भयो"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "मूल प्रमाणीकरण रणनीति प्रयोग गर्दै"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "च्यानलमा {entityIdsLength} {entityType} तोक्न असफल"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "पूर्वनिर्धारित भाषा"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "टोकन"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "पूरा गर्दै..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "उत्पादनमा विकल्प समूह थप्नुहोस्"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "{0} को पूर्वावलोकन"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "विक्रेता सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "अर्डरलाई स्थितिमा संक्रमण गर्न असफल"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "सबै देखाउनुहोस् ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "कर दर सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "मैले यो API Key सुरक्षित गरिसकेँ"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "तपाईंको स्टोर र च्यानलहरूको लागि उपलब्ध भाषाहरू कन्फिगर गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "उत्पादन सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "उत्पादन भेरियन्ट थप्नुहोस्"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "टाइप गर्नुहोस् र थप्न Enter वा अल्पविराम थिच्नुहोस्..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "टिप्पणी सम्पादन गर्नुहोस्"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "कुनै एसेट भेटिएन। कृपया फिल्टरहरू समायोजन गर्नुहोस्।"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "विकल्प थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "विकल्प समूह सुरक्षित गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "{createCount} भेरियन्टहरू सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "यो ढुवानी विधि परीक्षण गर्न \"परीक्षण चलाउनुहोस्\" क्लिक गर्नुहोस्।"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "प्रशासक सफलतापूर्वक अपडेट गरियो"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "फिल्टरहरू खाली गर्नुहोस्"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "{1} बाट {2} सम्म पूर्ति #{0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "ग्लोबल दृश्य मेट्न असफल"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "पूर्वनिर्धारित भाषा"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "स्थिति"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "कुनै विकल्प फेला परेन"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "बाइनरी"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "विकल्प समूह सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "नयाँ ढुवानी विधि"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "प्रत्येक १० सेकेन्ड"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "कर बाहेक:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "स्थानमा स्टक थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "विकल्प मान सफलतापूर्वक थपियो"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "संग्रह नयाँ अभिभावकमा सारियो"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "विकल्प समूह हटाइयो"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "चयन गरिएको स्थितिमा संक्रमण गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "{formattedDiff} को थप भुक्तानी आवश्यक हुनेछ।"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "पूर्वनिर्धारित रूपमा सूची ट्र्याक गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{total} मध्ये {selected} चयन गरिएको"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "ढुवानी विधि सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "नयाँ ग्राहक समूह"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "ग्राहकलाई देखिने"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "विकल्प समूह सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "कर दरहरू"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "स्लग स्वचालित रूपमा उत्पन्न हुनेछ..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "ग्राहक फेला परेन"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "{0} चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "थप्नको लागि नयाँ विशेषता मानहरू:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "फिर्ता प्रक्रिया गर्न असफल"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "पहिलो नाम"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "समावेश गर्दछ"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "कुनै विकल्प समूह भेटिएन"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "कुनै वस्तुहरू फेला परेन"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "उप योग"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "पूरा गरिएका वस्तुहरू ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "मान अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "प्रमाणित नगरिएको"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "मात्रा"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "फिल्टर थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "कर वर्ग"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "प्रोफाइल"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "परीक्षण डेटा अपडेट गरिएको छ। अपडेट गरिएका परिणामहरू हेर्न \"परीक्षण चलाउनुहोस्\" क्लिक गर्नुहोस्।"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "मा छैन"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "अर्डर लाइन अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "नयाँ भुक्तानी विधि"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "नक्कल मान \"{trimmed}\" पहिले नै अवस्थित छ"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "कारण"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "ग्राहक समूहहरू"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "च्यानलबाट {entityType} सफलतापूर्वक हटाइयो"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "विकल्प समूहहरू"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "अतिरिक्त शुल्क थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "वर्तमान विशेषता मानहरू"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "{totalPages} मध्ये पृष्ठ {page}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "गत महिना"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "देश थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "वस्तु हटाउनुहोस्"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "भिडियो"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "भन्दा सानो"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "भेरियन्ट थप्न सकिएन। सुनिश्चित गर्नुहोस् कि मुख्य उत्पादन सक्षम छ।"
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "अज्ञात त्रुटि भयो"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "मेट्रिक्स"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "भाषा"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "नयाँ संग्रह"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "फिर्ता र अर्डर रद्द गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "इमेल अपडेट प्रमाणित गरियो"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "बीचमा छ"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "फिर्ता र रद्द"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "ढुवानी विधिहरू परीक्षण गर्दै..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "ढुवानी विधि सिर्जना गर्न असफल"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "च्यानलमा {entityIdsLength} {entityType} सफलतापूर्वक असाइन गरियो"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "ग्लोबल भाषाहरू"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "नयाँ प्रशासक"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "मस्यौदा मेट्नुहोस्"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "स्रोत"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "कुनै कार्यहरू उपलब्ध छैनन्"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "च्यानल अपडेट गर्न असफल"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "सामान्य"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "च्यानलबाट उत्पादन हटाउन असफल"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "नयाँ ठेगाना थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "विशेषता सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "क्षेत्र सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "मान"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "ग्राहक अपडेट गरियो"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "मूल्य रूपान्तरण कारक"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "विक्रेता अर्डर"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "नयाँ विशेषता"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "के तपाईं यो विकल्प समूहलाई उत्पादनबाट हटाउन चाहनुहुन्छ?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "विवरण (वैकल्पिक पाठ)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "कुनै ट्यागहरू फेला परेन"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "पूर्वनिर्धारित मुद्रा"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "यी परिवर्तनहरूको लागि कुनै भुक्तानी वा रिफन्ड आवश्यक छैन।"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "कुल राजस्व"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "अर्को कार्यान्वयन"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "टिप्पणी निजी छ"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "मध्यम मिति"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "अमान्य संख्या"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "तपाईंले अझै कुनै दृश्यहरू सुरक्षित गर्नुभएको छैन।"
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "के तपाईं निश्चित हुनुहुन्छ कि तपाईं यो दृश्य मेट्न चाहनुहुन्छ? यो कार्य पूर्ववत गर्न सकिँदैन।"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "अर्डर प्रक्रिया हेर्नुहोस्"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "दृश्य नक्कल गर्न असफल"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "पूर्वनिर्धारित ढुवानी ठेगानाको रूपमा प्रयोग गर्नुहोस्"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "स्लग म्यानुअल रूपमा सम्पादन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "सङ्ग्रह सामग्रीहरूको पूर्वावलोकन गर्न फिल्टरहरू थप्नुहोस्।"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "उत्पादन विकल्प समूह"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "उप योग"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "भन्दा सानो छ"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "रिफन्ड ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "अर्डर अनुकूलन फिल्डहरू अद्यावधिक गरियो"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "क्याल्कुलेटर"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "च्यानलबाट विकल्प समूह हटाउन असफल: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "कार्य डेटा हेर्नुहोस्"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "शीर्ष स्तरमा सार्नुहोस्"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "खाली गर्नुहोस्"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "अर्डर सारांश"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "एसेटहरू खोज्नुहोस्..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "नयाँ विशेषता"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "च्यानलमा {entityType} असाइन गर्नुहोस्"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "जारी राख्नुहोस्"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "प्रमोशनहरू"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "त्रुटि सन्देश"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "अर्को स्थानको लागि स्टक स्तर थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "ठेगाना मेट्नुहोस्"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "विशेषता अपडेट गर्न असफल"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters लाई WidgetFiltersProvider भित्र प्रयोग गर्नुपर्छ"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "ठेगाना सम्पादन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "च्यानलबाट विशेषता हटाउन असफल: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "लिङ्क सेट गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "नयाँ विक्रेता"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "छवि सम्पादन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "भेरियन्टहरू व्यवस्थापन गर्नुहोस्"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "स्टक आवंटित गरियो"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "बराबर वा बढी"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "यो भेरियन्ट स्टक बाहिर मानिने स्टक स्तर सेट गर्दछ। नकारात्मक मान प्रयोग गर्दा ब्याकअर्डर समर्थन सक्षम हुन्छ।"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "उत्पादन विकल्पहरू सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "सुरक्षित गर्दै..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "परिणाम हेर्नुहोस्"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "प्रति पृष्ठ पङ्क्तिहरू"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "संग्रहहरू लोड गर्दै..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "विशेषता मान सफलतापूर्वक अपडेट गरियो"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "सम्पत्ति थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "परिवर्तनहरू सुरक्षित गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "ग्राहक समूहमा थपियो"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "विक्रेता अर्डरहरू"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "विकल्प मान थप्न असफल"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "{groupName} मा विकल्प मान थप्नुहोस्"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} वस्तु(हरू) फिर्ता गरियो"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "अझै कुनै विकल्प समूहहरू परिभाषित गरिएको छैन। तपाईंको उत्पादनका विभिन्न भेरियन्टहरू सिर्जना गर्न विकल्प समूहहरू थप्नुहोस् (जस्तै साइज, रङ, सामग्री)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "नयाँ इमेल:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "भुक्तानी विधि अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "उपलब्ध:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "सिर्जना मिति"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "उत्पादन भेरियन्ट सिर्जना गर्न असफल"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "भाषा: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "तपाईंसँग ग्लोबल भाषा सेटिङहरू हेर्ने अनुमति छैन"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "कर दर सफलतापूर्वक सिर्जना गरियो"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "शीर्षक ६"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "कुपन कोडहरू थपियो"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "सक्रिय"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "कर आधार"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "थप लोड गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "रिफन्ड सम्पन्न भयो"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} सफलतापूर्वक नक्कल गरियो"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "नयाँ विकल्प समूह"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "अझै कुनै परिणाम छैन"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "भुक्तानी सम्पन्न भयो"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "उपलब्ध सर्तहरू"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "सक्रिय फिल्टरहरू"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "सबै खाली गर्नुहोस्"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "भन्दा ठूलो छ"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "बन्द गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "अर्डरमा भुक्तानी थप्नुहोस्"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "लोड गर्दै..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "API अनुरोधहरू गर्दा च्यानल निर्दिष्ट गर्न टोकन प्रयोग गरिन्छ।"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "कुनै ठेगानाहरू फेला परेन"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "पूर्ति ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "फिर्ताको लागि भुक्तानीहरू छान्नुहोस्"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "{failed} {entityName} मेट्न असफल"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "स्टक बाहिर थ्रेसहोल्ड"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "च्यानलबाट उत्पादन सफलतापूर्वक हटाइयो"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "मान अपडेट गर्न असफल भयो"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "API Key सिर्जना गर्न असफल भयो"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "रिफन्ड सम्पन्न गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "भुक्तानी विधि आवश्यक छ"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "समूहमा ग्राहक थप्न असफल"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "भेरियन्टहरू व्यवस्थापन गर्नुहोस्"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "ग्लोबल दृश्य \"{viewName}\" लागू गरियो"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "ग्राहक दर्ता गरियो"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "क्षेत्रहरू"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "विक्रेताहरू खोज्नुहोस्..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "प्रमोशन सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "विकल्प"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "अर्डर प्रक्रिया"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "फोन नम्बर"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "निजी"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "भेरियन्ट"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "ग्लोबल सेटिङहरू सफलतापूर्वक अपडेट गरियो"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key सफलतापूर्वक अपडेट गरियो"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "यी भाषाहरू सबै च्यानलहरूलाई प्रयोग गर्नको लागि उपलब्ध हुनेछन्"

--- a/packages/dashboard/src/i18n/locales/nl.po
+++ b/packages/dashboard/src/i18n/locales/nl.po
@@ -13,6181 +13,6181 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Volledige naam"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Selecteer items"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Wijzigingen bekijken"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Trackingcode"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "De geselecteerde rechten worden toegepast op deze kanalen."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Productopties"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Nieuw belastingtarief"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Een bestaande optiegroep toewijzen of een nieuwe aanmaken"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Nieuwe rol"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Appartement, suite, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Geen items meer"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Link bewerken"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Voeg ten minste één artikel aan de bestelling toe"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Voeg producten toe om een testbestelling te maken"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Adres aanmaken mislukt"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Alles schakelen"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "JSON-waarde bewerken"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Externe authenticatiestrategie gebruiken: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Selecteer een reden..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Kop 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Betaling toevoegen mislukt"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Bijgewerkt"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Globale instellingen bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Bestelling succesvol afgehandeld"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Weet u zeker dat u {0} {entityName} wilt verwijderen?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Globale uitverkocht-drempelwaarde"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Talen beheren"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Dupliceren... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Succesvol verwijderd"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Verwijderen uit huidig kanaal"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} bestanden verwijderd"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Belastingtarief succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Voer een aangepaste reden in..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Type"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Selecteer {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Waarden bekijken"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Rij verwijderen"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Voorwaarden"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Huidig"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Geen afhandelingen"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Kan {1} voorraadlocatie niet verwijderen: {messages}} other {Kan {2} voorraadlocaties niet verwijderen: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Wanneer dit is ingeschakeld, worden de prijzen die in de productcatalogus zijn ingevoerd, opgenomen in de belasting voor de standaard belastingzone."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Maak varianten aan voor uw product"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Conceptbestelling voltooid"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Automatisch vernieuwen: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Statuscontroles"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} verwijderd"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Statuscontroles"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Verkopers"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Opties"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} taak succesvol geannuleerd} other {{fulfilled} taken succesvol geannuleerd}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Verkoper"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Betaling toevoegen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Test deze verzendmethode door een bestelling te simuleren om te zien of deze geschikt is en wat de verzendkosten zouden zijn."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Ontdek Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Voorraadlocaties"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Afhandelingshandler"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Bestellingen"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Rollen selecteren"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Rol succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Weet u zeker dat u deze variant wilt verwijderen?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Alle resources zijn operationeel"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Aanmaken van beheerder mislukt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Nee"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Productvariant succesvol bijgewerkt"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "{failed} {entityName} verwijderen mislukt: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Product succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Land bijwerken mislukt"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Typ minstens 2 tekens om te zoeken..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Achternaam"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Linktitel"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Klantengroep succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Aangepaste velden gewijzigd"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Voorraadlocatie succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Onbekende fout"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Restitutietotaal kan niet negatief zijn"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Details bekijken"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Selecteer een kanaal om {0} {entityType} aan toe te wijzen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Klant succesvol aangemaakt"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Laatste 7 dagen"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Kanaal aanmaken mislukt"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Ontwikkelaarsmodus"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Nieuwe rol"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Bestanden verwijderen mislukt: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Terugbrengen naar voorraad"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Zichtbaarheid"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Productvarianten"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Nieuwe klantengroep"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "\"{0}\" aanmaken"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Hernoemen"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Kies uw voorkeurstaal en landinstellingen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} optiegroepen succesvol verwijderd uit kanaal"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Verzendmethode is niet geschikt voor deze bestelling"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Adres bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adres succesvol verwijderd"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Belastingtarief"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Conceptbestelling is nog niet klaar om te worden voltooid"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Nieuwe collectie"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Inzichten"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Uitvoeren"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Belastingtarief bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Dit is de inhoud van de collectie <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privé"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Productoptie succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Hoofdproduct"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Plaats"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Beheerders"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Brutoprijs: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Ga naar volgende pagina"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Link verwijderen"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Dit veld is alleen-lezen"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Aantal bestellingen"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Bestelling succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Filters overnemen"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Beheer globale opgeslagen weergaven die zichtbaar zijn voor alle gebruikers"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Betaalmethoden zoeken..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Verzendadres verwijderd voor bestelling"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "{enabledCount} varianten aanmaken"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Betaling #{0} overgegaan naar {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Fout bij laden klantgeschiedenis: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} succesvol verwijderd uit kanaal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Optiewaarde toevoegen"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Globale instellingen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "is na"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Productoptie succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Facetwaarden bewerken"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Toevoegen..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Collecties verplaatsen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Rollen"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Rasterweergave"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Adres verwijderen mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Geen verzendmethoden beschikbaar"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Globale weergave succesvol geconverteerd naar persoonlijke weergave"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Afhandeling overgegaan"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Weet u zeker dat u {selectionLength} bestanden wilt verwijderen?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Inloggen"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Lijstweergave"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Testbestelling"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Selecteer een klant om door te gaan"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Optiegroep succesvol toegewezen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Test uitvoeren"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Belastingtarief: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Voeg producten toe en voltooi het verzendadres om de test uit te voeren."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Rijkop schakelen"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Selecteer adres"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Betalingsgeschiktheidscontrole"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Standaard belastingzone"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Conceptbestelling is klaar om te worden voltooid"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadata"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filteren..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Nieuwe facetwaarde"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Kanaal succesvol bijgewerkt"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Minder tonen"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Korte datum"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Beschikbare valuta's"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Selecteer {0} items"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Geplaatst op"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Het roteren van deze sleutel maakt de huidige sleutel onmiddellijk ongeldig. Integraties die deze sleutel gebruiken zullen niet meer werken totdat ze zijn bijgewerkt met de nieuwe sleutel."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "De gegevens die aan de taak zijn doorgegeven"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Navigatie bevestigen"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Linkdoel"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Concept voltooien"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Naam"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Bestelling afhandelen mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Totaal"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Voer de transactie-ID in voor deze terugbetalingsafhandeling"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Uw API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Weet u zeker dat u deze conceptbestelling wilt verwijderen?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Afhandeling aangemaakt"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "{0} geschikte verzendmethode(n) gevonden"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Afmetingen"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Wachtwoord tonen"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(max: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Bedrijf"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Kolom toevoegen na"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Acties"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Kortingen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Voer terugbetalingsnotitie in"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Bestelregel verwijderd"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Inhoud:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Sleutel"
 
-#: src/lib/components/login/login-form.tsx:112
+#: src/lib/components/login/login-form.tsx
 #~ msgid "Username"
 #~ msgstr "Gebruikersnaam"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Bevestigen"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Collectie aanmaken mislukt"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Ga naar eerste pagina"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Product aanmaken mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Klant"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Fout bij laden bestelgeschiedenis: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Verzendadres ingesteld voor bestelling"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Focuspunt"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Enkele variant, geen opties"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Selecteer de volgende status voor de bestelling"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Landinstelling"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Geplande taken"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Voer transactie-ID in"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Gegevens vernieuwen"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Facetwaarden toevoegen of verwijderen voor {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Dit zijn de facetwaarden voor het facet <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Betaling succesvol toegevoegd aan bestelling"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Factuuradres ingesteld voor bestelling"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Zone bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Verwijderen mislukt"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Geplande taak wordt uitgevoerd"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Nieuwe voorraadlocatie"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Rechten"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Verzendadres gewijzigd"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Geen producten gevonden"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Rij toevoegen voor"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Overgaan naar {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Deze maand"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Facet aanmaken mislukt"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Annuleren van bestelartikelen mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "Transactie-ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Toegewezen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Voeg nog een optiegroep toe"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Kies wat er met de resterende voorraad moet gebeuren"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Platform en Cloud verkennen"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Elke 5 seconden"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Collectie succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Prijs"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Conceptbestelling"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Bereik"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Voorwaarde toevoegen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Verzendmethode is geschikt voor deze bestelling"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Beheerders"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Verwijderd uit groep"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Breedte"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Geen betaling of terugbetaling vereist"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Downloaden als .env-bestand"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Wanneer ingeschakeld, is een promotie beschikbaar in de winkel"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Wanneer gevolgd, worden de voorraadniveaus van productvarianten automatisch aangepast bij verkoop. Deze instelling kan worden overschreven door individuele productvarianten."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Verzendmethode ingesteld voor bestelling"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Promotie bijwerken mislukt"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Afbeeldingen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Zoeken {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Bestand bewerken"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Betaling annuleren"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Taakwachtrij"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Middelen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "E-mailadres"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Slug opnieuw genereren vanuit bronveld"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Overnemen van globale instellingen"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Geen resultaten gevonden"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Huidige status"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Stel een verzendadres in en selecteer een verzendmethode"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Uit"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Instellingenopslag"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Wachtrij"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Nieuw belastingtarief"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Betaling overgegaan"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Resterend:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Geen duplicator gevonden met code \"{duplicatorCode}\" voor {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Prijzen zijn inclusief belasting voor standaard belastingzone"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Totale terugbetaling:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Taakresultaat bekijken"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Test uw verzendmethoden door een nieuwe bestelling te simuleren."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Geen items geselecteerd"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} geselecteerd"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Geen landen gevonden"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Varianten succesvol aangemaakt"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Slug automatisch genereren"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Toeslag"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Betaalmethoden"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Voorraad"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Geen klanten gevonden"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Globale uitverkocht-drempelwaarde gebruiken"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Nieuwe productoptiegroep"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Betalingsstatus succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Nieuw aanmaken"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Totaal restitutie"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adres verwijderd"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Alleen rollen die aan uw account zijn toegewezen zijn beschikbaar."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Item toegevoegd aan bestelling"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Focuspunt bewerken"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Geen verkopers gevonden"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Bestand"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Deze optiegroep wordt door een ander product gebruikt. Wijzigingen zijn ook daarop van toepassing.} other {Deze optiegroep wordt gedeeld door # producten. Wijzigingen zijn op allemaal van toepassing.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Mijn opgeslagen weergaven"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Nieuw kanaal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Verkoper aanmaken mislukt"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Duplicatie-instellingen configureren voor {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Geen varianten komen overeen met het huidige filter."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adressen"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Een nieuwe optiewaarde toevoegen aan de optiegroep {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Bestelwijziging #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Kolom toevoegen voor"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Kanaaltalen"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Optiegroep aanmaken mislukt"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Waar"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Selecteer klant"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Bestelling overgegaan"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Dit product heeft bestaande varianten maar geen optiegroepen gedefinieerd. U moet optiegroepen toevoegen voordat u nieuwe varianten aanmaakt."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "is voor"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Conceptbestelling verwijderen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Catalogus"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Nieuwe betaalmethode"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promotie succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {{rejected} taak kon niet worden geannuleerd} other {{rejected} taken konden niet worden geannuleerd}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Selecteer een kanaal"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Weergavetaal"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Afhandelingsdetails"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Resterende voorraad verwijderen"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Nu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Kanalen"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Weergave succesvol geconverteerd naar globaal"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "voor"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Maat"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Geen vertaling gevonden voor {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Nieuwe klant"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Laatste bestellingen"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} meer"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Gebruiken als standaard factuuradres"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Uitschakelen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Collecties"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Variant toevoegen"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Land aanmaken mislukt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Landen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Productopties aanmaken mislukt"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Weergave hernoemen mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Beschikbaar"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filters"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Klantengroepen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Klanten"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Voorbeeldopmaak"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nieuwe optie"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Gebruikslimiet"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Globale instellingen laden..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adres succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Aangemaakt"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Adressen laden..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Selecteer een doelcollectie om {0} naar te verplaatsen."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Klantgegevens bijgewerkt"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "niet in"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Toepassen"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nieuwe productoptie"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Ga naar laatste pagina"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Annuleren"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Productvariant succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Terugbetaling van deze methode"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Postcode"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Voeg eerst productopties toe"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Nieuwe belastingcategorie"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Optie toevoegen"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Gedeeltelijke restitutie voltooid"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Aangepaste velden instellen"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Collecties"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Variant verwijderen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Geen wijzigingen aangebracht"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Standaard verzendzone"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Reden:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Verzendadres"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Overgaan naar {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Belastingcategorieën"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Privécollecties zijn niet zichtbaar in de winkel"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Wanneer ingeschakeld, is een product beschikbaar in de winkel"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Geplande taak kon niet worden uitgevoerd"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Klantengroepen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Uitgeschakeld"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Nieuwe promotie"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Standaard verzendadres"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Terugbetaling vereist"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Bestelling afhandelen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "U heeft geen toestemming om kanaalinstellingen te bekijken"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Laatste 30 dagen"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Geen facetwaarden"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Een reden voor de restitutie is vereist"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Kon optiegroep niet verwijderen"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Belastingcategorie bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Terugbetaling succesvol afgehandeld"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Bijwerken"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Kop 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Bestelling geplaatst"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profiel succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Betaalmethode"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Bewerken"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variant succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filteren op collectienaam"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Notitie toegevoegd"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Selecteer hoeveelheden om af te handelen en configureer de afhandelingshandler"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Factuuradres verwijderd van bestelling"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Begint op"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Dupliceren"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Geen resultaten"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Kolominstellingen"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Kan {count} voorraadlocatie niet verwijderen} other {Kan {count} voorraadlocaties niet verwijderen}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Code"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Verwijderen van optiegroepen mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Bestelling afgeleverd"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Overdragen naar {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Resterende voorraad"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Uit zone verwijderen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Selecteer uit globaal beschikbare talen voor dit kanaal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Weet u zeker dat u dit adres wilt verwijderen?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Toewijzen van optiegroep mislukt"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Bestand bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Voorraadlocatie succesvol bijgewerkt"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Actie bevestigen"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Land succesvol bijgewerkt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Facetten"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Notitie toevoegen mislukt"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Notitie verwijderen mislukt"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Kon query document niet uitbreiden"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Notitie bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Verzendkosten restitueren"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Alleen-lezen"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Globale weergave dupliceren mislukt"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "{shown} van {total} weergegeven • {selected} geselecteerd"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Verzendmethode testen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Facetwaarden"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Bestand succesvol bijgewerkt"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Thema"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} klanten"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Selecteer een taal"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Uitloggen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Pogingen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Beschikbare valutacodes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Beschikbare taalcodes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Broodkruimels"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Categorie"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Kanalen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Onderliggende items"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Code"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Couponcode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Aangemaakt op"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Valutacode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Klant"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Klantengroep"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Klanten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Aangepaste velden"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Gegevens"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Standaard valutacode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Standaard taalcode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Standaard verzendzone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Standaard belastingzone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Beschrijving"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Duur"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "E-mailadres"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Ingeschakeld"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Eindigt op"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Fout"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Uitgelicht bestand"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Voornaam"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Afhandelingscode"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Is standaard"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Is privé"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Is afgehandeld"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Achternaam"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Naam"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Bestelling geplaatst op"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "Bovenliggend ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Gebruikslimiet per klant"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Rechten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Positie"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Prijs"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Prijzen incl. BTW"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Prijs incl. BTW"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Productvarianten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Voortgang"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Wachtrijnaam"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Resultaat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Nieuwe pogingen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Verkoper"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Afgewikkeld op"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Verzendregels"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Gestart op"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Begint op"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Status"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Voorraadniveaus"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Totaal"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Totaal incl. BTW"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Type"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Bijgewerkt op"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Gebruikslimiet"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Gebruiker"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Waarde"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Waardelijst"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Methode"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Belastingsamenvatting"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Stelt de talen in die beschikbaar zijn voor alle kanalen. Individuele kanalen kunnen vervolgens een subset van deze talen ondersteunen."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Collecties succesvol verplaatst"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Geregistreerd"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Taak annuleren"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Eindigt op"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Pagina {0} van {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Tarief"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Maat, kleur, etc."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Facetten doorbladeren"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Geannuleerd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Aangemaakt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Bezorgd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "In behandeling"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Verzonden"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Weergave opslaan"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} geselecteerd"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Optiegroepen zoeken..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Bestelling wijzigen"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Geselecteerde items"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Waarden"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Klant ingesteld voor bestelling"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Facetten"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Weet u zeker dat u {count} klant uit deze groep wilt verwijderen?} other {Weet u zeker dat u {count} klanten uit deze groep wilt verwijderen?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Voorraad op voorraad"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Opnieuw opbouwen van zoekindex kon niet worden gestart"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Verzendadres"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Nieuwe zone"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Nieuwe API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Kolom verwijderen"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Bestaande toewijzen"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "is leeg"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Dit zijn de klanten in de klantengroep <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Globale weergaven beheren"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Standaardkanaal"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Een nieuwe afbeelding invoegen met bron, titel en afmetingen"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Facetwaarde aanmaken mislukt"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Bijwerken van productoptie mislukt"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Couponcode"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Klant geverifieerd"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Globale instellingen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Planning"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Een collectie kan niet naar een eigen subniveau worden verplaatst"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Nieuwe belastingcategorie"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Geen voorraadlocaties beschikbaar op huidig kanaal"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Kanaal succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Klant succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Gegevens bekijken"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Weergave verwijderen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Voeg een nieuw adres toe aan de klant."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Meer weergaven"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "De eigenschappen van de geselecteerde afbeelding bewerken"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Weergave „{viewName}\" toegepast"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} facetten succesvol verwijderd uit kanaal"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Nieuw product"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Nieuw bestand"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Verzendkosten herberekenen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Selecteer welke opties van toepassing moeten zijn op de bestaande variant \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Middelen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Dit verwijdert alle optiegroepen van dit product en keert terug naar de variantkeuze."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Factuuradres"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Facetwaarde toevoegen"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Selecteer een doelcollectie"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Bekijk de wijzigingen voordat u ze toepast op de bestelling."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Selecteer een rol"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Bestelling geannuleerd"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Korting"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Alle typen"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Alleen conceptbestellingen kunnen worden voltooid"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Product bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "{0} regels aanpassen"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Facetwaarden toevoegen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "na"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Kanaal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Statuscontroles"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Bedrag"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Telefoonnummer"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Nieuwe klant"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Afbeelding"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Beheerder succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Productopties"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Selecteer land"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Aanmaken..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Weet u zeker dat u deze globale weergave wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt en heeft invloed op alle gebruikers."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Optiegroep geforceerd verwijderen"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Toegevoegd"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Klantgeschiedenis"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Facetwaarden succesvol bijgewerkt voor {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Klant uit groep verwijderen mislukt"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Systeem"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Gebruikslimiet per klant"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Factuuradres gewijzigd"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Selecteer een optie"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Kopiëren naar persoonlijk"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Restitutietotaal overschrijdt het maximaal restitueerbare bedrag van {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Globale weergave verwijderen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Aanmaken"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Elke 30 seconden"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Nieuw land"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "Van {0} tot {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Klant aanmaken mislukt"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Focuspunt bijgewerkt"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Optiewaarden"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Standaard factuuradres"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Geen klant"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Verwijderen van landen uit zone mislukt"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Promotie aanmaken mislukt"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Vandaag"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Gisteren"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Optienaam"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Weet u zeker dat u {0} {1} uit deze zone wilt verwijderen?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "{0} toeslag(en) toevoegen"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Link-href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Fallback: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Bestelgeschiedenis"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Overschrijven"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "Transactie-ID is vereist"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "komt overeen met regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Globale weergave succesvol hernoemd"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Geen tags geselecteerd"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Terug"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Weergave succesvol hernoemd"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Filter toepassen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Laatste resultaat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Toegevoegd aan groep"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Inzichten"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Varianten aanmaken"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Verzendmethode testen..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Donker"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Testresultaten"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Klant toevoegen"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Wijzigingen opslaan"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adres bijgewerkt"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Restitutie succesvol verwerkt"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Nieuwe zone"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Bijwerken van collectiepositie mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Restitutie"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Wijzigen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Geen globale talen geconfigureerd"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "{0} item(s) verwijderen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Volgen"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Variant aanmaken"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Facetwaarden voor {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Lay-out opslaan"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Wachtwoordherstel geverifieerd"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Weergave verwijderen mislukt"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Weet u zeker dat u deze pagina wilt verlaten? Niet-opgeslagen wijzigingen gaan verloren."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Kolomkop schakelen"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Nieuwe promotie"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Naam optiewaarde"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Laatst gebruikt"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Is standaard belastingcategorie"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug is ingesteld"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Bijwerken van focuspunt mislukt"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zone succesvol bijgewerkt"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Staat/Provincie"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Bijwerken van optiegroep mislukt"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Kanaalstandaarden"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Belastingcategorie aanmaken mislukt"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Filtercriteria instellen voor de kolom {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Land"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Eenvoudig product"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Taakwachtrij"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Bevestig dat u de API Key hebt opgeslagen voordat u sluit."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Verwijdering bevestigen"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Bestelling wijzigen mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Inclusief {taxRate}% belasting"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Bestelstatistieken"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Selecteer weergavetaal"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Authenticatiemethoden"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "begin"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Roteren van API Key mislukt"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "in"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Rollen zoeken..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Productvarianten"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Globale weergaven beheren"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Bezig met verwerken..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} gevonden"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Datumbereik selecteren"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Product"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "API Key roteren"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Categorie"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Verplaatsen..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Toewijzen"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Verkoper succesvol aangemaakt"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Verzendmethode succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Productvariant bijwerken mislukt"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Slepen om opnieuw te ordenen"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zones"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Kies wat er moet gebeuren met de resterende voorraad in {count, plural, one {# voorraadlocatie} other {# voorraadlocaties}} die u verwijdert. Alle geselecteerde locaties dragen hun resterende voorraad over naar de ene locatie die u kiest, of verwijderen die."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Facetwaarden zoeken..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Opmerking"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Beschikbare talen"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "{0} meer laden ({remaining} resterend)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Facetwaarden"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Opnieuw ordenen van artikelen mislukt"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Totaal bestellingen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Geen geschikte verzendmethoden gevonden voor deze bestelling."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Productoptie toevoegen"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Verzending"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions moet binnen een DashboardBaseWidget worden gebruikt"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Deze optiegroep wordt gebruikt door bestaande varianten. Geforceerd verwijderen kan deze varianten beïnvloeden. Weet u het zeker?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "E-mailupdate aangevraagd"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Fout bij overgaan naar status"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Klantengroep succesvol aangemaakt"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nieuw venster"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Betaling geautoriseerd"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Rol succesvol bijgewerkt"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Selecteer een land"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Bijwerken van verzendmethode mislukt"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} voorraadlocatie verwijderd} other {{deleted} voorraadlocaties verwijderd}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Verzendmethoden"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Selecteer een adres"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Ja"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Focuspunt instellen"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "einde"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Selecteer een valuta"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Notitie-inhoud of zichtbaarheid bijwerken"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget nieuwste bestellingen"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Collectie-inhoud voor {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Verzendmethode gewijzigd"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Belastingomschrijving"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "is kleiner dan of gelijk aan"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "is niet gelijk aan"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Vernieuwen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "bijv. Maat"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Betaling afhandelen"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Kanalen"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Verzendkosten gerestitueerd"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Bestandstype"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Nieuwe voorraadlocatie"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} betaling(en) gerestitueerd voor de fout. Controleer de bestelgeschiedenis voor details."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Selecteer item"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Nieuw product"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Tags beheren"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Artikelen gerestitueerd"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Actie toevoegen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Opties toewijzen aan bestaande variant"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "{0} dupliceren"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Verwijderen uit groep"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Afhandelingsstatus bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Een nieuwe productvariant aanmaken met opties, prijzen en voorraad"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Privéfacetten zijn niet zichtbaar in de winkel"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Selecteer een belastingcategorie"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Niet actief"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Toegewezen"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Kop 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Selecteer beschikbare talen"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "{0} item(s) toevoegen"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Rij toevoegen na"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Totale belasting"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Status conceptbestelling"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Productopties succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Locaties laden…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Betaalmethode aanmaken mislukt"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Facetwaarde succesvol aangemaakt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Conceptbestelling verwijderd"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "groter dan"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Statistieken-widget"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Valuta's zoeken..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Verwijderen uit kanaal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Titel"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Afbeelding invoegen"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Verkoper bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Land succesvol aangemaakt"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Selecteer verkoper"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Tags laden..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Facet succesvol aangemaakt"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} varianten"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Betaling afhandelen mislukt"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Geen factuuradres"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Kan {1} voorraadlocatie niet verwijderen} other {Kan {2} voorraadlocaties niet verwijderen}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Facet"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Kan niet uit actief kanaal verwijderen"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Niet ingesteld"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Geforceerd verwijderen"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Nieuw kanaal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Naam optiegroep"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "EN"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Klantengroep aanmaken mislukt"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Rol aanmaken mislukt"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Productnaam"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Afhandelingsstatus succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Producten"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adres aangemaakt"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key succesvol geroteerd"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Optiegroep toevoegen"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Restitutie {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Voer slug handmatig in"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Geen widgets beschikbaar"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Betaling annuleren mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Betaling succesvol geannuleerd"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Globale weergave succesvol gedupliceerd"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Aangemaakt door"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Varianten filteren..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Prijs in een andere valuta toevoegen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "E-mailadres of identificatie"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Terugbetaling #{0} overgegaan naar {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Klanten"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Kop 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Voorraadlocatie bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Bestelling verzonden"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Adres opslaan"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Maak globaal"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Selecteer volgende status"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Geen meldingen"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "{0} collectie(s) verplaatsen naar {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "tussen"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Notitie succesvol toegevoegd"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Notitie succesvol verwijderd"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Notitie succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Terugbetaling afhandelen mislukt"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Voorraadniveau"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Item toevoegen"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Voorbeeld laden..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Terug naar zoeken"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Weergave succesvol gedupliceerd"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Optiegroep verwijderen"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Beschrijving"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Landen"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Straatnaam 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Globale weergave succesvol verwijderd"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Lay-out bewerken"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Toewijzen aan kanaal"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Deze week"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Productoptiegroep succesvol aangemaakt"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Voeg een handmatige betaling van {0} toe"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "is in"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-mail"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Bijwerken van beheerder mislukt"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Beheer uw persoonlijke opgeslagen weergaven voor deze tabel"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filteren op tags"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Log in om toegang te krijgen tot het beheerdersdashboard"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Betaling toevoegen aan bestelling ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Onwaar"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Licht"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Resetten"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "is gelijk aan"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Opties aanmaken"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Wachtwoord bijgewerkt"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "bevat niet"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Optiegroep"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Bewerk de adresgegevens hieronder."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Belastingcategorie succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Collecties verplaatsen mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Betalingsstatus bijwerken mislukt"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Uw besteloverzicht"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Uploaden"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Product met opties"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Alle {0} resultaten weergeven"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Opzoek-ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} meer"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Optiegroepen"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Aangepaste velden"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Alle mogelijke bestelstatussen en hun overgangen. De huidige status is gemarkeerd."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Bestellingen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget bestellingsoverzicht"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Items toevoegen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Extra betaling regelen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Betaling regelen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Geannuleerd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Aangemaakt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Bezorgd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Concept"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Wijzigen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Gedeeltelijk bezorgd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Gedeeltelijk verzonden"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Betaling geautoriseerd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Betaling afgehandeld"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Verzonden"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Gemonitorde bronnen"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Entiteitsinformatie"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Besteltotaal"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Alleen zichtbaar voor beheerders"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Aantal"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Tags"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Superbeheerder"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Sommige bronnen zijn offline"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Beschikbare acties"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Link invoegen"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Indien ingeschakeld, worden de filters overgenomen van de bovenliggende collectie en gecombineerd met de filters die op deze collectie zijn ingesteld."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Selecteer een zone"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Verzendmethoden testen"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Betaling succesvol afgehandeld"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} uit zone verwijderd"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Inschakelen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Betaalmethoden"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Geautoriseerd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Geannuleerd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Aangemaakt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Afgewezen"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Fout"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Mislukt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "In behandeling"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Afgewikkeld"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Gemiddelde bestelwaarde"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Zone aanmaken mislukt"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Voorraadniveaus"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Bijwerken van API Key mislukt"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Bestelregels"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Globale weergave hernoemen mislukt"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Een nieuwe hyperlink invoegen met URL en doelopties"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Hoogte"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Een terugbetaling van {formattedDiff} is vereist. Selecteer betalingsbedragen en voer een notitie in om door te gaan."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Stukprijs"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Planningspatroon"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Betaling mislukt"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Kanaal toevoegen"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Bijwerken van productoptiegroep mislukt"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Kanalen zoeken..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Klantengroepen toevoegen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Beschikbare talen"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Selectie herstellen"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Geen adres"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Betaalmethode succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Klantinformatie bijgewerkt"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Weergave converteren naar globaal mislukt"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Productvarianten"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Producten"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promoties"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Aanmaken van productoptie mislukt"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Oud e-mailadres:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Sla een weergave op als \"Globaal\" om deze beschikbaar te maken voor alle gebruikers."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Aanmaken van varianten mislukt"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Stelt het voorraadniveau in waarbij deze variant als uitverkocht wordt beschouwd. Het gebruik van een negatieve waarde schakelt ondersteuning voor nabestellingen in. Kan worden overschreven door productvarianten."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Sleutel roteren"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Aanmaken van productvarianten mislukt"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Wachtwoord verbergen"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Nieuwe verkoper"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "bijv. Rood, Groot, Katoen"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Profiel bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Couponcodes verwijderd"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Filter wissen"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regio's"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Sleep bestanden hierheen om te uploaden"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Alle zichtbare varianten in-/uitschakelen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Geverifieerd"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Nieuwe optiegroep"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Laatst bijgewerkt {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Er zijn nog geen globale weergaven aangemaakt."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Rol bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Dit is de enige keer dat de volledige API Key wordt weergegeven. Kopieer of download deze nu — later kan deze niet meer worden opgehaald."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Collectie succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Betaalmethode succesvol bijgewerkt"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Weergave succesvol verwijderd"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Optiegroep {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "OF"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Tags beheren"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Couponcode verwijderd van bestelling"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Nooit"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Facetwaarde bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Groep verwijderen"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Bestelling afgehandeld"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Geen verzendadres"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Query extensie bevat ongeldige GraphQL syntaxis"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Query extensie fout"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Query extensie fout: "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Query extensie is ongeldig: moet ten minste één veld op het hoogste niveau hebben"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Query extensie komt niet overeen: "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "openbaar"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Belastingcategorie succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Verplaatsen"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Bestaande tags bewerken of verwijderen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "De geschiktheidsvoorwaarden van deze verzendmethode worden niet voldaan voor de huidige bestelling en het verzendadres."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Couponcode toevoegen"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Couponcode ingesteld voor bestelling"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Aangepaste velden"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Nieuwe verzendmethode"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Voorraadlocaties verwijderen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "is groter dan of gelijk aan"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Voorbeeld"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} van {1} beschikbaar om te verwerken"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Maand tot heden"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Klantverzoek"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Beschadigd tijdens verzending"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Niet beschikbaar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Overig"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Verkeerd artikel"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Samenvatting van wijzigingen"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Terugbetalingen ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Laatst uitgevoerd"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Betalingsdetails"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Zoekindex opnieuw opbouwen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Actief"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Elke 60 seconden"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Klantengroep bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Betalingsmetadata"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Wijziging annuleren"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Zelfde venster"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Pas filters toe op de tabel en klik op \"Weergave opslaan\" om te beginnen."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Rollen"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Extra betaling vereist"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Bestelling bijwerken mislukt"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Met geselecteerde..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Voorraadlocatie aanmaken mislukt"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "kleiner dan of gelijk aan"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Klantengroepleden voor {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Staat"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Niet volgen"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Afhandeling #{0} aangemaakt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Wachtende zoekindex-updates worden uitgevoerd"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Dit is een standaardrol en kan niet worden gewijzigd"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Mijn opgeslagen weergaven"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Staat / Provincie"
 
-#: src/lib/components/login/login-form.tsx:89
+#: src/lib/components/login/login-form.tsx
 #~ msgid "Welcome back!"
 #~ msgstr "Welkom terug!"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Items per pagina"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Leden bewerken"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Voorraad op voorraad"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filteren op {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Meldingen"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Optiewaarden"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Voorbeeld van wijzigingen"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Verwijderen van {entityType} uit kanaal mislukt"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variant succesvol verwijderd"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "De eigenschappen van de geselecteerde link bewerken"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Verkopen"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Selecteer een doelcollectie"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Uw laatste bestellingen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Geplande taken"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Weet u zeker dat u dit item wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Varianten"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Verkopers"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Instellingen"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Instellingenopslag"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Kop 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Welkom bij Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Verzendmethoden"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} restitueerbaar)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identificatie"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Collectie bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Prijs en belasting"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Bestelling niet gevonden"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Fout"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Bestelling gewijzigd"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Wachtwoordherstel aangevraagd"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Het toegewezen betalingsbedrag moet gelijk zijn aan het restitutietotaal"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "bijv. Klein"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Weet u zeker dat u {0} {entityType} uit het huidige kanaal wilt verwijderen?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Tags toevoegen..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Aanmaken van productoptiegroep mislukt"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} items geselecteerd"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Talen zoeken..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Voorraadlocaties"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Ga naar vorige pagina"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Inhoud"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Globale weergave converteren naar persoonlijke weergave mislukt"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Het resultaat van de taak"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Betaling toevoegen ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Systeem"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Variantnaam"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Klant bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Optiegroepen verwijderen?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Dit is een voorbeeld van de collectie-inhoud op basis van de huidige filterinstellingen. Zodra u de collectie opslaat, wordt de inhoud bijgewerkt volgens de nieuwe filterinstellingen."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} klant uit groep verwijderd} other {{count} klanten uit groep verwijderd}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Belastingcategorieën"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Belastingtarieven"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Klanten konden niet uit de groep worden verwijderd"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Globale instellingen laden mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Selecteer artikelen om te restitueren en optioneel terug te brengen naar voorraad"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Opslaan"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} van {0} rij(en) geselecteerd."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Voorbeeld van bestelwijzigingen"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Productoptiegroep succesvol bijgewerkt"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "De pagina zal doorgaan met de standaard query."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Straatnaam"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Geen facetten meer"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Opnieuw opbouwen van zoekindex gestart"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Collectiepositie bijgewerkt"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Naam optiegroep"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Voeg \"{newOptionInput}\" toe"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Nieuwe productvariant"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Terugbetaling overgegaan"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Native authenticatiestrategie gebruiken"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Toewijzing van {entityIdsLength} {entityType} aan kanaal mislukt"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Standaardtaal"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Afhandelen..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Optiegroep toevoegen aan product"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Voorbeeld van {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Verkoper succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Bestelling overgaan naar status mislukt"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Alles tonen ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Belastingtarief aanmaken mislukt"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Ik heb deze API Key opgeslagen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Configureer beschikbare talen voor uw winkel en kanalen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Product succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Productvariant toevoegen"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Typ en druk op Enter of komma om toe te voegen..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Notitie bewerken"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Geen bestanden gevonden. Probeer uw filters aan te passen."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Optie toevoegen"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Optiegroep opslaan"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "{createCount} varianten aanmaken"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Klik op \"Test uitvoeren\" om deze verzendmethode te testen."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Beheerder succesvol bijgewerkt"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Filters wissen"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Afhandeling #{0} van {1} naar {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Globale weergave verwijderen mislukt"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Standaardtaal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Geen opties gevonden"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binair"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Optiegroep succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Nieuwe verzendmethode"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Elke 10 seconden"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "excl. BTW:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Voorraad toevoegen aan locatie"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Optiewaarde succesvol toegevoegd"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Collectie naar nieuw bovenliggend niveau verplaatst"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Optiegroep verwijderd"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Overgaan naar geselecteerde status"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Een extra betaling van {formattedDiff} is vereist."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Voorraad standaard volgen"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} van {total} geselecteerd"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Verzendmethode succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nieuwe klantengroep"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Zichtbaar voor klant"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Optiegroep succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Belastingtarieven"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug wordt automatisch gegenereerd..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Klant niet gevonden"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Selecteer {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Nieuwe facetwaarden om toe te voegen:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Verwerking van restitutie mislukt"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Voornaam"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "bevat"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Geen optiegroepen gevonden"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Geen items gevonden"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Subtotaal"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Afgehandelde items ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Waarde bijgewerkt"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Niet geverifieerd"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Aantal"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Filter toevoegen"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Belastingcategorie"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profiel"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Testgegevens zijn bijgewerkt. Klik op \"Test uitvoeren\" om de bijgewerkte resultaten te zien."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "is niet in"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Bestelregel bijgewerkt"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Nieuwe betaalmethode"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Dubbele waarde \"{trimmed}\" bestaat al"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Reden"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Klantengroepen"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} succesvol verwijderd uit kanaal"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Optiegroepen"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Toeslag toevoegen"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Huidige facetwaarden"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Pagina {page} van {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Vorige maand"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Land toevoegen"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Item verwijderen"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "kleiner dan"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "De variant kon niet worden toegevoegd. Controleer of het hoofdproduct is ingeschakeld."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Er is een onbekende fout opgetreden"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Statistieken"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Taal"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Nieuwe collectie"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Bestelling restitueren en annuleren"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "E-mailupdate geverifieerd"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "is tussen"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Restitueren en annuleren"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Verzendmethoden testen..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Aanmaken van verzendmethode mislukt"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} succesvol toegewezen aan kanaal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Globale talen"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Nieuwe beheerder"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Concept verwijderen"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Bron"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Geen acties beschikbaar"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Kanaal bijwerken mislukt"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Algemeen"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Verwijderen van product uit kanaal mislukt"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Nieuw adres toevoegen"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Facet succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zone succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Waarde"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Klant bijgewerkt"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Prijsconversiefactor"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Verkopersbestelling"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Nieuw facet"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Weet u zeker dat u deze optiegroep van het product wilt verwijderen?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Beschrijving (alt-tekst)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Geen tags gevonden"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Standaardvaluta"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Voor deze wijzigingen is geen betaling of terugbetaling vereist."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Totale omzet"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Volgende uitvoering"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Notitie is privé"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Gemiddelde datum"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Ongeldig nummer"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "U heeft nog geen weergaven opgeslagen."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Weet u zeker dat u deze weergave wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Bestelproces bekijken"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Weergave dupliceren mislukt"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Gebruiken als standaard verzendadres"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Slug handmatig bewerken"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Voeg filters toe om een voorbeeld van de collectie-inhoud te bekijken."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Productoptiegroep"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Subtotaal"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "is kleiner dan"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "Terugbetalings-ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Aangepaste velden van bestelling bijgewerkt"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Calculator"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Verwijderen van optiegroep uit kanaal mislukt: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Taakgegevens bekijken"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Verplaatsen naar het hoogste niveau"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Wissen"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Besteloverzicht"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Bestanden zoeken..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Nieuw facet"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "{entityType} toewijzen aan kanaal"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Doorgaan"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promoties"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Foutmelding"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Voorraadniveau voor een andere locatie toevoegen"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Adres verwijderen"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Facet bijwerken mislukt"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters moet binnen een WidgetFiltersProvider worden gebruikt"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Adres bewerken"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Facet uit kanaal verwijderen mislukt: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Link instellen"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Nieuwe verkoper"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Afbeelding bewerken"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Varianten beheren"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Voorraad toegewezen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "groter dan of gelijk aan"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Stelt het voorraadniveau in waarbij deze variant als uitverkocht wordt beschouwd. Het gebruik van een negatieve waarde schakelt ondersteuning voor nabestellingen in."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Productopties aanmaken"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Opslaan..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Resultaat bekijken"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Rijen per pagina"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Collecties laden..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Facetwaarde succesvol bijgewerkt"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Bestand toevoegen"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Wijzigingen opslaan"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Klant toegevoegd aan groep"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Verkopersbestellingen"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Optiewaarde toevoegen mislukt"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Optiewaarde toevoegen aan {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} artikel(en) gerestitueerd"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Nog geen optiegroepen gedefinieerd. Voeg optiegroepen toe om verschillende varianten van uw product te maken (bijv. Maat, Kleur, Materiaal)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Nieuw e-mailadres:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Betaalmethode bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Beschikbaar:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Aangemaakt op"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Productvariant aanmaken mislukt"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Taal: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "U heeft geen toestemming om globale taalinstellingen te bekijken"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Belastingtarief succesvol aangemaakt"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Kop 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Couponcodes toegevoegd"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Actief"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Belastinggrondslag"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Meer laden"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Terugbetaling afgehandeld"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} succesvol gedupliceerd"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Nieuwe Optiegroep"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Nog geen resultaat"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Betaling afgehandeld"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Beschikbare voorwaarden"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Actieve filters"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Alles wissen"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "is groter dan"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Sluiten"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Betaling toevoegen aan bestelling"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Laden..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "De token wordt gebruikt om het kanaal op te geven bij het doen van API-verzoeken."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Geen adressen gevonden"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "Afhandelings-ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Selecteer betalingen om te restitueren"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "{failed} {entityName} verwijderen mislukt"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Uitverkocht-drempelwaarde"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Product succesvol uit kanaal verwijderd"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Bijwerken van waarde mislukt"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Aanmaken van API Key mislukt"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Terugbetaling afhandelen"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Betaalmethode is vereist"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Klant toevoegen aan groep mislukt"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Varianten beheren"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Globale weergave „{viewName}\" toegepast"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Klant geregistreerd"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zones"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Verkopers zoeken..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Promotie succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Optie"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Bestelproces"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Telefoonnummer"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privé"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variant"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Globale instellingen succesvol bijgewerkt"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key succesvol bijgewerkt"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Deze talen zijn beschikbaar voor alle kanalen"

--- a/packages/dashboard/src/i18n/locales/pl.po
+++ b/packages/dashboard/src/i18n/locales/pl.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Pełne imię i nazwisko"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Wybierz pozycje"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Zobacz zmiany"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Kod śledzenia"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Wybrane uprawnienia zostaną zastosowane do tych kanałów."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Opcje produktu"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Nowa stawka podatkowa"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Przypisz istniejącą grupę opcji lub utwórz nową"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Nowa rola"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Mieszkanie, apartament itp."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Nie ma więcej pozycji"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Edytuj link"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Dodaj co najmniej jeden produkt do zamówienia"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Dodaj produkty, aby utworzyć zamówienie testowe"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Nie udało się utworzyć adresu"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Przełącz wszystkie"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Edytuj wartość JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Używanie zewnętrznej strategii uwierzytelniania: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Wybierz powód..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Nagłówek 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Nie udało się dodać płatności"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Zaktualizowano"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Nie udało się zaktualizować ustawień globalnych"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Pomyślnie zrealizowano zamówienie"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Czy na pewno chcesz usunąć {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Globalny próg braku w magazynie"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Zarządzaj językami"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Duplikowanie... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Pomyślnie usunięto"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Usuń z bieżącego kanału"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Usunięto {selectionLength} zasobów"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Pomyślnie zaktualizowano stawkę podatkową"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Wprowadź własny powód..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Typ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Wybierz {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Zobacz wartości"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Usuń wiersz"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Warunki"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Bieżący"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Brak realizacji"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Nie udało się usunąć {1} lokalizacji magazynowej: {messages}} few {Nie udało się usunąć {2} lokalizacji magazynowych: {messages}} many {Nie udało się usunąć {2} lokalizacji magazynowych: {messages}} other {Nie udało się usunąć {2} lokalizacji magazynowych: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Gdy to jest włączone, ceny wprowadzone w katalogu produktów będą zawierać podatek dla domyślnej strefy podatkowej."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Utwórz warianty swojego produktu"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Ukończono zamówienie robocze"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Automatyczne odświeżanie: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Kontrole stanu"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Usunięto {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Kontrole stanu"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Sprzedawcy"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Opcje"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {Pomyślnie anulowano {fulfilled} zadanie} few {Pomyślnie anulowano {fulfilled} zadania} many {Pomyślnie anulowano {fulfilled} zadań} other {Pomyślnie anulowano {fulfilled} zadania}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Sprzedawca"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Dodaj płatność"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Przetestuj tę metodę wysyłki, symulując zamówienie, aby sprawdzić, czy się kwalifikuje i jaki byłby koszt wysyłki."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Poznaj Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Lokalizacje magazynowe"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Obsługa realizacji"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Zamówienia"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Wybierz role"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Pomyślnie utworzono rolę"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Czy na pewno chcesz usunąć ten wariant?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Wszystkie zasoby są aktywne"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Nie udało się utworzyć administratora"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Nie"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Pomyślnie zaktualizowano wariant produktu"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Nie udało się usunąć {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Pomyślnie zaktualizowano produkt"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Nie udało się zaktualizować kraju"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Wpisz co najmniej 2 znaki, aby wyszukać..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Nazwisko"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Tytuł linku"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Pomyślnie zaktualizowano grupę klientów"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Zmieniono pola niestandardowe"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Pomyślnie utworzono lokalizację magazynową"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Nieznany błąd"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Suma zwrotu nie może być ujemna"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Zobacz szczegóły"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Wybierz kanał, aby przypisać {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Pomyślnie utworzono klienta"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Ostatnie 7 dni"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Nie udało się utworzyć kanału"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Tryb programisty"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Nowa rola"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Nie udało się usunąć zasobów: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Zwróć na stan"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Widoczność"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Warianty produktu"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Nowa grupa klientów"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Utwórz „{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Zmień nazwę"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Wybierz preferowany język wyświetlania i ustawienia regionalne"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "Pomyślnie usunięto {successCount} grup opcji z kanału"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Metoda wysyłki nie kwalifikuje się do tego zamówienia"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Nie udało się zaktualizować adresu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adres usunięty pomyślnie"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Stawka podatkowa"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Wersja robocza zamówienia nie jest gotowa do ukończenia"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Nowa kolekcja"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Statystyki"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Uruchom"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Nie udało się zaktualizować stawki podatkowej"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "To jest zawartość kolekcji <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "prywatne"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Pomyślnie utworzono opcję produktu"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Produkt nadrzędny"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Miasto"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administratorzy"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Cena brutto: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Przejdź do następnej strony"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Usuń link"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "To pole jest tylko do odczytu"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Liczba zamówień"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Pomyślnie zaktualizowano zamówienie"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Dziedzicz filtry"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Zarządzaj globalnymi zapisanymi widokami widocznymi dla wszystkich użytkowników"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Szukaj metod płatności..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Adres dostawy usunięty dla zamówienia"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Utwórz {enabledCount} wariantów"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Płatność #{0} przeniesiono do {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Błąd ładowania historii klienta: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "Pomyślnie usunięto {selectionLength} {entityType} z kanału"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Dodaj wartość opcji"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Ustawienia globalne"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "jest po"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Pomyślnie zaktualizowano opcję produktu"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Edytuj wartości aspektów"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Dodawanie..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Przenieś kolekcje"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Role"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Widok siatki"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Nie udało się usunąć adresu"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Brak dostępnych metod wysyłki"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Pomyślnie przekonwertowano widok globalny na osobisty"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Realizację przeniesiono"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Czy na pewno chcesz usunąć {selectionLength} zasobów?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Zaloguj się"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Widok listy"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Zamówienie testowe"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Wybierz klienta, aby kontynuować"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Pomyślnie przypisano grupę opcji"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Uruchom test"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Stawka podatkowa: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Dodaj produkty i uzupełnij adres wysyłki, aby uruchomić test."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Przełącz wiersz nagłówka"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Wybierz adres"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Sprawdzanie kwalifikowalności płatności"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Domyślna strefa podatkowa"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Wersja robocza zamówienia jest gotowa do ukończenia"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadane"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtruj..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Nowa wartość aspektu"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Pomyślnie zaktualizowano kanał"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Pokaż mniej"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Data krótka"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Dostępne waluty"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Wybierz {0} pozycji"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Złożono"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Rotacja tego klucza natychmiast unieważni bieżący klucz. Wszystkie integracje korzystające z niego przestaną działać do czasu aktualizacji nowym kluczem."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Dane, które zostały przekazane do zadania"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Potwierdź nawigację"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Cel linku"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Ukończ wersję roboczą"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Nazwa"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Nie udało się zrealizować zamówienia"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Suma"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Wprowadź ID transakcji dla tego rozliczenia zwrotu"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Twój API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Czy na pewno chcesz usunąć ten projekt zamówienia?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Utworzono realizację"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Znaleziono {0} kwalifikujących się metod wysyłki"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Wymiary"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Pokaż hasło"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(maks: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Firma"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Dodaj kolumnę po"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Działania"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Rabaty"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Wprowadź notatkę zwrotu"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Usunięto wiersz zamówienia"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Zawartość:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Klucz"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Potwierdź"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Nie udało się utworzyć kolekcji"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Przejdź do pierwszej strony"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Nie udało się utworzyć produktu"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Klient"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Błąd ładowania historii zamówień: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Adres dostawy ustawiony dla zamówienia"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Punkt ogniskowy"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Pojedynczy wariant, bez opcji"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Wybierz następny stan dla zamówienia"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Ustawienia regionalne"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Zadania zaplanowane"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Wprowadź ID transakcji"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Odśwież dane"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Dodaj lub usuń wartości aspektów dla {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "To są wartości aspektów dla aspektu <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Pomyślnie dodano płatność do zamówienia"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Adres rozliczeniowy ustawiony dla zamówienia"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Nie udało się zaktualizować strefy"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Hasło"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Nie udało się usunąć"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Zaplanowane zadanie zostanie wykonane"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Nowa lokalizacja magazynowa"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Uprawnienia"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Zmieniono adres wysyłki"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Nie znaleziono produktów"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Dodaj wiersz przed"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Przejdź do {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Ten miesiąc"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Nie udało się utworzyć aspektu"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Nie udało się anulować pozycji zamówienia"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID transakcji"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Przydzielono"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Dodaj kolejną grupę opcji"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Wybierz, co zrobić z pozostałymi zapasami"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Odkryj Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Co 5 sekund"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Pomyślnie utworzono kolekcję"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Cena"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Zamówienie robocze"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Zakres"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Dodaj warunek"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Metoda wysyłki kwalifikuje się do tego zamówienia"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administratorzy"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Usunięto z grupy"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Szerokość"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Nie wymagana płatność ani zwrot"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Pobierz jako plik .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Po włączeniu promocja jest dostępna w sklepie"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Po włączeniu śledzenia poziomy magazynowe wariantów produktów będą automatycznie dostosowywane podczas sprzedaży. To ustawienie może zostać zastąpione przez poszczególne warianty produktów."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Metoda dostawy ustawiona dla zamówienia"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Nie udało się zaktualizować promocji"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Obrazy"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Szukaj {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Edytuj zasób"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Anuluj płatność"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Kolejka zadań"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Zasoby"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Adres e-mail"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Regeneruj slug z pola źródłowego"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Dziedzicz z ustawień globalnych"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Nie znaleziono wyników"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Bieżący status"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Ustaw adres dostawy i wybierz metodę wysyłki"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Wyłączone"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Ustawienia sklepu"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Kolejka"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Nowa stawka podatkowa"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Przeniesiono płatność"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Pozostało:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Nie znaleziono duplikatora z kodem „{duplicatorCode}\" dla {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Ceny zawierają podatek dla domyślnej strefy podatkowej"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Suma zwrotu:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Zobacz wynik zadania"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Przetestuj swoje metody wysyłki, symulując nowe zamówienie."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Nie wybrano pozycji"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} zaznaczono"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Nie znaleziono krajów"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Pomyślnie utworzono warianty"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Generuj slug automatycznie"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Dopłata"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Metody płatności"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Magazyn"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Nie znaleziono klientów"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Użyj globalnego progu braku w magazynie"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Nowa grupa opcji produktu"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Pomyślnie zaktualizowano stan płatności"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Utwórz nowy"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Suma zwrotu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adres został usunięty"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Dostępne są tylko role przypisane do Twojego konta."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Dodano pozycję do zamówienia"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Edytuj punkt ogniskowy"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Nie znaleziono sprzedawców"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Zasób"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Ta grupa opcji jest używana przez jeden inny produkt. Zmiany będą miały na niego wpływ.} other {Ta grupa opcji jest współdzielona przez # produktów. Zmiany będą miały wpływ na wszystkie.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Moje zapisane widoki"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Nowy kanał"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Nie udało się utworzyć sprzedawcy"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Skonfiguruj ustawienia duplikowania dla {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Żadne warianty nie pasują do bieżącego filtra."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adresy"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Dodaj nową wartość opcji do grupy opcji {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Modyfikacja zamówienia #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Dodaj kolumnę przed"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Języki kanału"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Nie udało się utworzyć grupy opcji"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Prawda"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Wybierz klienta"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Przeniesiono zamówienie"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Ten produkt ma istniejące warianty, ale nie zdefiniowano grup opcji. Musisz dodać grupy opcji przed utworzeniem nowych wariantów."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "jest przed"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Usuń zamówienie robocze"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Katalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Nowa metoda płatności"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Pomyślnie zaktualizowano promocję"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Nie udało się anulować {rejected} zadanie} few {Nie udało się anulować {rejected} zadania} many {Nie udało się anulować {rejected} zadań} other {Nie udało się anulować {rejected} zadania}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Wybierz kanał"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Język wyświetlania"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Szczegóły realizacji"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Odrzuć pozostałe zapasy"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Teraz"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Kanały"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Pomyślnie przekonwertowano widok na globalny"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "przed"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Rozmiar"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Nie znaleziono tłumaczenia dla {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Nowy klient"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Ostatnie zamówienia"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} więcej"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Użyj jako domyślny adres rozliczeniowy"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Usuń"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Wyłącz"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Kolekcje"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Dodaj wariant"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Nie udało się utworzyć kraju"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Kraje"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Nie udało się utworzyć opcji produktu"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Nie udało się zmienić nazwy widoku"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Dostępne"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtry"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Grupy klientów"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Klienci"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Przykładowe formatowanie"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nowa opcja"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Limit użycia"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Ładowanie ustawień globalnych..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adres zaktualizowany pomyślnie"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Utworzono"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Ładowanie adresów..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Wybierz kolekcję docelową, aby przenieść {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Zaktualizowano dane klienta"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "nie w"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nowa opcja produktu"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Przejdź do ostatniej strony"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Anuluj"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Pomyślnie utworzono wariant produktu"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Zwrot z tej metody"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Kod pocztowy"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Najpierw dodaj opcje produktu"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Nowa kategoria podatkowa"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Dodaj opcję"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Częściowy zwrot zakończony"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Ustaw pola niestandardowe"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Kolekcje"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Usuń wariant"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Nie wprowadzono modyfikacji"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Domyślna strefa wysyłki"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Powód:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Adres wysyłki"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Przejdź do {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Kategorie podatkowe"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Prywatne kolekcje nie są widoczne w sklepie"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Po włączeniu produkt jest dostępny w sklepie"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Nie można było wykonać zaplanowanego zadania"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Grupy klientów"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Wyłączono"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Nowa promocja"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Domyślny adres wysyłki"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Wymagany zwrot"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Zrealizuj zamówienie"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Nie masz uprawnień do wyświetlania ustawień kanału"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Ostatnie 30 dni"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Brak wartości aspektów"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Wymagany jest powód zwrotu"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Nie można usunąć grupy opcji"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Nie udało się zaktualizować kategorii podatkowej"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Pomyślnie rozliczono zwrot"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Zaktualizuj"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Nagłówek 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Złożono zamówienie"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Pomyślnie zaktualizowano profil"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "koniec"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Metoda płatności"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Edytuj"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Pomyślnie zaktualizowano wariant"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtruj według nazwy kolekcji"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Dodano notatkę"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Wybierz ilości do zrealizowania i skonfiguruj obsługę realizacji"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Adres rozliczeniowy usunięty z zamówienia"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Data rozpoczęcia"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplikuj"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Brak wyników"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Ustawienia kolumn"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Nie udało się usunąć {count} lokalizacji magazynowej} few {Nie udało się usunąć {count} lokalizacji magazynowych} many {Nie udało się usunąć {count} lokalizacji magazynowych} other {Nie udało się usunąć {count} lokalizacji magazynowych}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Kod"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Nie udało się usunąć grup opcji"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Dostarczono zamówienie"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Przenieś do {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Pozostałe zapasy"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Usuń ze strefy"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Wybierz spośród języków dostępnych globalnie dla tego kanału"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Czy na pewno chcesz usunąć ten adres?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Nie udało się przypisać grupy opcji"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Nie udało się zaktualizować zasobu"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Pomyślnie zaktualizowano lokalizację magazynową"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Potwierdź akcję"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Pomyślnie zaktualizowano kraj"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Aspekty"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Nie udało się dodać notatki"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Nie udało się usunąć notatki"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Nie udało się rozszerzyć dokumentu zapytania"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Nie udało się zaktualizować notatki"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Zwróć koszt wysyłki"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Tylko do odczytu"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Nie udało się zduplikować widoku globalnego"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Wyświetlanie {shown} z {total} • zaznaczono {selected}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Testuj metodę wysyłki"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Wartości aspektów"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Pomyślnie zaktualizowano zasób"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Motyw"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} klientów"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Wybierz język"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Wyloguj się"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Próby"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Dostępne kody walut"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Dostępne kody języków"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Okruszki nawigacyjne"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Kategoria"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Kanały"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Elementy podrzędne"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Kod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Kod kuponu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Utworzone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Kod waluty"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Klient"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Grupa klientów"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Klienci"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Pola niestandardowe"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Dane"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Domyślny kod waluty"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Domyślny kod języka"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Domyślna strefa wysyłki"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Domyślna strefa podatkowa"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Opis"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Czas trwania"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Adres e-mail"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Włączone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Data zakończenia"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Błąd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Wyróżniony zasób"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Imię"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Kod obsługi realizacji"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Jest domyślny"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Jest prywatny"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Jest rozliczony"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Nazwisko"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Nazwa"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Data złożenia zamówienia"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID nadrzędny"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Limit użycia na klienta"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Uprawnienia"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Pozycja"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Cena"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Ceny zawierają podatek"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Cena z podatkiem"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Warianty produktów"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Postęp"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Nazwa kolejki"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Wynik"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Ponowne próby"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Sprzedawca"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Rozliczone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Linie wysyłki"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Rozpoczęte"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Data rozpoczęcia"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Stan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Poziomy magazynowe"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Suma"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Suma z podatkiem"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Typ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Zaktualizowane"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Limit użycia"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Użytkownik"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Wartość"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Lista wartości"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Strefa"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Metoda"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Podsumowanie podatków"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Ustawia języki dostępne dla wszystkich kanałów. Poszczególne kanały mogą następnie obsługiwać podzbiór tych języków."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Kolekcje przeniesione pomyślnie"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Zarejestrowany"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Anuluj zadanie"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Data zakończenia"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Strona {0} z {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Stawka"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Rozmiar, kolor itp."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Przeglądaj fasety"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Strefa"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Anulowane"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Utworzono"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Dostarczone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Oczekujące"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Wysłane"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Zapisz widok"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} wybranych"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Szukaj grup opcji..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Modyfikuj zamówienie"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Wybrane pozycje"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Wartości"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Ustawiono klienta dla zamówienia"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Aspekty"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Czy na pewno chcesz usunąć {count} klienta z tej grupy?} few {Czy na pewno chcesz usunąć {count} klientów z tej grupy?} many {Czy na pewno chcesz usunąć {count} klientów z tej grupy?} other {Czy na pewno chcesz usunąć {count} klientów z tej grupy?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Stan magazynowy"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Nie można było rozpocząć przebudowy indeksu wyszukiwania"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Adres wysyłki"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Nowa strefa"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Nowy API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Usuń kolumnę"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Przypisz istniejący"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "jest puste"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "To są klienci w grupie klientów <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Zarządzaj widokami globalnymi"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Domyślny kanał"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Wstaw nowy obraz ze źródłem, tytułem i wymiarami"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Nie udało się utworzyć wartości aspektu"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Nie udało się zaktualizować opcji produktu"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Zapomniałeś hasła?</0><1>Poproś o reset</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Kod kuponu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Zweryfikowano klienta"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Ustawienia globalne"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Harmonogram"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Nie można przenieść kolekcji do jej własnego potomka"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Nowa kategoria podatkowa"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Brak dostępnych lokalizacji magazynowych w bieżącym kanale"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Pomyślnie utworzono kanał"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Pomyślnie zaktualizowano klienta"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Zobacz dane"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Usuń widok"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Dodaj nowy adres do klienta."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Więcej widoków"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Edytuj właściwości wybranego obrazu"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Zastosowano widok „{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Pomyślnie usunięto {successCount} aspektów z kanału"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Nowy produkt"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Nowy zasób"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Przelicz wysyłkę"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Wybierz, które opcje powinny dotyczyć istniejącego wariantu „{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Zasoby"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Spowoduje to usunięcie wszystkich grup opcji z tego produktu i powrót do wyboru konfiguracji wariantów."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Adres rozliczeniowy"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Dodaj wartość aspektu"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Wybierz kolekcję docelową"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Sprawdź zmiany przed zastosowaniem ich do zamówienia."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Wybierz rolę"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Anulowano zamówienie"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Rabat"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Wszystkie typy"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Tylko wersje robocze zamówień mogą zostać ukończone"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Nie udało się zaktualizować produktu"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Dostosowywanie {0} wierszy"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Dodaj wartości aspektów"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "po"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Kanał"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Kontrole stanu"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Kwota"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Numer telefonu"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Nowy klient"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Obraz"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Pomyślnie utworzono administratora"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Opcje produktu"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Wybierz kraj"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Tworzenie..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Czy na pewno chcesz usunąć ten widok globalny? Ta akcja nie może być cofnięta i wpłynie na wszystkich użytkowników."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Wymuś usunięcie grupy opcji"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Dodano"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Historia klienta"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Pomyślnie zaktualizowano wartości aspektów dla {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Nie udało się usunąć klienta z grupy"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Limit użycia na klienta"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Zmieniono adres rozliczeniowy"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Wybierz opcję"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Kopiuj do osobistych"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Suma zwrotu przekracza maksymalną kwotę do zwrotu wynoszącą {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Usuń widok globalny"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Utwórz"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Co 30 sekund"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Nowy kraj"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "Od {0} do {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Nie udało się utworzyć klienta"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Zaktualizowano punkt ogniskowy"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Wartości opcji"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Domyślny adres rozliczeniowy"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Brak klienta"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Nie udało się usunąć krajów ze strefy"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Nie udało się utworzyć promocji"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Dzisiaj"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Wczoraj"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Nazwa opcji"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Czy na pewno chcesz usunąć {0} {1} z tej strefy?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Dodawanie {0} dopłat(y)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Link href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Wartość zastępcza: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Historia zamówień"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Nadpisz"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "ID transakcji jest wymagane"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "pasuje do regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Pomyślnie zmieniono nazwę widoku globalnego"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Nie wybrano tagów"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Wstecz"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Pomyślnie zmieniono nazwę widoku"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Zastosuj filtr"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Ostatni wynik"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Dodano do grupy"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Statystyki"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Utwórz warianty"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Testowanie metody wysyłki..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Ciemny"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Wyniki testu"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Dodaj klienta"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Zapisz zmiany"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adres został zaktualizowany"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Zwrot przetworzony pomyślnie"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Nowa strefa"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Nie udało się zaktualizować pozycji kolekcji"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Zwrot"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Modyfikuj"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Nie skonfigurowano języków globalnych"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Usuwanie {0} pozycji"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Śledź"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Utwórz wariant"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Wartości aspektów dla {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Zapisz układ"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Zweryfikowano resetowanie hasła"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Nie udało się usunąć widoku"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Czy na pewno chcesz opuścić tę stronę? Wszystkie niezapisane zmiany zostaną utracone."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Przełącz kolumnę nagłówka"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Nowa promocja"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Nazwa wartości opcji"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Ostatnio użyto"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Jest domyślną kategorią podatkową"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug jest ustawiony"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Nie udało się zaktualizować punktu ogniskowego"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Pomyślnie zaktualizowano strefę"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Stan/Województwo"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Nie udało się zaktualizować grupy opcji"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Domyślne ustawienia kanału"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Nie udało się utworzyć kategorii podatkowej"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Ustaw kryteria filtrowania dla kolumny {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Kraj"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Produkt prosty"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Kolejka zadań"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Potwierdź, że zapisano API key przed zamknięciem."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Potwierdź usunięcie"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Nie udało się zmodyfikować zamówienia"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Zawiera podatek {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Metryki zamówień"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Wybierz język wyświetlania"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Metody uwierzytelniania"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "początek"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Nie udało się wykonać rotacji API key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "w"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Szukaj ról..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Warianty produktów"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Zarządzaj widokami globalnymi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Przetwarzanie..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "Znaleziono {totalItems} {0}"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Wybierz zakres dat"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Produkt"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rotacja API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Kategoria"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Przenoszenie..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Przypisz"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Pomyślnie utworzono sprzedawcę"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Pomyślnie zaktualizowano metodę wysyłki"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Nie udało się zaktualizować wariantu produktu"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Przeciągnij, aby zmienić kolejność"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Strefy"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Wybierz, co zrobić z zapasami pozostałymi w {count, plural, one {# lokalizacji magazynowej} few {# lokalizacjach magazynowych} many {# lokalizacjach magazynowych} other {# lokalizacjach magazynowych}}, które usuwasz. Wszystkie wybrane lokalizacje przeniosą pozostałe zapasy do jednej wskazanej przez Ciebie lokalizacji albo je odrzucą."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Wyszukaj wartości faset..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Notatka"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Dostępne języki"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Załaduj jeszcze {0} (pozostało {remaining})"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Wartości aspektów"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Nie udało się zmienić kolejności pozycji"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Łączna liczba zamówień"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Nie znaleziono kwalifikujących się metod wysyłki dla tego zamówienia."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Dodaj opcję produktu"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Wysyłka"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions musi być używane wewnątrz DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Ta grupa opcji jest używana przez istniejące warianty. Wymuszone usunięcie może wpłynąć na te warianty. Czy na pewno?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Zażądano aktualizacji e-maila"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Błąd przejścia do stanu"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Pomyślnie utworzono grupę klientów"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nowe okno"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Autoryzowano płatność"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Pomyślnie zaktualizowano rolę"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Wybierz kraj"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Nie udało się zaktualizować metody wysyłki"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Usunięto {deleted} lokalizację magazynową} few {Usunięto {deleted} lokalizacje magazynowe} many {Usunięto {deleted} lokalizacji magazynowych} other {Usunięto {deleted} lokalizacji magazynowych}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Metody wysyłki"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Wybierz adres"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Tak"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Ustaw punkt ogniskowy"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "koniec"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Wybierz walutę"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Zaktualizuj zawartość lub widoczność notatki"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget najnowszych zamówień"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Zawartość kolekcji {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Zmieniono metodę wysyłki"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Opis podatku"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "jest mniejsze lub równe"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "nie jest równe"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Odśwież"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "np. Rozmiar"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Rozlicz płatność"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Kanały"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Wysyłka zwrócona"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Typ zasobu"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Nowa lokalizacja magazynowa"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} płatności zwróconych przed błędem. Sprawdź historię zamówień, aby uzyskać szczegóły."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Wybierz pozycję"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Nowy produkt"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Zarządzaj tagami"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Pozycje zwrócone"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Dodaj akcję"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Przypisz opcje do istniejącego wariantu"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Duplikuj {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Usuń z grupy"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Nie udało się zaktualizować stanu realizacji"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Utwórz nowy wariant produktu z opcjami, cenami i stanem magazynowym"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Prywatne aspekty nie są widoczne w sklepie"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Wybierz kategorię podatkową"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Utworzone"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Nie uruchomiono"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Przypisane"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Nagłówek 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Wybierz dostępne języki"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Dodawanie {0} pozycji"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Dodaj wiersz po"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Suma podatków"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Status wersji roboczej zamówienia"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Pomyślnie utworzono opcje produktu"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Wczytywanie lokalizacji…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Nie udało się utworzyć metody płatności"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Pomyślnie utworzono wartość aspektu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Usunięto zamówienie robocze"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "większe niż"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Widget metryk"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Szukaj walut..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Usuń z kanału"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Tytuł"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Wstaw obraz"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Nie udało się zaktualizować sprzedawcy"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Pomyślnie utworzono kraj"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Wybierz sprzedawcę"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Ładowanie tagów..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Pomyślnie utworzono aspekt"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} wariantów"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Nie udało się rozliczyć płatności"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Brak adresu rozliczeniowego"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Nie udało się usunąć {1} lokalizacji magazynowej} few {Nie udało się usunąć {2} lokalizacji magazynowych} many {Nie udało się usunąć {2} lokalizacji magazynowych} other {Nie udało się usunąć {2} lokalizacji magazynowych}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Aspekt"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Nie można usunąć z aktywnego kanału"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Nie ustawiono"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Wymuś usunięcie"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Nowy kanał"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Nazwa grupy opcji"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "ORAZ"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Nie udało się utworzyć grupy klientów"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Nie udało się utworzyć roli"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Nazwa produktu"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Pomyślnie zaktualizowano stan realizacji"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Produkty"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adres został utworzony"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "Rotacja API key zakończona pomyślnie"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Dodaj grupę opcji"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Zwróć {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Wprowadź slug ręcznie"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Brak dostępnych widgetów"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Nie udało się anulować płatności"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Pomyślnie anulowano płatność"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Pomyślnie zduplikowano widok globalny"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Utworzono przez"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtruj warianty..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Dodaj cenę w innej walucie"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Adres e-mail lub identyfikator"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Zwrot #{0} przeniesiono do {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Klienci"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Nagłówek 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Nie udało się zaktualizować lokalizacji magazynowej"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Wysłano zamówienie"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Zapisz adres"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Uczyń globalnym"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Wybierz następny stan"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Brak alertów"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Przenoszenie {0} kolekcji do {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "pomiędzy"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Notatka została dodana"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Notatka została usunięta"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Notatka została zaktualizowana"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Nie udało się rozliczyć zwrotu"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Poziom magazynowy"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Dodaj element"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "Pomyślnie utworzono API key"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Ładowanie podglądu..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Wróć do wyszukiwania"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Pomyślnie zduplikowano widok"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Usuń grupę opcji"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Opis"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Kraje"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Ulica 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Pomyślnie usunięto widok globalny"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Edytuj układ"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Przypisz do kanału"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Ten tydzień"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Pomyślnie utworzono grupę opcji produktu"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Dodaj ręczną płatność {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "jest w"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-mail"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Nie udało się zaktualizować administratora"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Zarządzaj swoimi osobistymi zapisanymi widokami dla tej tabeli"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtruj według tagów"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Zaloguj się, aby uzyskać dostęp do panelu administracyjnego"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Dodaj płatność do zamówienia ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Fałsz"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Jasny"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Resetuj"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "jest równe"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Utwórz opcje"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Zaktualizowano hasło"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "nie zawiera"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Grupa opcji"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Edytuj szczegóły adresu poniżej."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Pomyślnie utworzono kategorię podatkową"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Nie udało się przenieść kolekcji"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Nie udało się zaktualizować stanu płatności"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Podsumowanie Twoich zamówień"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Prześlij"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Produkt z opcjami"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Wyświetlanie wszystkich {0} wyników"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Identyfikator wyszukiwania"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} więcej"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Grupy opcji"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Pola niestandardowe"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Wszystkie możliwe stany zamówienia i ich przejścia. Bieżący stan jest wyróżniony."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Zamówienia"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget podsumowania zamówień"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Dodawanie produktów"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Organizowanie dodatkowej płatności"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Organizowanie płatności"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Anulowano"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Utworzono"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Dostarczone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Wersja robocza"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Modyfikowanie"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Częściowo dostarczone"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Częściowo wysłane"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Płatność autoryzowana"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Płatność rozliczona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Wysłane"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Monitorowane zasoby"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Informacje o encji"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Suma zamówienia"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Widoczne tylko dla administratorów"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Ilość"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Tagi"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Superadministrator"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Niektóre zasoby są niedostępne"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Dostępne akcje"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Wstaw link"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Jeśli włączone, filtry zostaną odziedziczone z kolekcji nadrzędnej i połączone z filtrami ustawionymi w tej kolekcji."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Wybierz strefę"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Testuj metody wysyłki"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Pomyślnie rozliczono płatność"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "Usunięto {0} {1} ze strefy"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Włącz"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Metody płatności"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autoryzowana"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Anulowana"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Utworzona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Odrzucona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Błąd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Nieudana"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Oczekująca"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Rozliczona"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Średnia wartość zamówienia"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Nie udało się utworzyć strefy"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Poziomy magazynowe"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Nie udało się zaktualizować API key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Wiersze zamówienia"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Nie udało się zmienić nazwy widoku globalnego"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Wstaw nowy hiperłącze z URL i opcjami celu"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Wysokość"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Wymagany jest zwrot w wysokości {formattedDiff}. Wybierz kwoty płatności i wprowadź notatkę, aby kontynuować."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Cena jednostkowa"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Wzorzec harmonogramu"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Płatność nie powiodła się"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Dodaj kanał"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Nie udało się zaktualizować grupy opcji produktu"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Szukaj kanałów..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Dodaj grupy klientów"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Dostępne języki"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Resetuj wybór"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Brak adresu"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Pomyślnie utworzono metodę płatności"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Zaktualizowano informacje o kliencie"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Nie udało się przekonwertować widoku na globalny"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Warianty produktów"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Produkty"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promocje"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Nie udało się utworzyć opcji produktu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Stary e-mail:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Zapisz widok jako „Globalny\", aby był dostępny dla wszystkich użytkowników."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Nie udało się utworzyć wariantów"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Ustawia poziom magazynowy, przy którym ten wariant jest uważany za niedostępny. Użycie wartości ujemnej umożliwia obsługę zamówień wstecznych. Może zostać zastąpiony przez warianty produktu."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rotacja klucza"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Nie udało się utworzyć wariantów produktu"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Ukryj hasło"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Nowy sprzedawca"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "np. Czerwony, Duży, Bawełna"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Nie udało się zaktualizować profilu"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Usunięto kody kuponów"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Wyczyść filtr"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regiony"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Upuść pliki tutaj, aby przesłać"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Przełącz wszystkie widoczne warianty"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Zweryfikowany"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Nowa grupa opcji"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Ostatnia aktualizacja {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Nie utworzono jeszcze żadnych widoków globalnych."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Nie udało się zaktualizować roli"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "To jedyna okazja, aby zobaczyć pełny API key. Skopiuj go lub pobierz teraz — nie będzie można go później odzyskać."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Pomyślnie zaktualizowano kolekcję"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Pomyślnie zaktualizowano metodę płatności"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Pomyślnie usunięto widok"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Grupa opcji {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "LUB"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Zarządzaj tagami"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Kod kuponu usunięty z zamówienia"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Nigdy"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Nie udało się zaktualizować wartości aspektu"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Usuń grupę"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Zrealizowano zamówienie"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Brak adresu wysyłki"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Rozszerzenie zapytania zawiera nieprawidłową składnię GraphQL"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Błąd rozszerzenia zapytania"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Błąd rozszerzenia zapytania: "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Rozszerzenie zapytania jest nieprawidłowe: musi mieć co najmniej jedno pole najwyższego poziomu"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Niezgodność rozszerzenia zapytania: "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "publiczne"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Pomyślnie zaktualizowano kategorię podatkową"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Przenieś"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Edytuj lub usuń istniejące tagi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Warunki sprawdzania kwalifikowalności tej metody wysyłki nie są spełnione dla bieżącego zamówienia i adresu wysyłki."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Dodaj kod kuponu"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Kod kuponu ustawiony dla zamówienia"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Pola niestandardowe"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Nowa metoda wysyłki"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Usuń lokalizacje magazynowe"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "jest większe lub równe"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Podgląd"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} z {1} dostępnych do realizacji"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Od początku miesiąca"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Prośba klienta"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Uszkodzony podczas wysyłki"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Niedostępny"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Inne"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Niewłaściwy przedmiot"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Podsumowanie modyfikacji"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Zwroty ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Ostatnie wykonanie"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Szczegóły płatności"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Przebuduj indeks wyszukiwania"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Uruchomiono"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Co 60 sekund"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Nie udało się zaktualizować grupy klientów"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Metadane płatności"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Anuluj modyfikację"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "To samo okno"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Zastosuj filtry do tabeli i kliknij „Zapisz widok\", aby rozpocząć."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Role"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Wymagana dodatkowa płatność"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Nie udało się zaktualizować zamówienia"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Z wybranymi..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Nie udało się utworzyć lokalizacji magazynowej"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "mniejsze lub równe"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Członkowie grupy klientów {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Stan"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Nie śledź"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Utworzono realizację #{0}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Uruchamianie oczekujących aktualizacji indeksu wyszukiwania"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "To jest domyślna rola i nie może być modyfikowana"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Moje zapisane widoki"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Stan / Województwo"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Włączono"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Pozycji na stronę"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Edytuj członków"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Stan magazynowy"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtruj według {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Alerty"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Wartości opcji"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Podgląd zmian"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Nie udało się usunąć {entityType} z kanału"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Pomyślnie usunięto wariant"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Edytuj właściwości wybranego łącza"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Sprzedaż"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Wybierz kolekcję docelową"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Twoje ostatnie zamówienia"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Zadania zaplanowane"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Czy na pewno chcesz usunąć tę pozycję? Ta akcja nie może być cofnięta."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Warianty"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Sprzedawcy"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Ustawienia"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Ustawienia sklepu"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Nagłówek 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Witamy w Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Metody wysyłki"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} do zwrotu)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identyfikator"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Nie udało się zaktualizować kolekcji"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Cena i podatek"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Nie znaleziono zamówienia"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Błąd"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Zmodyfikowano zamówienie"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Zażądano resetowania hasła"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Przydzielona kwota płatności musi być równa sumie zwrotu"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "np. Mały"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Czy na pewno chcesz usunąć {0} {entityType} z bieżącego kanału?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Dodaj tagi..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Nie udało się utworzyć grupy opcji produktu"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} wybranych elementów"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Szukaj języków..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Lokalizacje magazynowe"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Przejdź do poprzedniej strony"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Zawartość"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Nie udało się przekonwertować widoku globalnego na osobisty"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Wynik zadania"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Dodaj płatność ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Nazwa wariantu"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Usuń"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Nie udało się zaktualizować klienta"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Usunąć grupy opcji?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "To jest podgląd zawartości kolekcji oparty na bieżących ustawieniach filtrów. Po zapisaniu kolekcji zawartość zostanie zaktualizowana, aby odzwierciedlić nowe ustawienia filtrów."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {Usunięto {count} klienta z grupy} few {Usunięto {count} klientów z grupy} many {Usunięto {count} klientów z grupy} other {Usunięto {count} klientów z grupy}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Kategorie podatkowe"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Stawki podatkowe"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Nie udało się usunąć klientów z grupy"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Nie udało się załadować ustawień globalnych"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Wybierz pozycje do zwrotu i opcjonalnie zwróć na stan"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Zapisz"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "Zaznaczono {selectedRowCount} z {0} wierszy."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Podgląd modyfikacji zamówienia"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Pomyślnie zaktualizowano grupę opcji produktu"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Strona będzie kontynuowana z domyślnym zapytaniem."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Ulica"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Brak więcej faset"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Rozpoczęto przebudowę indeksu wyszukiwania"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Pozycja kolekcji zaktualizowana"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Nazwa grupy opcji"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Dodaj \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Nowy wariant produktu"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Przeniesiono zwrot"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Używanie natywnej strategii uwierzytelniania"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Nie udało się przypisać {entityIdsLength} {entityType} do kanału"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Domyślny język"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Realizowanie..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Dodaj grupę opcji do produktu"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Podgląd {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Pomyślnie zaktualizowano sprzedawcę"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Nie udało się przenieść zamówienia do stanu"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Pokaż wszystko ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Nie udało się utworzyć stawki podatkowej"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Zapisałem ten API key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Skonfiguruj dostępne języki dla swojego sklepu i kanałów"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Pomyślnie utworzono produkt"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Dodaj wariant produktu"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Wpisz i naciśnij Enter lub przecinek, aby dodać..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Edytuj notatkę"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Nie znaleziono zasobów. Spróbuj dostosować filtry."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Dodaj opcję"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Zapisz grupę opcji"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Utwórz {createCount} wariantów"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Kliknij „Uruchom test\", aby przetestować tę metodę wysyłki."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Pomyślnie zaktualizowano administratora"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Wyczyść filtry"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Realizacja #{0} z {1} do {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Nie udało się usunąć widoku globalnego"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Domyślny język"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Nie znaleziono opcji"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binarny"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Pomyślnie zaktualizowano grupę opcji"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Nowa metoda wysyłki"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Co 10 sekund"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "bez podatku:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Dodaj stan magazynowy do lokalizacji"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Pomyślnie dodano wartość opcji"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Kolekcja przeniesiona do nowego rodzica"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Usunięto grupę opcji"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Przejdź do wybranego stanu"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Wymagana będzie dodatkowa płatność w wysokości {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Domyślnie śledź stan magazynowy"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "Zaznaczono {selected} z {total}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Pomyślnie utworzono metodę wysyłki"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Nowa grupa klientów"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Widoczne dla klienta"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Pomyślnie utworzono grupę opcji"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Stawki podatkowe"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug zostanie wygenerowany automatycznie..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Nie znaleziono klienta"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Wybierz {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Nowe wartości aspektów do dodania:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Nie udało się przetworzyć zwrotu"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Imię"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "zawiera"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Nie znaleziono grup opcji"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Nie znaleziono pozycji"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Suma częściowa"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Zrealizowane pozycje ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Wartość zaktualizowana"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Niezweryfikowany"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Ilość"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Dodaj filtr"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Kategoria podatkowa"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Zaktualizowano dane testowe. Kliknij „Uruchom test\", aby zobaczyć zaktualizowane wyniki."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "nie jest w"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Zaktualizowano wiersz zamówienia"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Nowa metoda płatności"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Zduplikowana wartość \"{trimmed}\" już istnieje"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Przyczyna"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Grupy klientów"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "Pomyślnie usunięto {entityType} z kanału"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Grupy opcji"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Dodaj dopłatę"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Bieżące wartości aspektów"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Strona {page} z {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Ostatni miesiąc"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Dodaj kraj"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Usuń pozycję"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Wideo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "mniejsze niż"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Nie można dodać wariantu. Upewnij się, że produkt nadrzędny jest włączony."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Wystąpił nieznany błąd"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Metryki"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Język"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Nowa kolekcja"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Zwróć i anuluj zamówienie"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Zweryfikowano aktualizację e-maila"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "jest pomiędzy"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Zwróć i anuluj"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Testowanie metod wysyłki..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Nie udało się utworzyć metody wysyłki"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "Pomyślnie przypisano {entityIdsLength} {entityType} do kanału"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Języki globalne"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Nowy administrator"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Usuń wersję roboczą"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Źródło"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Brak dostępnych akcji"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Nie udało się zaktualizować kanału"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Ogólne"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Nie udało się usunąć produktu z kanału"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Dodaj nowy adres"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Pomyślnie zaktualizowano aspekt"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Pomyślnie utworzono strefę"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Wartość"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Zaktualizowano klienta"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Współczynnik przeliczania cen"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Zamówienie sprzedawcy"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Nowy aspekt"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Czy na pewno chcesz usunąć tę grupę opcji z produktu?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Opis (tekst alternatywny)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Nie znaleziono tagów"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Domyślna waluta"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Te zmiany nie wymagają płatności ani zwrotu."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Łączny przychód"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Następne wykonanie"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Notatka jest prywatna"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Data średnia"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Nieprawidłowa liczba"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Nie zapisałeś jeszcze żadnych widoków."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Czy na pewno chcesz usunąć ten widok? Ta akcja nie może być cofnięta."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Wyświetl proces zamówienia"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Nie udało się zduplikować widoku"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Użyj jako domyślny adres wysyłki"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Edytuj slug ręcznie"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Dodaj filtry, aby wyświetlić podgląd zawartości kolekcji."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Grupa opcji produktu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Suma częściowa"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "jest mniejsze niż"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID zwrotu"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Niestandardowe pola zamówienia zaktualizowane"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Kalkulator"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Nie udało się usunąć grupy opcji z kanału: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Zobacz dane zadania"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Przenieś na najwyższy poziom"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Wyczyść"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Podsumowanie zamówień"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Szukaj zasobów..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Nowy aspekt"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Przypisz {entityType} do kanału"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Kontynuuj"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promocje"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Komunikat błędu"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Dodaj poziom zapasów dla innej lokalizacji"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Usuń adres"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Nie udało się zaktualizować aspektu"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters musi być używane wewnątrz WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Edytuj adres"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Nie udało się usunąć aspektu z kanału: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Ustaw link"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Nowy sprzedawca"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Edytuj obraz"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Zarządzaj wariantami"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Przydzielono stan magazynowy"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "większe lub równe"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Ustawia poziom magazynowy, przy którym ten wariant jest uważany za niedostępny. Użycie wartości ujemnej umożliwia obsługę zamówień wstecznych."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Utwórz opcje produktu"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Zapisywanie..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Zobacz wynik"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Wierszy na stronę"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Ładowanie kolekcji..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Pomyślnie zaktualizowano wartość aspektu"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Dodaj zasób"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Zapisz zmiany"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Dodano klienta do grupy"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Zamówienia sprzedawcy"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Nie udało się dodać wartości opcji"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Dodaj wartość opcji do {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "Zwrócono {totalQuantity} pozycji"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Nie zdefiniowano jeszcze grup opcji. Dodaj grupy opcji, aby utworzyć różne warianty swojego produktu (np. Rozmiar, Kolor, Materiał)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Nowy e-mail:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Nie udało się zaktualizować metody płatności"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Dostępne:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Data utworzenia"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Nie udało się utworzyć wariantu produktu"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Język: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Nie masz uprawnień do wyświetlania globalnych ustawień języka"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Pomyślnie utworzono stawkę podatkową"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Nagłówek 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Dodano kody kuponów"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Aktywny"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Podstawa opodatkowania"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Załaduj więcej"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Rozliczono zwrot"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "Pomyślnie zduplikowano {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Nowa grupa opcji"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Brak wyniku"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Rozliczono płatność"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Dostępne warunki"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Aktywne filtry"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Wyczyść wszystko"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "jest większe niż"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Zamknij"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Dodaj płatność do zamówienia"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Ładowanie..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Token służy do określenia kanału podczas wykonywania żądań API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Nie znaleziono adresów"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID realizacji"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Wybierz płatności do zwrotu"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Nie udało się usunąć {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Próg braku w magazynie"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt został pomyślnie usunięty z kanału"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Nie udało się zaktualizować wartości"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Nie udało się utworzyć API key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Rozlicz zwrot"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Metoda płatności jest wymagana"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Nie udało się dodać klienta do grupy"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Zarządzaj wariantami"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Zastosowano widok globalny „{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Zarejestrowano klienta"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Strefy"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Szukaj sprzedawców..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Pomyślnie utworzono promocję"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Opcja"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Proces zamówienia"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Numer telefonu"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Prywatne"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Wariant"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Pomyślnie zaktualizowano ustawienia globalne"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "Pomyślnie zaktualizowano API key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Te języki będą dostępne dla wszystkich kanałów"

--- a/packages/dashboard/src/i18n/locales/pt_BR.po
+++ b/packages/dashboard/src/i18n/locales/pt_BR.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Nome completo"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Selecionar itens"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Ver alterações"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Código de rastreamento"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "As permissões selecionadas serão aplicadas a estes canais."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Opções de produto"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Nova alíquota fiscal"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Atribuir um grupo de opcoes existente ou criar um novo"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Nova função"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Apartamento, suíte, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Não há mais itens"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Editar link"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Adicione pelo menos um item ao pedido"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Adicione produtos para criar um pedido de teste"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Falha ao criar endereço"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Alternar todos"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Editar valor JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Usando estratégia de autenticação externa: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Selecione um motivo..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Título 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Falha ao adicionar pagamento"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Atualizado"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Falha ao atualizar configurações globais"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Pedido atendido com sucesso"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Tem certeza de que deseja excluir {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Limite global de fora de estoque"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Gerenciar idiomas"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Duplicando... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Excluído com sucesso"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Remover do canal atual"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} arquivos excluídos"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Alíquota fiscal atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Digite um motivo personalizado..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Tipo"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Selecionar {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Ver valores"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Excluir linha"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Condições"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Atual"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Nenhum atendimento"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Falha ao excluir {1} local de estoque: {messages}} other {Falha ao excluir {2} locais de estoque: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Quando isto estiver habilitado, os preços inseridos no catálogo de produtos incluirão o imposto para a zona fiscal padrão."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Crie variantes para seu produto"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Pedido rascunho concluído"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Atualização automática: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Verificações de saúde"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} excluído(s)"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Verificações de saúde"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Vendedores"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Opções"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} tarefa cancelada com sucesso} other {{fulfilled} tarefas canceladas com sucesso}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Vendedor"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Adicionar pagamento"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Teste este método de envio simulando um pedido para ver se é elegível e qual seria o custo de envio."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Explorar Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Locais de estoque"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Manipulador de atendimento"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Pedidos"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Selecionar funcoes"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Função criada com sucesso"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Tem certeza de que deseja excluir esta variante?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Todos os recursos estão operacionais"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Falha ao criar administrador"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Nao"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Variante de produto atualizada com sucesso"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Falha ao excluir {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Produto atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Falha ao atualizar país"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Digite pelo menos 2 caracteres para pesquisar..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Sobrenome"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Título do link"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Grupo de clientes atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Campos personalizados alterados"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Local de estoque criado com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Erro desconhecido"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "O total do reembolso não pode ser negativo"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Ver detalhes"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Selecione um canal para atribuir {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Cliente criado com sucesso"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Últimos 7 dias"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Falha ao criar canal"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Modo de desenvolvedor"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Nova função"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Falha ao excluir arquivos: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Devolver ao estoque"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Visibilidade"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Variantes do produto"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Novo grupo de clientes"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Criar \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Renomear"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Escolha seu idioma de exibicao e configuracoes de localidade preferidos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} grupos de opcoes removidos do canal com sucesso"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Método de envio não é elegível para este pedido"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Falha ao atualizar endereço"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Endereço excluído com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Alíquota fiscal"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "O rascunho do pedido não está pronto para ser concluído"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Nova coleção"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Insights"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Executar"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Falha ao atualizar alíquota fiscal"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Este é o conteúdo da coleção <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privado"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Opção de produto criada com sucesso"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Produto principal"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Cidade"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administradores"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Preço bruto: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Ir para a próxima página"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Remover link"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Este campo e somente leitura"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Quantidade de pedidos"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Pedido atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Herdar filtros"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Gerenciar visões salvas globais visíveis para todos os usuários"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Pesquisar métodos de pagamento..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Endereço de entrega removido para o pedido"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Criar {enabledCount} variantes"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Pagamento #{0} transitado para {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Erro ao carregar histórico do cliente: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} removido(s) do canal com sucesso"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Adicionar valor de opção"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Configurações globais"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "é depois de"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Opção de produto atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Editar valores de faceta"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Adicionando..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Mover coleções"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Funções"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Visualizacao em grade"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Falha ao excluir endereço"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Nenhum método de envio disponível"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Visão global convertida em visão pessoal com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Atendimento transitado"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Tem certeza de que deseja excluir {selectionLength} arquivos?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Entrar"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Visualizacao em lista"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Pedido de teste"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Selecione um cliente para continuar"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Grupo de opcoes atribuido com sucesso"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Executar teste"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Alíquota fiscal: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Adicione produtos e complete o endereço de entrega para executar o teste."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Alternar linha de cabeçalho"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Selecionar endereço"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Verificador de elegibilidade de pagamento"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Zona fiscal padrão"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "O rascunho do pedido está pronto para ser concluído"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadados"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrar..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Novo valor de faceta"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Canal atualizado com sucesso"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Mostrar menos"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Data curta"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Moedas disponíveis"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Selecionar {0} itens"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Realizado em"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "A rotacao desta chave invalidara imediatamente a chave atual. Quaisquer integracoes que a utilizam deixarao de funcionar ate serem atualizadas com a nova chave."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Os dados que foram passados para a tarefa"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Confirmar navegação"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Destino do link"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Concluir rascunho"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Nome"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Falha ao atender pedido"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Total"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Insira o ID da transação para esta liquidação de reembolso"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Sua API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Tem certeza de que deseja excluir este rascunho de pedido?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Atendimento criado"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Encontrado(s) {0} método(s) de envio elegível(eis)"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Dimensoes"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Mostrar senha"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(máx: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Empresa"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Adicionar coluna depois"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Ações"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Descontos"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Insira nota de reembolso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Linha de pedido removida"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Conteúdo:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Chave"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Confirmar"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Falha ao criar coleção"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Ir para a primeira página"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Falha ao criar produto"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Cliente"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Erro ao carregar histórico de pedidos: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Endereço de entrega definido para o pedido"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Ponto focal"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Variante unica, sem opcoes"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Selecione o próximo estado para o pedido"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Localidade"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Tarefas agendadas"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Insira ID da transação"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Atualizar dados"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Adicionar ou remover valores de faceta para {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Estes são os valores de faceta para a faceta <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Pagamento adicionado ao pedido com sucesso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Endereço de cobrança definido para o pedido"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Falha ao atualizar zona"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Senha"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Falha ao excluir"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Tarefa agendada será executada"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Novo local de estoque"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Permissões"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Endereço de entrega alterado"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Nenhum produto encontrado"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Adicionar linha antes"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Transicionar para {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Este mês"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Falha ao criar faceta"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Falha ao cancelar itens do pedido"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID da transação"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Alocado"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Adicionar outro grupo de opções"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Selecione o que fazer com o estoque restante"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Explorar Plataforma e Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "A cada 5 segundos"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Coleção criada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Preço"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Pedido rascunho"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Escopo"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Adicionar condição"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Método de envio é elegível para este pedido"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administradores"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Removido do grupo"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Largura"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Nenhum pagamento ou reembolso necessário"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Baixar como arquivo .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Quando habilitada, uma promoção fica disponível na loja"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Quando rastreado, os níveis de estoque das variantes de produto serão ajustados automaticamente quando vendidos. Esta configuração pode ser substituída por variantes de produto individuais."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Método de entrega definido para o pedido"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Falha ao atualizar promoção"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Imagens"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Pesquisar {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Editar arquivo"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Cancelar pagamento"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Fila de trabalhos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Recursos"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Endereço de e-mail"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Regenerar slug do campo de origem"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Herdar das configurações globais"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Status atual"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Defina um endereço de entrega e selecione um método de envio"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Desligado"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Loja de Configuracoes"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Fila"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Nova alíquota fiscal"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Pagamento transitado"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Restante:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Nenhum duplicador encontrado com código \"{duplicatorCode}\" para {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Preços incluem imposto para zona fiscal padrão"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Reembolso total:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Ver resultado da tarefa"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Teste seus métodos de envio simulando um novo pedido."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Nenhum item selecionado"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} selecionado(s)"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Nenhum país encontrado"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Variantes criadas com sucesso"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Gerar slug automaticamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Sobretaxa"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Métodos de pagamento"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Estoque"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Nenhum cliente encontrado"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Usar limite global de fora de estoque"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Novo grupo de opções de produto"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Estado de pagamento atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Criar novo"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Total do reembolso"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Endereço excluído"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Somente funcoes atribuidas a sua conta estao disponiveis."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Item adicionado ao pedido"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Editar ponto focal"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Nenhum vendedor encontrado"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Recurso"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Este grupo de opcoes e utilizado por outro produto. As alteracoes tambem o afetarao.} other {Este grupo de opcoes e compartilhado entre # produtos. As alteracoes afetarao todos eles.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Minhas visões salvas"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Novo canal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Falha ao criar vendedor"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Configurar opcoes de duplicacao para {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Nenhuma variante corresponde ao filtro atual."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Endereços"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Adicionar um novo valor de opcao ao grupo de opcoes {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Modificação de pedido #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Adicionar coluna antes"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Idiomas do canal"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Falha ao criar grupo de opções"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Verdadeiro"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Selecionar cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Pedido transitado"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Este produto possui variantes existentes, mas nenhum grupo de opções definido. Você precisa adicionar grupos de opções antes de criar novas variantes."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "é antes de"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Excluir pedido rascunho"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Catálogo"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Novo método de pagamento"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promoção atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Falha ao cancelar {rejected} tarefa} other {Falha ao cancelar {rejected} tarefas}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Selecione um canal"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Idioma de exibição"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Detalhes do atendimento"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Descartar o estoque restante"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Agora"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Canais"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Visão convertida em global com sucesso"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "antes"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Tamanho"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Nenhuma tradução encontrada para {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Novo cliente"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Últimos pedidos"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} mais"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Usar como endereço de cobrança padrão"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Excluir"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Desabilitar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Coleções"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Adicionar variante"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Falha ao criar país"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Países"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Falha ao criar opções de produto"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Falha ao renomear visão"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Disponível"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtros"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Grupos de clientes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Clientes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Formatação de exemplo"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nova opção"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Limite de uso"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Carregando configurações globais..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Endereço atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Criado"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Carregando endereços..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Selecione uma coleção de destino para mover {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Detalhes do cliente atualizados"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "não em"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Aplicar"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nova opção de produto"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Ir para a última página"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Variante de produto criada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Reembolso deste método"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "CEP"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Adicione opções de produto primeiro"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Nova categoria fiscal"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Adicionar opção"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Reembolso parcial concluído"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Definir campos personalizados"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Coleções"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Excluir variante"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Nenhuma modificação feita"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Zona de envio padrão"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Motivo:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Endereço de entrega"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Transicionar para {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Categorias de impostos"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Coleções privadas não são visíveis na loja"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Quando habilitado, um produto fica disponível na loja"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Tarefa agendada não pôde ser executada"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Grupos de clientes"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Desabilitado"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Nova promoção"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Endereço de entrega padrão"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Reembolso necessário"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Atender pedido"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Você não tem permissão para visualizar configurações do canal"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Últimos 30 dias"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Nenhum valor de faceta"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Um motivo para o reembolso é obrigatório"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Nao foi possivel remover o grupo de opcoes"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Falha ao atualizar categoria fiscal"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Reembolso liquidado com sucesso"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Atualizar"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Título 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Pedido realizado"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Perfil atualizado com sucesso"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "fim"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Método de pagamento"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Editar"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variante atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtrar por nome de coleção"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Nota adicionada"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Selecione quantidades a atender e configure o manipulador de atendimento"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Endereço de cobrança removido do pedido"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Começa em"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Nenhum resultado"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Configurações de coluna"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Falha ao excluir {count} local de estoque} other {Falha ao excluir {count} locais de estoque}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Código"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Falha ao remover grupos de opcoes"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Pedido entregue"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Transferir para {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Estoque restante"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Remover da zona"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Selecione entre os idiomas disponíveis globalmente para este canal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Tem certeza de que deseja excluir este endereço?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Falha ao atribuir grupo de opcoes"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Falha ao atualizar arquivo"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Local de estoque atualizado com sucesso"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Confirmar ação"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "País atualizado com sucesso"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Facetas"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Falha ao adicionar nota"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Falha ao excluir nota"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Falha ao estender documento de consulta"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Falha ao atualizar nota"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Reembolsar frete"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Somente leitura"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Falha ao duplicar visão global"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Mostrando {shown} de {total} • {selected} selecionadas"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Testar método de envio"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Valores de faceta"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Arquivo atualizado com sucesso"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Tema"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} clientes"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Selecione um idioma"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Sair"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Tentativas"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Códigos de moedas disponíveis"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Códigos de idiomas disponíveis"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Breadcrumbs"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Categoria"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Canais"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Filhos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Código"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Código do cupom"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Criado em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Código da moeda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Grupo de clientes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Clientes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Campos personalizados"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Dados"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Código da moeda padrão"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Código de idioma padrão"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Zona de envio padrão"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Zona fiscal padrão"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Descrição"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Duração"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Endereço de e-mail"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Habilitado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Termina em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Erro"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Arquivo em destaque"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Nome"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Código do manipulador de atendimento"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "É padrão"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "É privado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Está liquidado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Sobrenome"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Nome"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Pedido realizado em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID pai"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Limite de uso por cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Permissões"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Posição"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Preço"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Preços incluem impostos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Preço com imposto"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Variantes de produtos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Progresso"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Nome da fila"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Resultado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Tentativas"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Vendedor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Liquidado em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Linhas de envio"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Iniciado em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Começa em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Estado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Níveis de estoque"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Total"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Total com imposto"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Tipo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Atualizado em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Limite de uso"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Usuário"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Valor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Lista de valores"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zona"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Método"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Resumo fiscal"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Define os idiomas disponíveis para todos os canais. Canais individuais podem então suportar um subconjunto desses idiomas."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Coleções movidas com sucesso"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registrado"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Cancelar tarefa"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Termina em"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Página {0} de {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Taxa"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Tamanho, cor, etc."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Navegar por facetas"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Cancelado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Criado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Entregue"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Pendente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Enviado"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Salvar visualização"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} selecionados"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Pesquisar grupos de opcoes..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Modificar pedido"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Itens selecionados"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Valores"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Cliente definido para o pedido"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Facetas"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Tem certeza de que deseja remover {count} cliente deste grupo?} other {Tem certeza de que deseja remover {count} clientes deste grupo?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Estoque disponível"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Reconstrução do índice de pesquisa não pôde ser iniciada"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Endereço de entrega"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Nova zona"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Nova API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Excluir coluna"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Atribuir existente"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "é nulo"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Estes são os clientes do grupo de clientes <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Gerenciar visões globais"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Canal padrão"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Inserir uma nova imagem com origem, titulo e dimensoes"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Falha ao criar valor de faceta"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Falha ao atualizar opção de produto"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Esqueceu a senha?</0><1>Solicitar redefinição</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Código de cupom"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Cliente verificado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Configurações globais"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Agendamento"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Não é possível mover uma coleção para seu próprio descendente"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Nova categoria fiscal"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Nenhum local de estoque disponível no canal atual"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Canal criado com sucesso"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Cliente atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Ver dados"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Excluir visão"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Adicionar um novo endereço ao cliente."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Mais visões"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Editar as propriedades da imagem selecionada"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Visualização „{viewName}\" aplicada"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} facetas removidas do canal com sucesso"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Novo produto"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Novo arquivo"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Recalcular frete"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Selecione quais opções devem ser aplicadas à variante existente \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Recursos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Isso removera todos os grupos de opcoes deste produto e retornara a escolha de configuracao de variantes."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Endereço de cobrança"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Adicionar valor de faceta"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Selecione uma coleção de destino"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Revise as alterações antes de aplicá-las ao pedido."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Selecione uma função"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Pedido cancelado"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Desconto"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Todos os tipos"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Somente rascunhos de pedidos podem ser concluídos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Falha ao atualizar produto"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Ajustando {0} linhas"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Adicionar valores de faceta"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "depois"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Canal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Verificações de saúde"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Valor"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Número de telefone"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Novo cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Imagem"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administrador criado com sucesso"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Opções de produto"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Selecionar país"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Criando..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Tem certeza de que deseja excluir esta visão global? Esta ação não pode ser desfeita e afetará todos os usuários."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Forçar remoção do grupo de opções"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Adicionado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Histórico do cliente"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Valores de faceta atualizados com sucesso para {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Falha ao remover cliente do grupo"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Sistema"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Limite de uso por cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Endereço de cobrança alterado"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Selecione uma opção"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Copiar para pessoal"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "O total do reembolso excede o valor máximo reembolsável de {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Excluir visão global"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Criar"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "A cada 30 segundos"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Novo país"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "De {0} a {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Falha ao criar cliente"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Ponto focal atualizado"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Valores de opção"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Endereço de cobrança padrão"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Nenhum cliente"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Falha ao remover países da zona"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Falha ao criar promoção"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Hoje"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Ontem"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Nome da opção"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Tem certeza de que deseja remover {0} {1} desta zona?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Adicionando {0} sobretaxa(s)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Link href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Fallback: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Histórico de pedidos"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Substituir"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "ID da transação é obrigatório"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "corresponde a regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Visão global renomeada com sucesso"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Nenhuma tag selecionada"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Voltar"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Visão renomeada com sucesso"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Aplicar filtro"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Último resultado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Adicionado ao grupo"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Insights"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Criar variantes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Testando método de envio..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Escuro"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Resultados do teste"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Adicionar cliente"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Salvar alterações"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Endereço atualizado"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Reembolso processado com sucesso"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Nova zona"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Falha ao atualizar posição da coleção"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Reembolso"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Modificar"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Nenhum idioma global configurado"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Removendo {0} item(ns)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Rastrear"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Criar variante"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Valores de faceta para {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Salvar layout"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Redefinição de senha verificada"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Falha ao excluir visão"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Tem certeza de que deseja sair desta página? Quaisquer alterações não salvas serão perdidas."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Alternar coluna de cabeçalho"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Nova promoção"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Nome do valor da opção"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Ultimo uso"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "É categoria fiscal padrão"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug está definido"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Falha ao atualizar o ponto focal"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zona atualizada com sucesso"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Estado/Província"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Falha ao atualizar grupo de opcoes"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Padrões do canal"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Falha ao criar categoria fiscal"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Definir criterios de filtro para a coluna {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "País"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Produto simples"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Fila de trabalhos"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Por favor, confirme que salvou a API Key antes de fechar."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Confirmar exclusão"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Falha ao modificar pedido"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Inclui imposto de {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Métricas de pedidos"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Selecionar idioma de exibição"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Métodos de autenticação"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "início"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Falha ao rotacionar a API Key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "em"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Pesquisar funções..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Variantes de produto"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Gerenciar visões globais"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Processando..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} encontrado(s)"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Selecionar período"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Produto"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rotacionar API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Categoria"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Movendo..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Atribuir"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Vendedor criado com sucesso"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Método de envio atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Falha ao atualizar variante de produto"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Arraste para reordenar"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zonas"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Escolha o que fazer com o estoque restante {count, plural, one {no # local de estoque} other {nos # locais de estoque}} que você está excluindo. Todos os locais selecionados transferem o estoque restante para o único local que você escolher, ou o descartam."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Pesquisar valores de facetas..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Nota"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Idiomas disponíveis"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Carregar mais {0} ({remaining} restantes)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Valores de faceta"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Falha ao reordenar itens"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Total de pedidos"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Nenhum método de envio elegível encontrado para este pedido."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Adicionar opção de produto"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Envio"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions deve ser usado dentro de um DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Este grupo de opções está em uso por variantes existentes. Forçar a remoção pode afetar essas variantes. Tem certeza?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Atualização de e-mail solicitada"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Erro ao fazer transição para estado"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Grupo de clientes criado com sucesso"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nova janela"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Pagamento autorizado"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Função atualizada com sucesso"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Selecione um país"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Falha ao atualizar método de envio"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} local de estoque excluído} other {{deleted} locais de estoque excluídos}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Métodos de envio"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Selecione um endereço"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Sim"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Definir ponto focal"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "fim"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Selecione uma moeda"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Atualizar conteúdo ou visibilidade da nota"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget de últimos pedidos"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Conteúdo da coleção {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Método de envio alterado"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Descrição do imposto"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "é menor ou igual a"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "não é igual a"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Atualizar"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "ex. Tamanho"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Liquidar pagamento"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Canais"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Frete reembolsado"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Tipo de recurso"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Novo local de estoque"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} pagamento(s) reembolsado(s) antes da falha. Verifique o histórico do pedido para detalhes."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Selecionar item"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Novo produto"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gerenciar tags"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Itens reembolsados"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Adicionar ação"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Atribuir opções à variante existente"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Duplicar {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Remover do grupo"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Falha ao atualizar estado de atendimento"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Criar uma nova variante de produto com opcoes, precos e estoque"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Facetas privadas não são visíveis na loja"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Selecione uma categoria fiscal"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Criado"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Não em execução"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Atribuido"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Título 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Selecionar idiomas disponíveis"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Adicionando {0} item(ns)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Adicionar linha depois"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Total de impostos"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Status do rascunho do pedido"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Opções de produto criadas com sucesso"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Carregando locais…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Falha ao criar método de pagamento"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Valor de faceta criado com sucesso"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Pedido rascunho excluído"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "maior que"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Widget de métricas"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Pesquisar moedas..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Remover do canal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Título"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Inserir imagem"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Falha ao atualizar vendedor"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "País criado com sucesso"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Selecionar vendedor"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Carregando tags..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Faceta criada com sucesso"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} variantes"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Falha ao liquidar pagamento"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Nenhum endereço de cobrança"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Falha ao excluir {1} local de estoque} other {Falha ao excluir {2} locais de estoque}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Faceta"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Não é possível remover do canal ativo"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Não definido"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Forçar remoção"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Novo canal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Nome do grupo de opções"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "E"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Falha ao criar grupo de clientes"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Falha ao criar função"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Nome do produto"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Estado de atendimento atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Produtos"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Endereço criado"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key rotacionada com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Adicionar grupo de opções"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Reembolsar {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Insira slug manualmente"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Nenhum widget disponível"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Falha ao cancelar pagamento"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Pagamento cancelado com sucesso"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Visão global duplicada com sucesso"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Criado por"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtrar variantes..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Adicionar um preço em outra moeda"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Endereço de e-mail ou identificador"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Reembolso #{0} transitado para {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Clientes"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Título 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Falha ao atualizar local de estoque"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Pedido enviado"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Salvar endereço"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Tornar global"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Selecionar próximo estado"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Sem alertas"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Movendo {0} coleção(ões) para {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Teste"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "entre"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Nota adicionada com sucesso"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Nota excluída com sucesso"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Nota atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Falha ao liquidar reembolso"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Nível de estoque"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Adicionar item"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key criada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Carregando visualização..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Voltar à pesquisa"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Visão duplicada com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Remover grupo de opções"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Descrição"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Países"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Complemento"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Visão global excluída com sucesso"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Editar layout"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Atribuir ao canal"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Esta semana"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Grupo de opções de produto criado com sucesso"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Adicionar um pagamento manual de {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "está em"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-mail"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Falha ao atualizar administrador"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Gerenciar suas visões salvas pessoais para esta tabela"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtrar por tags"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Entre para acessar o painel administrativo"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Adicionar pagamento ao pedido ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Falso"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Claro"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Redefinir"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "é igual a"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Criar opções"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Senha atualizada"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "não contém"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Grupo de Opcoes"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Edite os detalhes do endereço abaixo."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Categoria fiscal criada com sucesso"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Falha ao mover coleções"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Falha ao atualizar estado de pagamento"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Resumo dos seus pedidos"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Enviar"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Produto com opcoes"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Mostrando todos os {0} resultados"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "ID de Consulta"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} mais"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Grupos de Opcoes"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Campos personalizados"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Todos os estados possiveis do pedido e suas transicoes. O estado atual esta destacado."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Pedidos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget de resumo de pedidos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Adicionando itens"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Organizando pagamento adicional"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Organizando pagamento"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Cancelado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Criado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Entregue"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Rascunho"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Modificando"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Parcialmente entregue"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Parcialmente enviado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Pagamento autorizado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Pagamento liquidado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Enviado"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Recursos monitorados"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Informações da entidade"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Total do pedido"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Visível apenas para administradores"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Qtd"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Tags"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super administrador"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Alguns recursos estão inativos"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Ações disponíveis"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Inserir link"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Se habilitado, os filtros serão herdados da coleção pai e combinados com os filtros definidos nesta coleção."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Selecione uma zona"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Testar métodos de envio"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Pagamento liquidado com sucesso"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} removidos da zona"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Habilitar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Métodos de pagamento"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autorizado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Cancelado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Criado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Recusado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Erro"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Falhado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Pendente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Liquidado"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Valor médio do pedido"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Falha ao criar zona"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Níveis de estoque"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Falha ao atualizar a API Key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Linhas de pedido"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Falha ao renomear visão global"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Inserir um novo hiperlink com URL e opcoes de destino"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Altura"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Um reembolso de {formattedDiff} é necessário. Selecione os valores de pagamento e insira uma nota para prosseguir."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Preço unitário"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Padrão de agendamento"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Pagamento falhou"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Adicionar canal"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Falha ao atualizar grupo de opções de produto"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Pesquisar canais..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Adicionar grupos de clientes"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Idiomas disponíveis"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Redefinir selecao"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Nenhum endereço"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Método de pagamento criado com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Informações do cliente atualizadas"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Falha ao converter visão em global"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Variantes de produto"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Produtos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promoções"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Falha ao criar opção de produto"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "E-mail antigo:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Salve uma visão como \"Global\" para disponibilizá-la a todos os usuários."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Falha ao criar variantes"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Define o nível de estoque no qual esta variante é considerada fora de estoque. Usar um valor negativo habilita suporte a pedidos em atraso. Pode ser substituído por variantes de produto."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rotacionar Chave"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Falha ao criar variantes do produto"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Ocultar senha"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Novo vendedor"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "ex. Vermelho, Grande, Algodão"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Falha ao atualizar perfil"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Códigos de cupom removidos"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Limpar filtro"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regiões"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Solte os arquivos aqui para enviar"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Alternar todas as variantes visíveis"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verificado"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Novo grupo de opcoes"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Última atualização {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Nenhuma visão global foi criada ainda."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Falha ao atualizar função"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Esta e a unica vez que a API Key completa sera exibida. Copie ou baixe agora — ela nao podera ser recuperada posteriormente."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Coleção atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Método de pagamento atualizado com sucesso"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Visão excluída com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Grupo de opções {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "OU"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Gerenciar tags"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Código do cupom removido do pedido"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Nunca"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Falha ao atualizar valor de faceta"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Remover grupo"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Pedido atendido"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Nenhum endereço de entrega"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "A extensão de consulta contém sintaxe GraphQL inválida"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Erro de extensão de consulta"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Erro de extensão de consulta: "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "A extensão de consulta é inválida: deve ter pelo menos um campo de nível superior"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Incompatibilidade de extensão de consulta: "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "público"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Categoria fiscal atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Mover"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Editar ou excluir tags existentes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "As condições do verificador de elegibilidade deste método de envio não são atendidas para o pedido atual e endereço de entrega."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Adicionar código de cupom"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Código do cupom definido para o pedido"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Campos personalizados"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Novo método de envio"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Excluir locais de estoque"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "é maior ou igual a"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Visualização"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} de {1} disponíveis para atender"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Mês até a data"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Solicitação do cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Danificado no envio"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Não disponível"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Outro"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Item errado"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Resumo das modificações"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Reembolsos ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Última execução"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Detalhes do pagamento"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Reconstruir índice de pesquisa"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Em execução"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "A cada 60 segundos"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Falha ao atualizar grupo de clientes"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Metadados do pagamento"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Cancelar modificação"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Mesma janela"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Aplique filtros à tabela e clique em \"Salvar visão\" para começar."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Funções"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Pagamento adicional necessário"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Falha ao atualizar pedido"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Com selecionados..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Falha ao criar local de estoque"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "menor ou igual a"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Membros do grupo de clientes {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Estado"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Não rastrear"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Atendimento #{0} criado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Executando atualizações pendentes do índice de pesquisa"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Esta é uma função padrão e não pode ser modificada"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Minhas visões salvas"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Estado / Província"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Itens por pagina"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Editar membros"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Estoque disponível"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtrar por {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Alertas"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Valores de opção"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Visualizar alterações"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Falha ao remover {entityType} do canal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variante excluída com sucesso"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Editar as propriedades do link selecionado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Vendas"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Selecione uma coleção de destino"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Seus últimos pedidos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Tarefas agendadas"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Tem certeza de que deseja excluir este item? Esta ação não pode ser desfeita."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Variantes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Vendedores"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Configurações"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Loja de Configuracoes"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Título 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Bem-vindo ao Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Métodos de envio"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} reembolsável)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identificador"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Falha ao atualizar coleção"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Preço e imposto"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Pedido não encontrado"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Erro"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Pedido modificado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Redefinição de senha solicitada"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "O valor do pagamento alocado deve ser igual ao total do reembolso"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "ex. Pequeno"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Tem certeza de que deseja remover {0} {entityType} do canal atual?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Adicionar tags..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Falha ao criar grupo de opções de produto"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} itens selecionados"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Pesquisar idiomas..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Locais de estoque"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Ir para a página anterior"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Conteúdo"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Falha ao converter visão global em visão pessoal"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "O resultado da tarefa"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Adicionar pagamento ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Sistema"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Nome da variante"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Remover"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Falha ao atualizar cliente"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Remover grupos de opcoes?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Esta é uma visualização do conteúdo da coleção com base nas configurações de filtro atuais. Depois de salvar a coleção, o conteúdo será atualizado para refletir as novas configurações de filtro."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} cliente removido do grupo} other {{count} clientes removidos do grupo}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Categorias de impostos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Taxas de impostos"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Falha ao remover clientes do grupo"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Falha ao carregar configurações globais"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Selecione itens para reembolso e opcionalmente devolva ao estoque"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Salvar"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} de {0} linha(s) selecionada(s)."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Visualizar modificações do pedido"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Grupo de opções de produto atualizado com sucesso"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "A página continuará com a consulta padrão."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Endereço"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Não há mais facetas"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Reconstrução do índice de pesquisa iniciada"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Posição da coleção atualizada"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Nome do grupo de opções"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Adicionar \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Nova variante de produto"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Reembolso transitado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Usando estratégia de autenticação nativa"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Falha ao atribuir {entityIdsLength} {entityType} ao canal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Idioma padrão"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Atendendo..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Adicionar grupo de opções ao produto"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Visualização de {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Vendedor atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Falha ao fazer transição do pedido para estado"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Mostrar tudo ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Falha ao criar alíquota fiscal"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Eu salvei esta API Key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Configure os idiomas disponíveis para sua loja e canais"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Produto criado com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Adicionar variante de produto"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Digite e pressione Enter ou vírgula para adicionar..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Editar nota"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Nenhum recurso encontrado. Tente ajustar seus filtros."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Adicionar opção"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Salvar grupo de opções"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Criar {createCount} variantes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Clique em \"Executar teste\" para testar este método de envio."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administrador atualizado com sucesso"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Limpar filtros"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Atendimento #{0} de {1} para {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Falha ao excluir visão global"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Idioma padrão"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Nenhuma opção encontrada"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binario"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Grupo de opcoes atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Novo método de envio"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "A cada 10 segundos"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "sem imposto:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Adicionar estoque ao local"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Valor de opção adicionado com sucesso"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Coleção movida para novo pai"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Grupo de opções removido"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Transicionar para estado selecionado"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Um pagamento adicional de {formattedDiff} será necessário."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Rastrear estoque por padrão"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} de {total} selecionadas"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Método de envio criado com sucesso"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Novo grupo de clientes"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Visível para o cliente"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Grupo de opções criado com sucesso"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Taxas de impostos"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug será gerado automaticamente..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Cliente não encontrado"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Selecionar {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Novos valores de faceta a adicionar:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Falha ao processar reembolso"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Nome"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "contém"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Nenhum grupo de opcoes encontrado"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Nenhum item encontrado"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Subtotal"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Itens atendidos ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Valor atualizado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Não verificado"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Quantidade"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Adicionar filtro"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Categoria fiscal"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Perfil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Dados de teste foram atualizados. Clique em \"Executar teste\" para ver resultados atualizados."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "não está em"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Linha de pedido atualizada"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Novo método de pagamento"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "O valor duplicado \"{trimmed}\" já existe"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Motivo"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Grupos de clientes"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} removido(a) do canal com sucesso"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Grupos de opções"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Adicionar sobretaxa"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Valores de faceta atuais"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Pagina {page} de {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Mês passado"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Adicionar país"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Remover item"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "menor que"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "A variante não pôde ser adicionada. Certifique-se de que o produto principal esteja habilitado."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Ocorreu um erro desconhecido"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Métricas"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Idioma"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Nova coleção"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Reembolsar e cancelar pedido"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Atualização de e-mail verificada"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "está entre"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Reembolsar e cancelar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Testando métodos de envio..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Falha ao criar método de envio"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} atribuído(s) ao canal com sucesso"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Idiomas globais"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Novo administrador"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Excluir rascunho"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Origem"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Nenhuma ação disponível"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Falha ao atualizar canal"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Geral"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Falha ao remover produto do canal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Adicionar novo endereço"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Faceta atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zona criada com sucesso"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Valor"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Cliente atualizado"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Fator de conversão de preço"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Pedido do vendedor"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Nova faceta"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Tem certeza de que deseja remover este grupo de opções do produto?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Descrição (texto alternativo)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Nenhuma tag encontrada"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Moeda padrão"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Nenhum pagamento ou reembolso é necessário para estas alterações."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Receita total"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Próxima execução"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Nota é privada"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Data média"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Numero invalido"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Você ainda não salvou nenhuma visão."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Tem certeza de que deseja excluir esta visão? Esta ação não pode ser desfeita."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Ver processo do pedido"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Falha ao duplicar visão"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Usar como endereço de entrega padrão"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Editar slug manualmente"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Adicione filtros para visualizar o conteúdo da coleção."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Grupo de opções de produto"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "é menor que"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID de reembolso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Campos personalizados do pedido atualizados"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Calculadora"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Falha ao remover grupo de opcoes do canal: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Ver dados da tarefa"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Mover para o nível superior"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Limpar"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Resumo de pedidos"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Pesquisar recursos..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Nova faceta"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Atribuir {entityType} ao canal"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Continuar"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promoções"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Mensagem de erro"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Adicionar nível de estoque para outro local"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Excluir endereço"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Falha ao atualizar faceta"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters deve ser usado dentro de um WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Editar endereço"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Falha ao remover faceta do canal: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Definir link"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Novo vendedor"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Editar imagem"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Gerenciar variantes"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Estoque alocado"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "maior ou igual a"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Define o nível de estoque no qual esta variante é considerada fora de estoque. Usar um valor negativo habilita suporte a pedidos em atraso."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Criar opções de produto"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Salvando..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Ver resultado"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Linhas por página"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Carregando coleções..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Valor de faceta atualizado com sucesso"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Adicionar arquivo"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Salvar alterações"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Cliente adicionado ao grupo"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Pedidos do vendedor"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Falha ao adicionar valor de opção"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Adicionar valor de opção a {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} item(ns) reembolsado(s)"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Nenhum grupo de opções definido ainda. Adicione grupos de opções para criar diferentes variantes do seu produto (ex. Tamanho, Cor, Material)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Novo e-mail:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Falha ao atualizar método de pagamento"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Disponível:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Criado em"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Falha ao criar variante de produto"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Idioma: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Você não tem permissão para visualizar configurações de idioma global"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Alíquota fiscal criada com sucesso"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Título 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Códigos de cupom adicionados"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Ativo"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Base fiscal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Carregar mais"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Reembolso liquidado"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} duplicado(s) com sucesso"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Novo Grupo de Opcoes"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Nenhum resultado ainda"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Pagamento liquidado"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Condições disponíveis"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Filtros ativos"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Limpar tudo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "é maior que"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Fechar"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Adicionar pagamento ao pedido"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Carregando..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "O token é usado para especificar o canal ao fazer solicitações de API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Nenhum endereço encontrado"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID de atendimento"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Selecione pagamentos para reembolso"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Falha ao excluir {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Limite de fora de estoque"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produto removido do canal com sucesso"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Falha ao atualizar valor"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Falha ao criar API Key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Liquidar reembolso"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Método de pagamento é obrigatório"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Falha ao adicionar cliente ao grupo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Gerenciar variantes"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Visualização global „{viewName}\" aplicada"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Cliente registrado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zonas"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Pesquisar vendedores..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Promoção criada com sucesso"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Opção"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Processo do pedido"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Número de telefone"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privado"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variante"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Configurações globais atualizadas com sucesso"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key atualizada com sucesso"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Estes idiomas estarão disponíveis para todos os canais usarem"

--- a/packages/dashboard/src/i18n/locales/pt_PT.po
+++ b/packages/dashboard/src/i18n/locales/pt_PT.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Nome completo"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Selecionar itens"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Ver alterações"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Código de rastreamento"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "As permissões selecionadas serão aplicadas a estes canais."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Opções de produto"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Nova taxa fiscal"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Atribuir um grupo de opcoes existente ou criar um novo"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Nova função"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Apartamento, suite, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Não há mais itens"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Editar ligação"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Adicione pelo menos um artigo à encomenda"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Adicione produtos para criar uma encomenda de teste"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Falha ao criar morada"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Alternar todos"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Editar valor JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "A usar estratégia de autenticação externa: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Selecione um motivo..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Título 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Falha ao adicionar pagamento"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Atualizado"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Falha ao atualizar definições globais"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Encomenda atendida com sucesso"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Tem a certeza de que deseja eliminar {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Limite global de esgotado"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Gerir idiomas"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "A duplicar... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Eliminado com sucesso"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Remover do canal atual"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} recursos eliminados"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Taxa fiscal atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Introduza um motivo personalizado..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Tipo"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Selecionar {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Ver valores"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Eliminar linha"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Condições"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Atual"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Nenhum atendimento"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Falha ao eliminar {1} localização de stock: {messages}} other {Falha ao eliminar {2} localizações de stock: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Quando isto estiver ativado, os preços introduzidos no catálogo de produtos incluirão o IVA para a zona fiscal predefinida."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Crie variantes para o seu produto"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Encomenda rascunho concluída"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Atualização automática: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Verificações de saúde"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} eliminado(s)"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Verificações de saúde"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Vendedores"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Opções"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} tarefa cancelada com sucesso} other {{fulfilled} tarefas canceladas com sucesso}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Vendedor"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Adicionar pagamento"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Teste este método de envio simulando uma encomenda para ver se é elegível e qual seria o custo de envio."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Explorar Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Localizações de stock"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Manipulador de atendimento"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Encomendas"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Selecionar funcoes"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Função criada com sucesso"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Tem a certeza de que deseja eliminar esta variante?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Todos os recursos estão operacionais"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Falha ao criar administrador"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Nao"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Variante de produto atualizada com sucesso"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Falha ao eliminar {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Produto atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Falha ao atualizar país"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Digite pelo menos 2 caracteres para pesquisar..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Apelido"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Título da ligação"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Grupo de clientes atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Campos personalizados alterados"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Localização de stock criada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Erro desconhecido"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "O total do reembolso não pode ser negativo"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Ver detalhes"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Selecione um canal para atribuir {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Cliente criado com sucesso"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Últimos 7 dias"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Falha ao criar canal"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Modo de programador"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Nova função"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Falha ao eliminar recursos: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Devolver ao stock"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Visibilidade"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Variantes do produto"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Novo grupo de clientes"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Criar \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Renomear"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Escolha o seu idioma de apresentacao e definicoes de localidade preferidos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} grupos de opcoes removidos do canal com sucesso"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Método de envio não é elegível para esta encomenda"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Falha ao atualizar morada"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Morada eliminada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Taxa fiscal"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "O rascunho da encomenda não está pronto para ser concluído"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Nova coleção"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Informações"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Executar"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Falha ao atualizar taxa fiscal"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Este é o conteúdo da coleção <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privado"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Opção de produto criada com sucesso"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Produto principal"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Cidade"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administradores"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Preço bruto: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Ir para a página seguinte"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Remover ligação"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Este campo e apenas de leitura"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Número de encomendas"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Encomenda atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Herdar filtros"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Gerir vistas guardadas globais visíveis para todos os utilizadores"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Pesquisar métodos de pagamento..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Endereço de envio removido da encomenda"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Criar {enabledCount} variantes"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Pagamento #{0} transitado para {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Erro ao carregar histórico do cliente: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} removido(s) do canal com sucesso"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Adicionar valor de opção"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Definições globais"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "é depois de"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Opção de produto atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Editar valores de faceta"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "A adicionar..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Mover coleções"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Funções"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Vista em grelha"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Falha ao eliminar morada"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Nenhum método de envio disponível"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Vista global convertida em vista pessoal com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Atendimento transitado"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Tem a certeza de que deseja eliminar {selectionLength} recursos?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Iniciar sessão"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Vista em lista"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Encomenda de teste"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Selecione um cliente para continuar"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Grupo de opcoes atribuido com sucesso"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Executar teste"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Taxa fiscal: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Adicione produtos e complete a morada de envio para executar o teste."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Alternar linha de cabeçalho"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Selecionar morada"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Verificador de elegibilidade de pagamento"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Zona fiscal predefinida"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "O rascunho da encomenda está pronto para ser concluído"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadados"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrar..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Novo valor de faceta"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Canal atualizado com sucesso"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Mostrar menos"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Data curta"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Moedas disponíveis"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Selecionar {0} itens"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Efetuada a"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "A rotacao desta chave invalidara imediatamente a chave atual. Quaisquer integracoes que a utilizem deixarao de funcionar ate serem atualizadas com a nova chave."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Os dados que foram passados para a tarefa"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Confirmar navegação"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Destino da ligação"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Concluir rascunho"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Nome"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Falha ao atender encomenda"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Total"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Introduza o ID da transação para esta liquidação de reembolso"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "A sua API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Tem a certeza de que deseja eliminar esta encomenda rascunho?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Atendimento criado"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Encontrado(s) {0} método(s) de envio elegível(eis)"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Dimensoes"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Mostrar palavra-passe"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(máx: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Empresa"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Adicionar coluna depois"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Ações"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Descontos"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Introduza nota de reembolso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Linha de encomenda removida"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Conteúdo:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Chave"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Confirmar"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Falha ao criar coleção"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Ir para a primeira página"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Falha ao criar produto"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Cliente"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Erro ao carregar histórico de encomendas: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Endereço de envio definido para a encomenda"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Ponto focal"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Variante unica, sem opcoes"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Selecione o próximo estado para a encomenda"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Localidade"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Tarefas agendadas"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Introduza ID da transação"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Atualizar dados"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Adicionar ou remover valores de faceta para {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Estes são os valores de faceta para a faceta <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Pagamento adicionado à encomenda com sucesso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Endereço de faturação definido para a encomenda"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Falha ao atualizar zona"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Falha ao eliminar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Tarefa agendada será executada"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Nova localização de stock"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Permissões"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Morada de envio alterada"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Nenhum produto encontrado"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Adicionar linha antes"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Transitar para {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Este mês"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Falha ao criar faceta"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Falha ao cancelar artigos da encomenda"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID da transação"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Alocado"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Adicionar outro grupo de opções"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Selecione o que fazer com o stock restante"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Explorar Plataforma e Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "A cada 5 segundos"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Coleção criada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Preço"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Encomenda rascunho"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Ambito"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Adicionar condição"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Método de envio é elegível para esta encomenda"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administradores"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Removido do grupo"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Largura"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Nenhum pagamento ou reembolso necessário"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Transferir como ficheiro .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Quando ativada, uma promoção fica disponível na loja"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Quando rastreado, os níveis de stock das variantes de produto serão ajustados automaticamente quando vendidos. Esta definição pode ser substituída por variantes de produto individuais."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Método de envio definido para a encomenda"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Falha ao atualizar promoção"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Imagens"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Pesquisar {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Editar recurso"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Cancelar pagamento"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Fila de tarefas"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Recursos"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Endereço de e-mail"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Regenerar slug do campo de origem"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Herdar das definições globais"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Estado atual"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Defina uma morada de envio e selecione um método de envio"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Desligado"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Loja de Definicoes"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Fila"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Nova taxa fiscal"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Pagamento transitado"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Restante:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Nenhum duplicador encontrado com código \"{duplicatorCode}\" para {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Preços incluem IVA para zona fiscal predefinida"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Reembolso total:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Ver resultado da tarefa"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Teste os seus métodos de envio simulando uma nova encomenda."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Nenhum item selecionado"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} selecionado(s)"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Nenhum país encontrado"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Variantes criadas com sucesso"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Gerar slug automaticamente"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Sobretaxa"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Métodos de pagamento"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Stock"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Nenhum cliente encontrado"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Usar limite global de esgotado"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Novo grupo de opções de produto"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Estado de pagamento atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Criar novo"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Total do reembolso"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Morada eliminada"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Apenas as funcoes atribuidas a sua conta estao disponiveis."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Item adicionado à encomenda"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Editar ponto focal"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Nenhum vendedor encontrado"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Recurso"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Este grupo de opcoes e utilizado por outro produto. As alteracoes tambem o afetarao.} other {Este grupo de opcoes e partilhado entre # produtos. As alteracoes afetarao todos eles.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "As minhas vistas guardadas"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Novo canal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Falha ao criar vendedor"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Configurar definicoes de duplicacao para {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Nenhuma variante corresponde ao filtro atual."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Moradas"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Adicionar um novo valor de opcao ao grupo de opcoes {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Modificação de encomenda #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Adicionar coluna antes"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Idiomas do canal"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Falha ao criar grupo de opções"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Verdadeiro"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Selecionar cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Encomenda transitada"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Este produto possui variantes existentes, mas nenhum grupo de opções definido. Precisa de adicionar grupos de opções antes de criar novas variantes."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "é antes de"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Eliminar encomenda rascunho"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Catálogo"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Novo método de pagamento"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promoção atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Falha ao cancelar {rejected} tarefa} other {Falha ao cancelar {rejected} tarefas}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Selecione um canal"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Idioma de apresentação"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Detalhes do atendimento"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Descartar o stock restante"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Agora"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Canais"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Vista convertida em global com sucesso"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "antes"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Tamanho"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Nenhuma tradução encontrada para {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Novo cliente"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Últimas encomendas"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} mais"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Usar como morada de faturação predefinida"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Desativar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Coleções"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Adicionar variante"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Falha ao criar país"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Países"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Falha ao criar opções de produto"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Falha ao renomear vista"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Disponível"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtros"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Grupos de clientes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Clientes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Formatação de exemplo"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nova opção"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Limite de utilização"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "A carregar definições globais..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Morada atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Criada"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "A carregar moradas..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Selecione uma coleção de destino para mover {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Detalhes do cliente atualizados"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "não em"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Aplicar"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nova opção de produto"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Ir para a última página"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Variante de produto criada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Reembolso deste método"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Código postal"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Adicione opções de produto primeiro"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Nova categoria fiscal"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Adicionar opção"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Reembolso parcial concluído"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Definir campos personalizados"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Coleções"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Eliminar variante"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Nenhuma modificação efetuada"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Zona de envio predefinida"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Motivo:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Morada de envio"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Transitar para {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Categorias fiscais"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Coleções privadas não são visíveis na loja"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Quando ativado, um produto fica disponível na loja"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Tarefa agendada não pôde ser executada"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Grupos de clientes"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Desativado"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Nova promoção"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Morada de envio predefinida"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Reembolso necessário"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Atender encomenda"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Não tem permissão para visualizar definições do canal"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Últimos 30 dias"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Nenhum valor de faceta"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "É necessário um motivo para o reembolso"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Nao foi possivel remover o grupo de opcoes"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Falha ao atualizar categoria fiscal"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Reembolso liquidado com sucesso"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Atualizar"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Título 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Encomenda efetuada"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Perfil atualizado com sucesso"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "fim"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Método de pagamento"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Editar"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variante atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtrar por nome de coleção"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Nota adicionada"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Selecione quantidades a atender e configure o manipulador de atendimento"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Endereço de faturação removido da encomenda"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Começa em"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Nenhum resultado"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Definições de coluna"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Falha ao eliminar {count} localização de stock} other {Falha ao eliminar {count} localizações de stock}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Código"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Falha ao remover grupos de opcoes"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Encomenda entregue"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Transferir para {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Stock restante"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Remover da zona"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Selecione entre os idiomas disponíveis globalmente para este canal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Tem a certeza de que deseja eliminar esta morada?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Falha ao atribuir grupo de opcoes"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Falha ao atualizar recurso"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Localização de stock atualizada com sucesso"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Confirmar ação"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "País atualizado com sucesso"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Facetas"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Falha ao adicionar nota"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Falha ao eliminar nota"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Falha ao estender documento de consulta"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Falha ao atualizar nota"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Reembolsar envio"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Apenas de leitura"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Falha ao duplicar vista global"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "A mostrar {shown} de {total} • {selected} selecionadas"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Testar método de envio"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Valores de faceta"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Recurso atualizado com sucesso"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Tema"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} clientes"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Selecione um idioma"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Terminar sessão"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Tentativas"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Códigos de moeda disponíveis"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Códigos de idiomas disponíveis"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Breadcrumbs"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Categoria"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Canais"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Filhos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Código"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Código de cupão"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Criado em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Código de moeda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Grupo de clientes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Clientes"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Campos personalizados"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Dados"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Código de moeda predefinido"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Código de idioma predefinido"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Zona de envio predefinida"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Zona fiscal predefinida"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Descrição"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Duração"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Endereço de e-mail"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Ativado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Termina em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Erro"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Recurso em destaque"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Nome próprio"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Código do manipulador de atendimento"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "É predefinido"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "É privado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Está liquidado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Apelido"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Nome"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Encomenda efetuada em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID pai"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Limite de utilização por cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Permissões"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Posição"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Preço"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Preços incluem IVA"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Preço com IVA"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Variantes de produtos"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Progresso"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Nome da fila"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Resultado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Tentativas"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Vendedor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Liquidado em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Linhas de envio"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Iniciado em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Começa em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Estado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Níveis de stock"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Total"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Total com IVA"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Tipo"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Atualizado em"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Limite de utilização"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Utilizador"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Valor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Lista de valores"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zona"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Método"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Resumo fiscal"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Define os idiomas disponíveis para todos os canais. Canais individuais podem então suportar um subconjunto desses idiomas."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Coleções movidas com sucesso"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registado"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Cancelar tarefa"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Termina em"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Página {0} de {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Taxa"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Tamanho, cor, etc."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Explorar facetas"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zona"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Cancelado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Criado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Entregue"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Pendente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Enviado"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Guardar vista"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} selecionados"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Pesquisar grupos de opcoes..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Modificar encomenda"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Itens selecionados"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Valores"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Cliente definido para a encomenda"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Facetas"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Tem a certeza de que pretende remover {count} cliente deste grupo?} other {Tem a certeza de que pretende remover {count} clientes deste grupo?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Stock disponível"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Reconstrução do índice de pesquisa não pôde ser iniciada"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Morada de envio"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Nova zona"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Nova API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Eliminar coluna"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Atribuir existente"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "é nulo"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Estes são os clientes do grupo de clientes <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Gerir vistas globais"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Canal predefinido"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Inserir uma nova imagem com origem, titulo e dimensoes"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Falha ao criar valor de faceta"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Falha ao atualizar opção de produto"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Esqueceu-se da palavra-passe?</0><1>Solicitar redefinição</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Código de cupão"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Cliente verificado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Definições globais"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Agendamento"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Não é possível mover uma coleção para o seu próprio descendente"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Nova categoria fiscal"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Nenhuma localização de stock disponível no canal atual"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Canal criado com sucesso"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Cliente atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Ver dados"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Eliminar vista"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Adicionar uma nova morada ao cliente."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Mais vistas"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Editar as propriedades da imagem selecionada"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Vista \"{viewName}\" aplicada"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} facetas removidas do canal com sucesso"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Novo produto"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Novo recurso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Recalcular envio"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Selecione quais opções devem ser aplicadas à variante existente \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Recursos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Isto removera todos os grupos de opcoes deste produto e regressara a escolha de configuracao de variantes."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Morada de faturação"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Adicionar valor de faceta"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Selecione uma coleção de destino"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Reveja as alterações antes de as aplicar à encomenda."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Selecione uma função"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Encomenda cancelada"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Desconto"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Todos os tipos"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Apenas rascunhos de encomendas podem ser concluídos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Falha ao atualizar produto"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "A ajustar {0} linhas"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Adicionar valores de faceta"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "depois"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Canal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Verificações de saúde"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Valor"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Número de telefone"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Novo cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Imagem"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administrador criado com sucesso"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Opções de produto"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Selecionar país"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "A criar..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Tem a certeza de que deseja eliminar esta vista global? Esta ação não pode ser revertida e afetará todos os utilizadores."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Forçar remoção do grupo de opções"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Adicionado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Histórico do cliente"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Valores de faceta atualizados com sucesso para {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Falha ao remover cliente do grupo"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Sistema"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Limite de utilização por cliente"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Morada de faturação alterada"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Selecione uma opção"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Copiar para pessoal"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "O total do reembolso excede o montante máximo reembolsável de {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Eliminar vista global"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Criar"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "A cada 30 segundos"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Novo país"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "De {0} a {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Falha ao criar cliente"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Ponto focal atualizado"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Valores de opção"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Morada de faturação predefinida"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Nenhum cliente"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Falha ao remover países da zona"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Falha ao criar promoção"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Hoje"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Ontem"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Nome da opção"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Tem a certeza de que pretende remover {0} {1} desta zona?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "A adicionar {0} sobretaxa(s)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Ligação href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Fallback: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Histórico de encomendas"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Substituir"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "ID da transação é obrigatório"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "corresponde a regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Vista global renomeada com sucesso"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Nenhuma etiqueta selecionada"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Voltar"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Vista renomeada com sucesso"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Aplicar filtro"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Último resultado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Adicionado ao grupo"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Estatísticas"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Criar variantes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "A testar método de envio..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Escuro"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Resultados do teste"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Adicionar cliente"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Guardar alterações"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Morada atualizada"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Reembolso processado com sucesso"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Nova zona"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Falha ao atualizar posição da coleção"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Reembolso"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Modificar"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Nenhum idioma global configurado"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "A remover {0} item(ns)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Rastrear"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Criar variante"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Valores de faceta para {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Guardar layout"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Redefinição de palavra-passe verificada"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Falha ao eliminar vista"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Tem a certeza de que deseja sair desta página? Quaisquer alterações não guardadas serão perdidas."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Alternar coluna de cabeçalho"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Nova promoção"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Nome do valor da opção"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Ultima utilizacao"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "É categoria fiscal predefinida"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug está definido"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Falha ao atualizar o ponto focal"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zona atualizada com sucesso"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Estado/Província"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Falha ao atualizar grupo de opcoes"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Predefinições do canal"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Falha ao criar categoria fiscal"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Definir criterios de filtro para a coluna {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "País"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Produto simples"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Fila de tarefas"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Por favor, confirme que guardou a API Key antes de fechar."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Confirmar eliminação"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Falha ao modificar encomenda"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Inclui IVA de {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Métricas de encomendas"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Selecionar idioma de apresentação"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Métodos de autenticação"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "início"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Falha ao rodar a API Key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "em"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Pesquisar funções..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Variantes de produtos"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Gerir vistas globais"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "A processar..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} encontrado(s)"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Selecionar intervalo de datas"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Produto"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rodar API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Categoria"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "A mover..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Atribuir"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Vendedor criado com sucesso"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Método de envio atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Falha ao atualizar variante de produto"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Arrastar para reordenar"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zonas"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Escolha o que fazer com o stock restante {count, plural, one {na # localização de stock} other {nas # localizações de stock}} que está a eliminar. Todas as localizações selecionadas transferem o stock restante para a única localização que escolher, ou descartam-no."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Pesquisar valores de facetas..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Nota"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Idiomas disponíveis"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Carregar mais {0} ({remaining} restantes)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Valores de faceta"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Falha ao reordenar artigos"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Total de encomendas"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Nenhum método de envio elegível encontrado para esta encomenda."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Adicionar opção de produto"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Envio"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions deve ser utilizado dentro de um DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Este grupo de opções está a ser utilizado por variantes existentes. Forçar a remoção pode afetar essas variantes. Tem a certeza?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Atualização de e-mail solicitada"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Erro ao fazer transição para estado"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Grupo de clientes criado com sucesso"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nova janela"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Pagamento autorizado"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Função atualizada com sucesso"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Selecione um país"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Falha ao atualizar método de envio"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Eliminada {deleted} localização de stock} other {Eliminadas {deleted} localizações de stock}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Métodos de envio"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Selecione uma morada"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Sim"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Definir ponto focal"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "fim"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Selecione uma moeda"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Atualizar conteúdo ou visibilidade da nota"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget de encomendas recentes"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Conteúdo da coleção {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Método de envio alterado"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Descrição do imposto"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "é menor ou igual a"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "não é igual a"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Atualizar"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "ex. Tamanho"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Liquidar pagamento"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Canais"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Portes reembolsados"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Tipo de recurso"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Nova localização de stock"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} pagamento(s) reembolsado(s) antes da falha. Verifique o histórico da encomenda para detalhes."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Selecionar item"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Novo produto"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gerir etiquetas"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Artigos reembolsados"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Adicionar ação"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Atribuir opções à variante existente"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Duplicar {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Remover do grupo"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Falha ao atualizar estado de atendimento"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Criar uma nova variante de produto com opcoes, precos e stock"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Facetas privadas não são visíveis na loja"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Selecione uma categoria fiscal"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Criado"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Não em execução"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Atribuido"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Título 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Selecionar idiomas disponíveis"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "A adicionar {0} item(ns)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Adicionar linha depois"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Total de IVA"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Estado do rascunho da encomenda"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Opções de produto criadas com sucesso"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "A carregar localizações…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Falha ao criar método de pagamento"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Valor de faceta criado com sucesso"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Encomenda rascunho eliminada"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "maior que"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Widget de métricas"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Pesquisar moedas..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Remover do canal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Título"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Inserir imagem"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Falha ao atualizar vendedor"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "País criado com sucesso"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Selecionar vendedor"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "A carregar etiquetas..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Faceta criada com sucesso"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} variantes"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Falha ao liquidar pagamento"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Nenhuma morada de faturação"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Falha ao eliminar {1} localização de stock} other {Falha ao eliminar {2} localizações de stock}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Faceta"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Não é possível remover do canal ativo"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Não definido"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Forçar remoção"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Novo canal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Nome do grupo de opções"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "E"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Falha ao criar grupo de clientes"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Falha ao criar função"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Nome do produto"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Estado de atendimento atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Produtos"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Morada criada"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key rodada com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Adicionar grupo de opções"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Reembolsar {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Introduza slug manualmente"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Nenhum widget disponível"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Falha ao cancelar pagamento"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Pagamento cancelado com sucesso"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Vista global duplicada com sucesso"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Criado por"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtrar variantes..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Adicionar um preço noutra moeda"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Endereço de e-mail ou identificador"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Reembolso #{0} transitado para {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Clientes"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Título 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Falha ao atualizar localização de stock"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Encomenda enviada"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Guardar morada"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Tornar global"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Selecionar próximo estado"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Sem alertas"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "A mover {0} coleção(ões) para {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Teste"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "entre"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Nota adicionada com sucesso"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Nota eliminada com sucesso"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Nota atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Falha ao liquidar reembolso"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Nível de stock"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Adicionar item"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key criada com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "A carregar pré-visualização..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Voltar à pesquisa"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Vista duplicada com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Remover grupo de opções"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Descrição"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Países"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Morada (linha 2)"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Vista global eliminada com sucesso"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Editar layout"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Atribuir ao canal"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Esta semana"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Grupo de opções de produto criado com sucesso"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Adicionar um pagamento manual de {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "está em"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-mail"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Falha ao atualizar administrador"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Gerir as suas vistas guardadas pessoais para esta tabela"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtrar por etiquetas"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Inicie sessão para aceder ao painel de administração"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Adicionar pagamento à encomenda ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Falso"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Claro"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Redefinir"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "é igual a"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Criar opções"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Palavra-passe atualizada"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "não contém"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Grupo de Opcoes"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Edite os detalhes da morada abaixo."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Categoria fiscal criada com sucesso"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Falha ao mover coleções"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Falha ao atualizar estado de pagamento"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Resumo das suas encomendas"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Carregar"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Produto com opcoes"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "A mostrar todos os {0} resultados"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "ID de Consulta"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} mais"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Grupos de Opcoes"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Campos personalizados"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Todos os estados possiveis da encomenda e as suas transicoes. O estado atual esta destacado."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Encomendas"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget de resumo de encomendas"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "A adicionar itens"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "A Organizar Pagamento Adicional"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "A organizar pagamento"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Cancelada"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Criada"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Entregue"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Rascunho"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "A Modificar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Parcialmente Entregue"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Parcialmente Enviado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Pagamento autorizado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Pagamento liquidado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Enviado"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Recursos monitorizados"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Informações da entidade"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Total da encomenda"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Visível apenas para administradores"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Qtd"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super administrador"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Alguns recursos estão inativos"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Ações disponíveis"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Inserir ligação"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Se ativado, os filtros serão herdados da coleção pai e combinados com os filtros definidos nesta coleção."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Selecione uma zona"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Testar métodos de envio"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Pagamento liquidado com sucesso"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} removidos da zona"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Ativar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Métodos de pagamento"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autorizado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Cancelado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Criado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Recusado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Erro"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Falhado"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Pendente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Liquidado"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Valor médio da encomenda"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Falha ao criar zona"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Níveis de stock"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Falha ao atualizar a API Key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Linhas de encomenda"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Falha ao renomear vista global"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Inserir uma nova hiperligacao com URL e opcoes de destino"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Altura"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "É necessário um reembolso de {formattedDiff}. Selecione os valores de pagamento e insira uma nota para prosseguir."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Preço unitário"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Padrão de agendamento"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Pagamento falhou"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Adicionar canal"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Falha ao atualizar grupo de opções de produto"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Pesquisar canais..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Adicionar grupos de clientes"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Idiomas disponíveis"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Repor selecao"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Nenhuma morada"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Método de pagamento criado com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Informações do cliente atualizadas"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Falha ao converter vista em global"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Variantes de produtos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Produtos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promoções"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Falha ao criar opção de produto"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "E-mail antigo:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Guarde uma vista como \"Global\" para a disponibilizar a todos os utilizadores."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Falha ao criar variantes"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Define o nível de stock no qual esta variante é considerada esgotada. Usar um valor negativo ativa suporte a encomendas pendentes. Pode ser substituído por variantes de produto."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rodar Chave"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Falha ao criar variantes do produto"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Ocultar palavra-passe"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Novo vendedor"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "ex. Vermelho, Grande, Algodão"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Falha ao atualizar perfil"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Códigos de cupão removidos"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Limpar filtro"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regiões"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Largue os ficheiros aqui para carregar"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Alternar todas as variantes visíveis"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verificado"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Novo grupo de opcoes"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Última atualização {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Nenhuma vista global foi criada ainda."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Falha ao atualizar função"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Esta e a unica vez que a API Key completa sera apresentada. Copie ou transfira agora — nao podera ser recuperada posteriormente."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Coleção atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Método de pagamento atualizado com sucesso"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Vista eliminada com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Grupo de opções {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "OU"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Gerir etiquetas"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Código de cupão removido da encomenda"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Nunca"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Falha ao atualizar valor de faceta"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Remover grupo"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Encomenda atendida"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Nenhuma morada de envio"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Extensão de consulta contém sintaxe GraphQL inválida"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Erro de extensão de consulta"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Erro de extensão de consulta:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Extensão de consulta inválida: deve ter pelo menos um campo de nível superior"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Incompatibilidade de extensão de consulta:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "público"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Categoria fiscal atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Mover"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Editar ou eliminar etiquetas existentes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "As condições do verificador de elegibilidade deste método de envio não são cumpridas para a encomenda atual e morada de envio."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Adicionar código de cupão"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Código de cupão definido para a encomenda"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Campos personalizados"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Novo método de envio"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Eliminar localizações de stock"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "é maior ou igual a"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Pré-visualização"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} de {1} disponíveis para satisfazer"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Mês até à data"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Solicitação do cliente"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Danificado no envio"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Não disponível"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Outro"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Artigo errado"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Resumo das modificações"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Reembolsos ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Última execução"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Detalhes do pagamento"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Reconstruir índice de pesquisa"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Em execução"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "A cada 60 segundos"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Falha ao atualizar grupo de clientes"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Metadados do pagamento"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Cancelar modificação"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Mesma janela"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Aplique filtros à tabela e clique em \"Guardar vista\" para começar."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Funções"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Pagamento adicional necessário"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Falha ao atualizar encomenda"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Com selecionados..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Falha ao criar localização de stock"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "menor ou igual a"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Membros do grupo de clientes {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Estado"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Não rastrear"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Atendimento #{0} criado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "A executar atualizações pendentes do índice de pesquisa"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Esta é uma função predefinida e não pode ser modificada"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "As minhas vistas guardadas"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Estado / Província"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Ativado"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Itens por pagina"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Editar membros"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Stock disponível"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtrar por {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Alertas"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Valores de opção"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Pré-visualizar alterações"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Falha ao remover {entityType} do canal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variante eliminada com sucesso"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Editar as propriedades da ligacao selecionada"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Vendas"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Selecione uma coleção de destino"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "As suas últimas encomendas"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Tarefas agendadas"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Tem a certeza de que deseja eliminar este item? Esta ação não pode ser revertida."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Variantes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Vendedores"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Definições"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Loja de Definicoes"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Título 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Bem-vindo ao Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Métodos de envio"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} reembolsável)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identificador"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Falha ao atualizar coleção"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Preço e IVA"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Encomenda não encontrada"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Erro"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Encomenda modificada"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Redefinição de palavra-passe solicitada"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "O montante de pagamento atribuído deve ser igual ao total do reembolso"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "ex. Pequeno"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Tem a certeza de que deseja remover {0} {entityType} do canal atual?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Adicionar etiquetas..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Falha ao criar grupo de opções de produto"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} itens selecionados"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Pesquisar idiomas..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Localizações de stock"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Ir para a página anterior"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Conteúdo"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Falha ao converter vista global em vista pessoal"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "O resultado da tarefa"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Adicionar pagamento ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Sistema"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Nome da variante"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Remover"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Falha ao atualizar cliente"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Remover grupos de opcoes?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Esta é uma pré-visualização do conteúdo da coleção com base nas definições de filtro atuais. Depois de guardar a coleção, o conteúdo será atualizado para refletir as novas definições de filtro."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} cliente removido do grupo} other {{count} clientes removidos do grupo}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Categorias fiscais"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Taxas fiscais"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Falha ao remover clientes do grupo"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Falha ao carregar definições globais"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Selecione artigos para reembolso e opcionalmente devolva ao stock"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Guardar"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} de {0} linha(s) selecionada(s)."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Pré-visualizar modificações da encomenda"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Grupo de opções de produto atualizado com sucesso"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "A página continuará com a consulta predefinida."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Morada"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Não existem mais facetas"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Reconstrução do índice de pesquisa iniciada"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Posição da coleção atualizada"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Nome do grupo de opções"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Adicionar \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Nova variante de produto"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Reembolso transitado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "A usar estratégia de autenticação nativa"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Falha ao atribuir {entityIdsLength} {entityType} ao canal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Idioma predefinido"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "A atender..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Adicionar grupo de opções ao produto"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Pré-visualização de {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Vendedor atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Falha ao fazer transição da encomenda para estado"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Mostrar tudo ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Falha ao criar taxa fiscal"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Guardei esta API Key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Configure os idiomas disponíveis para a sua loja e canais"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Produto criado com sucesso"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Adicionar variante de produto"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Escreva e prima Enter ou vírgula para adicionar..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Editar nota"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Nenhum recurso encontrado. Tente ajustar os seus filtros."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Adicionar opção"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Guardar grupo de opções"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Criar {createCount} variantes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Clique em \"Executar teste\" para testar este método de envio."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administrador atualizado com sucesso"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Limpar filtros"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Atendimento #{0} de {1} para {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Falha ao eliminar vista global"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Idioma predefinido"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Estado"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Nenhuma opção encontrada"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binario"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Grupo de opcoes atualizado com sucesso"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Novo método de envio"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "A cada 10 segundos"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "s/ IVA:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Adicionar stock à localização"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Valor de opção adicionado com sucesso"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Coleção movida para novo pai"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Grupo de opções removido"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Transitar para estado selecionado"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Será necessário um pagamento adicional de {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Rastrear stock por predefinição"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} de {total} selecionadas"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Método de envio criado com sucesso"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Novo grupo de clientes"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Visível para o cliente"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Grupo de opções criado com sucesso"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Taxas fiscais"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug será gerado automaticamente..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Cliente não encontrado"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Selecionar {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Novos valores de faceta a adicionar:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Falha ao processar reembolso"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Nome próprio"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "contém"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Nenhum grupo de opcoes encontrado"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Nenhum item encontrado"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Subtotal"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Itens atendidos ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Valor atualizado"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Não verificado"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Quantidade"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Adicionar filtro"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Categoria fiscal"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Perfil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Dados de teste foram atualizados. Clique em \"Executar teste\" para ver resultados atualizados."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "não está em"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Linha de encomenda atualizada"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Novo método de pagamento"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "O valor duplicado \"{trimmed}\" já existe"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Motivo"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Grupos de clientes"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} removido(a) do canal com sucesso"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Grupos de opções"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Adicionar sobretaxa"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Valores de faceta atuais"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Pagina {page} de {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Mês passado"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Adicionar país"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Remover item"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "menor que"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "A variante não pôde ser adicionada. Certifique-se de que o produto principal está ativado."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Ocorreu um erro desconhecido"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Métricas"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Idioma"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Nova coleção"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Reembolsar e cancelar encomenda"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Atualização de e-mail verificada"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "está entre"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Reembolsar e cancelar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "A testar métodos de envio..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Falha ao criar método de envio"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} atribuído(s) ao canal com sucesso"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Idiomas globais"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Novo administrador"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Eliminar rascunho"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Origem"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Nenhuma ação disponível"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Falha ao atualizar canal"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Geral"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Falha ao remover produto do canal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Adicionar nova morada"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Faceta atualizada com sucesso"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zona criada com sucesso"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Valor"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Cliente atualizado"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Fator de conversão de preço"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Encomenda do vendedor"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Nova faceta"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Tem a certeza de que pretende remover este grupo de opções do produto?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Descrição (texto alternativo)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Nenhuma etiqueta encontrada"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Moeda predefinida"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Nenhum pagamento ou reembolso é necessário para estas alterações."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Receita total"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Próxima execução"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Nota é privada"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Data média"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Numero invalido"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Ainda não guardou nenhuma vista."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Tem a certeza de que deseja eliminar esta vista? Esta ação não pode ser revertida."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Ver processo da encomenda"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Falha ao duplicar vista"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Usar como morada de envio predefinida"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Editar slug manualmente"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Adicionar filtros para pré-visualizar o conteúdo da coleção."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Grupo de opções de produto"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "é menor que"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID de reembolso"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Campos personalizados da encomenda atualizados"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Calculadora"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Falha ao remover grupo de opcoes do canal: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Ver dados da tarefa"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Mover para o nível superior"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Limpar"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Resumo de encomendas"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Pesquisar recursos..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Nova faceta"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Atribuir {entityType} ao canal"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Continuar"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promoções"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Mensagem de erro"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Adicionar nível de stock para outra localização"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Eliminar morada"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Falha ao atualizar faceta"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters deve ser utilizado dentro de um WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Editar morada"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Falha ao remover faceta do canal: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Definir ligação"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Novo vendedor"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Editar imagem"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Gerir variantes"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Stock alocado"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "maior ou igual a"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Define o nível de stock no qual esta variante é considerada esgotada. Usar um valor negativo ativa suporte a encomendas pendentes."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Criar opções de produto"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "A guardar..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Ver resultado"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Linhas por página"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "A carregar coleções..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Valor de faceta atualizado com sucesso"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Adicionar recurso"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Guardar alterações"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Cliente adicionado ao grupo"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Encomendas do vendedor"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Falha ao adicionar valor de opção"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Adicionar valor de opção a {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} artigo(s) reembolsado(s)"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Nenhum grupo de opções definido ainda. Adicione grupos de opções para criar diferentes variantes do seu produto (ex. Tamanho, Cor, Material)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Novo e-mail:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Falha ao atualizar método de pagamento"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Disponível:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Criada em"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Falha ao criar variante de produto"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Idioma: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Não tem permissão para visualizar definições de idioma global"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Taxa fiscal criada com sucesso"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Título 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Códigos de cupão adicionados"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Ativo"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Base fiscal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Carregar mais"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Reembolso liquidado"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} duplicado(s) com sucesso"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Novo Grupo de Opcoes"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Nenhum resultado ainda"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Pagamento liquidado"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Condições disponíveis"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Filtros ativos"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Limpar tudo"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "é maior que"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Fechar"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Adicionar pagamento à encomenda"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "A carregar..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "O token é usado para especificar o canal ao fazer pedidos de API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Nenhuma morada encontrada"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID de atendimento"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Selecione pagamentos para reembolso"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Falha ao eliminar {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Limite de esgotado"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produto removido do canal com sucesso"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Falha ao atualizar valor"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Falha ao criar API Key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Liquidar reembolso"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Método de pagamento é obrigatório"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Falha ao adicionar cliente ao grupo"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Gerir variantes"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Vista global \"{viewName}\" aplicada"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Cliente registado"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zonas"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Pesquisar vendedores..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Promoção criada com sucesso"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Opção"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Processo da encomenda"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Número de telefone"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privado"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variante"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Definições globais atualizadas com sucesso"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key atualizada com sucesso"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Estes idiomas estarão disponíveis para todos os canais usarem"

--- a/packages/dashboard/src/i18n/locales/ro.po
+++ b/packages/dashboard/src/i18n/locales/ro.po
@@ -13,5974 +13,5974 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Nume complet"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Selectează elementele"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Vizualizează modificările"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Cod de urmărire"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Permisiunile selectate vor fi aplicate acestor canale."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Opțiuni produs"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Cotă de Taxă Nouă"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Atribuie un grup de opțiuni existent sau creează unul nou"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Rol nou"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Apartament, bloc, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Nu mai sunt elemente"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Editează link"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Adaugă cel puțin un articol la comandă"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Adaugă produse pentru a crea o comandă de test"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Nu s-a putut crea adresa"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Comută toate"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Editează valoare JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Folosind strategia de autentificare externă: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Alege un motiv..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Heading 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Nu s-a putut adăuga plata"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Actualizat"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Nu s-au putut actualiza setările globale"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Comanda a fost onorată cu succes"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Ești sigur că vrei să ștergi {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Prag global stoc epuizat"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Gestionează limbi"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Se duplică... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Șters(e) cu succes"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} resurse șterse"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Cota de taxă a fost actualizată cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Introdu motiv personalizat..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Tip"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Selectează {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Vizualizează valorile"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Șterge rândul"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Condiții"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Curent"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Fără livrări"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Ștergerea a {1} locație de stoc a eșuat: {messages}} few {Ștergerea a {2} locații de stoc a eșuat: {messages}} other {Ștergerea a {2} de locații de stoc a eșuat: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Când este activat, prețurile introduse în catalogul de produse vor include taxa pentru zona de impozitare implicită."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Comandă ciornă finalizată"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Reîmprospătare automată: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} șterse"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Vânzători"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Opțiuni"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} job anulat cu succes} few {{fulfilled} joburi anulate cu succes} other {{fulfilled} de joburi anulate cu succes}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Vânzător"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Adaugă plată"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Testați această metodă de livrare simulând o comandă pentru a vedea dacă este eligibilă și care ar fi costul de livrare."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Locații Stoc"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Procesator livrare"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Comenzi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Selectează roluri"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Rolul a fost creat cu succes"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Ești sigur că vrei să ștergi această variantă?"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Nu s-a putut crea administratorul"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Nu"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Varianta produsului a fost actualizată cu succes"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Nu s-au putut șterge {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Produsul a fost actualizat cu succes"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Nu s-a putut actualiza țara"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Introduceți cel puțin 2 caractere pentru căutare..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Nume"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Titlu link"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Grupul de clienți a fost actualizat cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Câmpuri personalizate modificate"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Locația de stoc a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Eroare necunoscută"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Totalul rambursării nu poate fi negativ"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Vizualizează detaliile"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Selectează un canal pentru a atribui {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Clientul a fost creat cu succes"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Ultimele 7 zile"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Nu s-a putut crea canalul"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Mod dezvoltare"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Rol Nou"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Nu s-au putut șterge resursele: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Returnează în stoc"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Vizibilitate"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Variante de produs"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Grup client nou"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Creează \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Redenumește"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Alege limba de afișare preferată și setările regionale"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "Au fost eliminate cu succes {successCount} grupuri de opțiuni din canal"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Metoda de livrare nu este eligibilă pentru această comandă"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Nu s-a putut actualiza adresa"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adresă ștearsă cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Cota de taxă"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Ciorna comenzii nu este gata pentru finalizare"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Colecție nouă"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Perspective"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Rulează"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Nu s-a putut actualiza cota de taxă"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Acesta este conținutul colecției <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privat"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Opțiunea produsului a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Produs părinte"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Oraș"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administratori"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Preț brut: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Mergi la pagina următoare"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Elimină link"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Acest câmp este doar în citire"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Număr comenzi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Comanda a fost actualizată cu succes"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Moștenește filtre"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Gestionează vizualizările globale salvate care sunt vizibile tuturor utilizatorilor"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Caută metode de plată..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Adresa de livrare anulată pentru comandă"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Creează {enabledCount} variante"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Plata #{0} a trecut la {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Eroare la încărcarea istoricului de client: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "Au fost eliminate cu succes {selectionLength} {entityType} din canal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Adaugă valoare opțiune"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Setări globale"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "este după"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Opțiunea produsului a fost actualizată cu succes"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Editează valori atribut"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Se adaugă..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Mută Colecții"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Roluri"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Vizualizare grilă"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Nu s-a putut șterge adresa"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Nu sunt disponibile metode de livrare"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Vizualizare globală convertită la personală cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Statusul livrării a fost schimbat"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Ești sigur că vrei să ștergi {selectionLength} resurse?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Autentificare"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Vizualizare listă"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Comandă de test"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Selectează un client pentru a continua"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Grupul de opțiuni a fost atribuit cu succes"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Rulează test"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Cota de taxă: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Te rugăm să adaugi produse și să completezi adresa de livrare pentru a rula testul."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Comută rândul antet"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Selectează adresa"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Verificator eligibilitate plată"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Zonă de taxare implicită"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Ciorna comenzii este gata pentru finalizare"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadate"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrează..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Valoare atribut nouă"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Canalul a fost actualizat cu succes"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Afișează mai puțin"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Dată scurtă"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Monede disponibile"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Selectează {0} elemente"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Plasată la"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Rotirea acestei chei va invalida imediat cheia curentă. Orice integrări care o folosesc vor înceta să funcționeze până când sunt actualizate cu noua cheie."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Datele care au fost transmise job-ului"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Confirmă navigarea"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Comportament link"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Finalizează ciorna"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Nume"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Nu s-a putut livra comanda"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Total"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Introdu ID-ul tranzacției pentru această soluționare rambursare"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Cheia ta API"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Ești sigur că vrei să ștergi această comandă ciornă?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Livrare creată"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "S-au găsit {0} metode de livrare eligibile"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Dimensiuni"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Afișează parola"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(max.: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Companie"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Adaugă coloană după"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Acțiuni"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Reduceri"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Introdu notă rambursare"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Linie comandă eliminată"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Conținut:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Cheie"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Confirmă"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Nu s-a putut crea colecția"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Mergi la prima pagină"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Nu s-a putut crea produsul"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Client"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Eroare la încărcarea istoricului comenzii: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Adresa de livrare setată pentru comandă"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Punct focal"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Variantă unică, fără opțiuni"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Selectează statusul următor pentru comandă"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Localizare"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Sarcini planificate"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Introdu ID tranzacție"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Reîmprospătează datele"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Adaugă sau elimină valori atribut pentru {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Acestea sunt valorile pentru atributul <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Plata a fost adăugată cu succes la comandă"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Adresă de facturare setată pentru comandă"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Nu s-a putut actualiza zona"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Parolă"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Nu s-a putut șterge"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Sarcina planificată va fi executată"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Locație stoc nouă"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Permisiuni"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Adresa de livrare a fost modificată"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Nu s-au găsit produse"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Adaugă rând înainte"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Tranziție la {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Luna aceasta"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Nu s-a putut crea atributul"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Nu s-au putut anula articolele comenzii"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID tranzacție"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Alocat"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Selectați ce se întâmplă cu stocul rămas"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Explorează Platforma și Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "La fiecare 5 secunde"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Colecția a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Preț"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Comandă ciornă"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Domeniu"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Adaugă condiție"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Metoda de livrare este eligibilă pentru această comandă"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administratori"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Eliminat din grup"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Lățime"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Nu este necesară plată sau rambursare"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Descarcă ca fișier .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Când este activat, o promoție este disponibilă în magazin"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Când este activ, nivelurile de stoc ale variantelor de produse vor fi ajustate automat la vânzare. Această setare poate fi suprascrisă de variantele individuale de produse."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Metoda de livrare setată pentru comandă"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Nu s-a putut actualiza promoția"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Imagini"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "Chei API"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Caută {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Editează resursă"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Anulează plata"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Coadă de joburi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Resurse"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Adresă de email"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Regenerează identificator URL din câmpul sursă"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Moștenește de la setările globale"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Nu s-au găsit rezultate"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Setează o adresă de livrare și selectează o metodă de livrare"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Oprit"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Stocare setări"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Coadă"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Cotă de taxă nouă"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Status plată schimbat"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Rămas:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Nu s-a găsit duplicator cu codul \"{duplicatorCode}\" pentru {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Prețurile includ taxa pentru zona de taxare implicită"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Total rambursare:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Vizualizează rezultatul job-ului"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Testați metodele de livrare simulând o comandă nouă."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Nu sunt selectate elemente"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} selectate"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Nu s-au găsit țări"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Variantele au fost create cu succes"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Generează identificator URL automat"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Suprataxă"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Metode de Plată"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Stoc"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Nu s-au găsit clienți"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Folosește pragul global de stoc epuizat"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Status plată actualizat cu succes"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Creează nou"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Total rambursare"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adresă ștearsă"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Sunt disponibile doar rolurile atribuite contului tău."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Articol adăugat la comandă"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Editează punctul focal"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Resursă"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Acest grup de opțiuni este folosit de încă un produs. Modificările îl vor afecta și pe acesta.} other {Acest grup de opțiuni este partajat între # produse. Modificările le vor afecta pe toate.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Vizualizările Mele Salvate"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Canal nou"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Nu s-a putut crea vânzătorul"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Configurează setările de duplicare pentru {0}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Nicio variantă nu corespunde filtrului curent."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adrese"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Adaugă o valoare nouă de opțiune în grupul de opțiuni {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Modificare comandă #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Adaugă coloană înainte"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Limbi canal"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Nu s-a putut crea grupul de opțiuni"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Adevărat"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Selectează clientul"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Status comandă schimbat"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "este înainte"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Șterge comanda ciornă"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Catalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Metodă de plată nouă"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promoția a fost actualizată cu succes"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Nu s-a putut anula {rejected} job} few {Nu s-au putut anula {rejected} joburi} other {Nu s-au putut anula {rejected} de joburi}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Selectează un canal"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Limbă afișare"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Detalii livrare"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Elimină stocul rămas"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Acum"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Canale"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Vizualizare convertită la globală cu succes"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "înainte"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Dimensiune"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Nu s-a găsit traducere pentru {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Client Nou"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Comenzi recente"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ încă {leftOver}"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Folosește ca adresă de facturare implicită"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Șterge"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Dezactivează"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Colecții"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Adaugă variantă"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Nu s-a putut crea țara"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Țări"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Nu s-a putut redenumi vizualizarea"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Disponibil"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtre"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Grupuri de clienți"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Clienți"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Formatare exemplu"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Opțiune nouă"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Limită de utilizare"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Se încarcă setările globale..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adresă actualizată cu succes"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Creat"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Se încarcă adresele..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Selectează o colecție țintă pentru a muta {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Detalii client actualizate"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "nu este în"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Aplică"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Opțiune produs nouă"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Mergi la ultima pagină"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Anulează"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Varianta produsului a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Rambursare din această metodă"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Cod Poștal"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Categorie de taxă nouă"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Rambursare parțială finalizată"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Setează câmpuri personalizate"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Colecții"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Șterge varianta"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Nu s-au făcut modificări"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Zonă de livrare implicită"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Motiv:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Adresă de livrare"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Tranziție la {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Categorii de taxă"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Colecțiile private nu sunt vizibile în magazin"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Când este activat, un produs este disponibil în magazin"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Sarcina planificată nu a putut fi executată"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Grupuri de clienți"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Dezactivat"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Promoție nouă"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Adresă de livrare implicită"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Rambursare necesară"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Livrare comandă"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Nu aveți permisiunea de a vizualiza setările canalului"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Ultimele 30 de zile"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Fără valori atribut"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Este necesar un motiv pentru rambursare"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Nu s-a putut elimina grupul de opțiuni"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Nu s-a putut actualiza categoria de taxă"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Rambursare soluționată cu succes"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Actualizare"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Heading 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Comandă plasată"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profilul a fost actualizat cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Metodă de plată"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Editează"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variantă actualizată cu succes"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtrează după nume colecție"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Notă adăugată"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Selectează cantitățile de onorat și configurează handler-ul de onorare"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Adresă de facturare neconfigurată pentru comandă"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Începe la"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplică"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Fără rezultate"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Setări coloane"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Ștergerea a {count} locație de stoc a eșuat} few {Ștergerea a {count} locații de stoc a eșuat} other {Ștergerea a {count} de locații de stoc a eșuat}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Cod"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Nu s-au putut elimina grupurile de opțiuni"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Comandă livrată"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Transferă în {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Stoc rămas"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Elimină din zonă"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Selectează din limbile disponibile global pentru acest canal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Ești sigur că vrei să ștergi această adresă?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Nu s-a putut atribui grupul de opțiuni"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Nu s-a putut actualiza resursa"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Locația de stoc a fost actualizată cu succes"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Confirmă acțiunea"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Țara a fost actualizată cu succes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Atribute"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Nu s-a putut adăuga nota"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Nu s-a putut șterge nota"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Nu s-a putut extinde query-ul"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Nu s-a putut actualiza nota"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Rambursează livrarea"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Doar citire"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Nu s-a putut duplica vizualizarea globală"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Se afișează {shown} din {total} • {selected} selectate"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Testare metodă de livrare"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Valori atribute"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Resursa a fost actualizată cu succes"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Temă"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} clienți"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "Chei API"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Selectează o limbă"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Deconectare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Încercări"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Coduri monede disponibile"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Coduri de limbă disponibile"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Cale de navigare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Categorie"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Canale"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Copii"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Cod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Cod cupon"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Creat la"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Moneda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Client"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Grup client"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Clienți"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Câmpuri personalizate"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Date"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Monedă implicită"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Cod de limbă implicit"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Zonă livrare implicită"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Zonă de taxare implicită"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Descriere"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Durată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Adresă de email"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Activat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Se termină la"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Eroare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Resursă principală"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Prenume"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Cod procesator livrare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Este implicit"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Este privat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Este soluționat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Nume"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Nume"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Comandă plasată la"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID părinte"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Limită utilizare per client"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Permisiuni"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Poziție"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Preț"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Prețurile includ taxa"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Preț cu taxă"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Variante produs"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Progres"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Nume coadă"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Rezultat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Reîncercări"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Vânzător"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Soluționat la"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Linii livrare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Identificator URL"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Început la"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Începe la"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Stare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Niveluri stoc"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Total"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Total cu taxă"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Tip"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Actualizat la"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Limită utilizare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Utilizator"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Valoare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Listă valori"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zonă"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Metodă"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Rezumat taxe"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Setează limbile care sunt disponibile pentru toate canalele. Canalele individuale pot apoi suporta un subset din aceste limbi."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Colecții mutate cu succes"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Înregistrat"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Anulează job"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Se termină la"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Pagina {0} din {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Cotă"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Mărime, culoare etc."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Caută atribute"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zonă"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Anulată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Creată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Livrată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "În așteptare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Expediată"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Salvează vizualizarea"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} selectate"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Caută grupuri de opțiuni..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Modifică comandă"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Elemente selectate"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Valori"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Client setat pentru comandă"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Atribute"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Sigur doriți să eliminați {count} client din acest grup?} few {Sigur doriți să eliminați {count} clienți din acest grup?} other {Sigur doriți să eliminați {count} de clienți din acest grup?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Stoc Disponibil"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Reconstrucția indexului de căutare nu a putut fi pornită"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Adresă de livrare"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Zonă nouă"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Cheie API nouă"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Șterge coloana"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Atribuie existent"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "este nul"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Aceștia sunt clienții din grupul de clienți <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Gestionează vizualizări globale"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Canal implicit"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Inserează o imagine nouă cu sursa, titlul și dimensiunile"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Nu s-a putut crea valoarea atributului"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Nu s-a putut actualiza opțiunea produsului"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Cod cupon"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Client verificat"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Setări globale"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Program"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Nu poți muta o colecție în propriul descendent"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Categorie de Taxă Nouă"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Canalul a fost creat cu succes"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Clientul a fost actualizat cu succes"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Vizualizează datele"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Șterge vizualizarea"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Adaugă o adresă nouă pentru client."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Mai multe vizualizări"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Editează proprietățile imaginii selectate"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Vizualizare \"{viewName}\" aplicată"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Au fost eliminate cu succes {successCount} atribute din canal"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Produs Nou"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Resursă nouă"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Recalculează livrarea"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Resurse"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Se vor elimina toate grupurile de opțiuni de pe acest produs și veți reveni la alegerea configurării variantelor."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Adresă de facturare"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Adaugă valoare pentru atribut"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Te rugăm să selectezi o colecție țintă"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Revizuiește modificările înainte de a le aplica comenzii."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Selectează un rol"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Comandă anulată"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Reducere"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Toate tipurile"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Doar ciornele de comenzi pot fi finalizate"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Nu s-a putut actualiza produsul"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Se ajustează {0} linii"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Adaugă valori atribute"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "după"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Canal"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Sumă"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Număr de Telefon"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Client nou"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Imagine"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administratorul a fost creat cu succes"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Opțiuni Produs"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Selectează țara"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Se creează..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Ești sigur că vrei să ștergi această vizualizare globală? Această acțiune nu poate fi anulată și va afecta toți utilizatorii."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Elimină forțat grupul de opțiuni"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Adăugat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Istoric client"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Valorile atributului au fost actualizate cu succes pentru {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Nu s-a putut elimina clientul din grup"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Sistem"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Limită utilizare per client"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Adresă de facturare schimbată"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Selectează o opțiune"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Copiază la personal"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Totalul rambursării depășește suma maximă rambursabilă de {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Șterge vizualizarea globală"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Creează"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "La fiecare 30 de secunde"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Țară nouă"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "De la {0} la {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Nu s-a putut crea clientul"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Punct focal actualizat"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Valori opțiuni"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Adresă de facturare implicită"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Fără client"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Nu s-au putut elimina țările din zonă"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Nu s-a putut crea promoția"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Astăzi"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Ieri"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Ești sigur că vrei să elimini {0} {1} din această zonă?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Se adaugă suprataxa ({0})"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Link"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Alternativă: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Istoric comandă"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Suprascrie"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "ID-ul tranzacției este obligatoriu"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "se potrivește cu regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Vizualizare globală redenumită cu succes"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Nu sunt selectate etichete"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Înapoi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Vizualizare redenumită cu succes"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Aplică filtru"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Ultimul rezultat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Adăugat la grup"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Perspective"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Se testează metoda de livrare..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Dark"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Rezultate test"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Adaugă client"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Salvează modificările"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adresă actualizată"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Rambursarea a fost procesată cu succes"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Zonă Nouă"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Nu s-a putut actualiza poziția colecției"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Rambursare"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Modifică"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Nu sunt configurate limbi globale"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Se elimină {0} articol(e)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Urmărire"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Creează variantă"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Valori atribut pentru {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Salvează layout"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Resetare parolă verificată"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Nu s-a putut șterge vizualizarea"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Ești sigur că vrei să navighezi din această pagină? Orice modificări nesalvate vor fi pierdute."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Comută coloana antet"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Promoție Nouă"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Nume valoare opțiune"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Ultima utilizare"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Este categoria de taxă implicită"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Identificator-ul URL este setat"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Actualizarea punctului focal a eșuat"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zona a fost actualizată cu succes"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Județ/Provincie"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Nu s-a putut actualiza grupul de opțiuni"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Valori implicite canal"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Nu s-a putut crea categoria de taxă"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Setează criteriile de filtrare pentru coloana {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Țară"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Produs simplu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Coadă de joburi"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Confirmă că ai salvat cheia API înainte de a închide."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Confirmă ștergerea"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Nu s-a putut modifica comanda"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Include taxa de {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Metrici comenzi"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Selectează limba de afișare"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Metode de autentificare"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "început"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Nu s-a putut roti cheia API"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "în"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Caută roluri..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Variante Produs"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Gestionează Vizualizări Globale"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Se procesează..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} găsite"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Selectează intervalul de date"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Produs"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rotește cheia API"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Categorie"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Se mută..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Atribuie"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Vânzătorul a fost creat cu succes"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Metoda de livrare a fost actualizată cu succes"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Nu s-a putut actualiza varianta produsului"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Trage pentru a reordona"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Alegeți ce se întâmplă cu stocul rămas în {count, plural, one {# locație de stoc} few {# locații de stoc} other {# de locații de stoc}} pe care le ștergeți. Toate locațiile selectate își transferă stocul rămas în singura locație pe care o alegeți sau îl elimină."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Caută valori de atribute..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Notă"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Limbi disponibile"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Încarcă încă {0} ({remaining} rămase)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Valori atribut"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Nu s-a putut reordona elementele"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Total Comenzi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Nu s-au găsit metode de livrare eligibile pentru această comandă."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Adaugă opțiune produs"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Livrare"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions trebuie folosit în interiorul unui DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Acest grup de opțiuni este folosit de variante existente. Eliminarea forțată îl poate afecta. Ești sigur?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Actualizare email solicitată"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Eroare la schimbarea statusului"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Grupul de clienți a fost creat cu succes"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Fereastră nouă"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Plată autorizată"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Rolul a fost actualizat cu succes"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Selectează o țară"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Nu s-a putut actualiza metoda de livrare"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {S-a șters {deleted} locație de stoc} few {S-au șters {deleted} locații de stoc} other {S-au șters {deleted} de locații de stoc}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Metode de livrare"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Selectează o adresă"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Da"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Identificator URL"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Setează punctul focal"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "sfârșit"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Selectează o monedă"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Actualizați conținutul sau vizibilitatea notei"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Widget comenzi recente"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Conținut colecție pentru {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Metoda de livrare a fost modificată"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Descriere taxă"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "este mai mic sau egal cu"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "nu este egal cu"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Finalizează plata"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Canale"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Livrare rambursată"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Tip resursă"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Locație Stoc Nouă"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} plată(ți) rambursată(e) înainte de eșec. Verifică istoricul comenzii pentru detalii."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Selectează elementul"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Produs nou"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gestionează Etichete"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Articole rambursate"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Adaugă acțiune"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Duplică {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Elimină din grup"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Nu s-a putut actualiza statusul livrării"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Creează o variantă nouă de produs cu opțiuni, prețuri și stoc"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Atributele private nu sunt vizibile în magazin"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Selectează o categorie de taxă"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Nu rulează"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Atribuit"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Heading 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Selectează limbile disponibile"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Se adaugă {0} articol(e)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Adaugă rând după"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Total taxe"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Starea ciornei comenzii"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Se încarcă locațiile…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Nu s-a putut crea metoda de plată"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Valoarea atributului a fost creată cu succes"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Comandă ciornă ștearsă"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "mai mare decât"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Widget metrici"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Caută monede..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Elimină din canal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Titlu"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Inserează imagine"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Nu s-a putut actualiza vânzătorul"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Țara a fost creată cu succes"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Selectează vânzătorul"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Se încarcă etichetele..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Atributul a fost creat cu succes"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} variante"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Nu s-a putut soluționa plata"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Fără adresă de facturare"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Ștergerea a {1} locație de stoc a eșuat} few {Ștergerea a {2} locații de stoc a eșuat} other {Ștergerea a {2} de locații de stoc a eșuat}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Atribut"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Nu poți elimina din canalul activ"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Nu este setat"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Elimină forțat"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Canal Nou"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Nume Grup Opțiuni"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "ȘI"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Nu s-a putut crea grupul de clienți"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Nu s-a putut crea rolul"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Nume produs"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Status livrare actualizat cu succes"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Produse"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adresă creată"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "Cheia API a fost rotită cu succes"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Adaugă grup de opțiuni"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Rambursare {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Introdu identificator URL manual"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Nu există widgeturi disponibile"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Nu s-a putut anula plata"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Plată anulată cu succes"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Vizualizare globală duplicată cu succes"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Creat de"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtrează variantele..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Adaugă un preț în altă monedă"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Adresă de email sau identificator"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Rambursarea #{0} a trecut la {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Clienți"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Heading 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Nu s-a putut actualiza locația de stoc"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Comandă expediată"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Salvează adresa"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Fă global"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Selectează statusul următor"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Fără alerte"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Se mută {0} colecții în {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "între"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Notă adăugată cu succes"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Notă ștearsă cu succes"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Notă actualizată cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Nu s-a putut soluționa rambursarea"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Nivel stoc"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Adaugă element"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "Cheia API a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Se încarcă previzualizare..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Înapoi la căutare"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Vizualizare duplicată cu succes"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Elimină grupul de opțiuni"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Descriere"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Țări"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Adresă 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Vizualizare globală ștearsă cu succes"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Editează layout"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Atribuie la canal"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Săptămâna aceasta"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Adaugă o plată manuală de {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "este în"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "Email"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Nu s-a putut actualiza administratorul"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Gestionează vizualizările tale personale salvate pentru acest tabel"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtrează după etichete"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Autentifică-te pentru a accesa panoul de administrare"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Fals"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Light"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Resetează"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "este egal cu"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Parolă actualizată"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "nu conține"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Grup de opțiuni"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Editează detaliile adresei de mai jos."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Categoria de taxă a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Nu s-au putut muta colecțiile"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Nu s-a putut actualiza statusul plății"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Rezumatul comenzilor tale"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Încărcare"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Produs cu opțiuni"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Se afișează toate cele {0} rezultate"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "ID de căutare"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ încă {0}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Grupuri de opțiuni"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Câmpuri personalizate"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Toate stările posibile ale comenzii și tranzițiile dintre ele. Starea curentă este evidențiată."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Comenzi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Widget rezumat comenzi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Adăugare articole"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Organizare plată suplimentară"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Organizare plată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Anulată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Creată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Livrată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Ciornă"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "În modificare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Livrată parțial"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Expediată parțial"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Plată autorizată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Plată soluționată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Expediată"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Informații entitate"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Total Comandă"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Vizibil doar pentru administratori"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Cant."
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Etichete"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super Administrator"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Acțiuni disponibile"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Inserează link"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Dacă este activat, filtrele vor fi moștenite de la colecția părinte și combinate cu filtrele setate pe această colecție."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Selectează o zonă"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Testare metode de livrare"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Plată soluționată cu succes"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "Au fost eliminate {0} {1} din zonă"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Activează"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Metode de plată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Autorizată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Anulată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Creată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Refuzată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Eroare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Eșuată"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "În așteptare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Soluționată"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Valoare medie comandă"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Nu s-a putut crea zona"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Niveluri stoc"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Nu s-a putut actualiza cheia API"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Linii comandă"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Nu s-a putut redenumi vizualizarea globală"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Inserează un hyperlink nou cu URL și opțiuni de destinație"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Înălțime"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Este necesară o rambursare de {formattedDiff}. Selectează sumele de plată și introdu o notă pentru a continua."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Preț unitar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Model de planificare"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Plată eșuată"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Adaugă canal"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Caută canale..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Adaugă grupuri de clienți"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Limbi disponibile"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Resetează selecția"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Fără adresă"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Metoda de plată a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Informații client actualizate"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Nu s-a putut converti vizualizarea la globală"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Variante de produse"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Produse"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promoții"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Nu s-a putut crea opțiunea produsului"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Email vechi:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Salvează o vizualizare ca \"Globală\" pentru a o face disponibilă tuturor utilizatorilor."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Nu s-au putut crea variantele"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Setează nivelul de stoc la care o variantă este considerată a fi în afara stocului. Folosirea unei valori negative activează suportul pentru precomandă. Poate fi suprascris de variantele de produs."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rotește cheia"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Ascunde parola"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Vânzător nou"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "ex., Roșu, Large, Bumbac"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Nu s-a putut actualiza profilul"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Coduri cupon eliminate"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Șterge filtru"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regiuni"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Trage fișiere aici pentru încărcare"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Comută toate variantele vizibile"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verificat"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Grup de opțiuni nou"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Nu au fost create încă vizualizări globale."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Nu s-a putut actualiza rolul"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Aceasta este singura dată când cheia API completă va fi afișată. Copiaz-o sau descarc-o acum — nu va putea fi recuperată ulterior."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Colecția a fost actualizată cu succes"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Metoda de plată a fost actualizată cu succes"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Vizualizare ștearsă cu succes"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "SAU"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Gestionează etichete"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Cod cupon eliminat din comandă"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Niciodată"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Nu s-a putut actualiza valoarea atributului"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Comandă livrată"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Fără adresă de livrare"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Extinderea query-ului conține sintaxă GraphQL invalidă"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Eroare în extinderea query-ului"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Eroare în extinderea query-ului: "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Extinderea query-ului este invalidă: trebuie să aibă cel puțin un câmp de nivel superior"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Neconcordanță în extinderea query-ului: "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "public"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Categoria de taxă a fost actualizată cu succes"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Mută"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Editează sau șterge etichete existente"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Condițiile verificării eligibilității acestei metode de livrare nu sunt îndeplinite pentru comanda curentă și adresa de livrare."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Adaugă cod cupon"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Cod cupon setat pentru comandă"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Câmpuri personalizate"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Metodă de Livrare Nouă"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Șterge locațiile de stoc"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "este mai mare sau egal cu"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Previzualizare"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} din {1} disponibile pentru livrare"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Luna până acum"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Cererea clientului"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Deteriorat la transport"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Indisponibil"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Altul"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Articol greșit"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Rezumat modificări"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Rambursări ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Ultima execuție"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Detalii plată"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Reconstruiește indexul de căutare"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Rulează"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "La fiecare 60 de secunde"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Nu s-a putut actualiza grupul de clienți"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Metadate plată"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Anulează modificarea"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Aceeași fereastră"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Aplică filtre la tabel și apasă \"Salvează vizualizare\" pentru a începe."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Roluri"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Plată suplimentară necesară"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Nu s-a putut actualiza comanda"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Cu selecția..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Nu s-a putut crea locația de stoc"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "mai mic sau egal"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Membri grup client pentru {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Stare"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Nu urmări"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Livrare #{0} creată"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Se rulează actualizările în așteptare ale indexului de căutare"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Acesta este un rol implicit și nu poate fi modificat"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Vizualizările mele salvate"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Județ / Provincie"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Activat"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Elemente pe pagină"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Editează membri"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Stoc disponibil"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtrează după {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Alerte"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Valori Opțiuni"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Previzualizează modificările"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Nu s-a putut elimina {entityType} din canal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variantă ștearsă cu succes"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Editează proprietățile linkului selectat"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Vânzări"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Selectează o colecție de destinație"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Comenzile tale recente"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Sarcini programate"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Ești sigur că vrei să ștergi acest element? Această acțiune nu poate fi anulată."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Variante"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Vânzători"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Setări"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Stocare setări"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Heading 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Bun venit la Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Metode de livrare"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} rambursabil)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identificator"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Nu s-a putut actualiza colecția"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Preț și taxă"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Comandă negăsită"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Eroare"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Comandă modificată"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Resetare parolă solicitată"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Suma alocată plății trebuie să fie egală cu totalul rambursării"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Ești sigur că vrei să elimini {0} {entityType} din canalul curent?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Adaugă etichete..."
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} elemente selectate"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Caută limbi..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Locații de stoc"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Mergi la pagina anterioară"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Conținut"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Nu s-a putut converti vizualizarea globală la personală"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Rezultatul job-ului"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Adaugă plată ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Sistem"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Nume variantă"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Elimină"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Nu s-a putut actualiza clientul"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Eliminați grupurile de opțiuni?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Acesta este o previzualizare a conținutului colecției bazată pe setările curente de filtrare. După ce salvați colecția, conținutul va fi actualizat pentru a reflecta noile setări de filtrare."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} client eliminat din grup} few {{count} clienți eliminați din grup} other {{count} de clienți eliminați din grup}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Categorii de taxă"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Cote de taxă"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Eliminarea clienților din grup a eșuat"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Nu s-au putut încărca setările globale"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Selectează articolele de rambursat și, opțional, returnează-le în stoc"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Salvează"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Previzualizează modificările comenzii"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Pagina va continua cu query-ul implicit."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Adresă"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Nu mai sunt atribute"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Reconstrucția indexului de căutare a fost pornită"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Poziția colecției a fost actualizată"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Adaugă \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Variantă produs nouă"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Status rambursare schimbat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Folosind strategia de autentificare nativă"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Nu s-a putut atribui {entityIdsLength} {entityType} canalului"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Limbă implicită"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Se livrează..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Adaugă grup de opțiuni la produs"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Previzualizare a {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Vânzătorul a fost actualizat cu succes"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Nu s-a putut schimba statusul comenzii"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Afișează toate ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Nu s-a putut crea cota de taxă"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Am salvat această cheie API"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Configurează limbile disponibile pentru magazin și canale"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Produsul a fost creat cu succes"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Adaugă variantă produs"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Tastează și apasă Enter sau virgulă pentru a adăuga..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Editează nota"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Nu s-au găsit resurse. Încearcă să ajustezi filtrele."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Adaugă opțiune"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Salvează grup opțiuni"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Apasă \"Rulează test\" pentru a testa această metodă de livrare."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administratorul a fost actualizat cu succes"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Șterge filtre"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Livrare #{0} de la {1} la {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Nu s-a putut șterge vizualizarea globală"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Limbă implicită"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Nu au fost găsite opțiuni"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binar"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Grupul de opțiuni a fost actualizat cu succes"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Metodă de livrare nouă"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "La fiecare 10 secunde"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "fără taxă:"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Valoarea opțiunii a fost adăugată cu succes"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Colecția a fost mutată la un părinte nou"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Grup opțiuni eliminat"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Tranziție la statusul selectat"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Va fi necesară o plată suplimentară de {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Urmărește inventarul implicit"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} din {total} selectate"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Metoda de livrare a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Grup Client Nou"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Vizibil pentru client"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Grupul de opțiuni a fost creat cu succes"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Cote de taxă"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Identificator-ul URL va fi generat automat..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Client negăsit"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Selectează {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Valori atribut noi de adăugat:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Nu s-a putut procesa rambursarea"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Prenume"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "conține"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Nu s-au găsit grupuri de opțiuni"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Nu s-au găsit elemente"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Subtotal"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Articole livrate ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Valoarea a fost actualizată"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Neverificat"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Cantitate"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Adaugă filtru"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Categorie de taxă"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Datele de test au fost actualizate. Faceți clic pe \"Rulează testul\" pentru a vedea rezultatele actualizate."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "nu este în"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Linie comandă actualizată"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Metodă de Plată Nouă"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Valoarea duplicată \"{trimmed}\" există deja"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Motiv"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Grupuri de clienți"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "Au fost eliminate cu succes {entityType} din canal"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Grupuri Opțiuni"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Adaugă suprataxă"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Valori atribut curent"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Pagina {page} din {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Luna trecută"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Adaugă țară"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Elimină element"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "mai mic decât"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Varianta nu a putut fi adăugată. Asigurați-vă că produsul părinte este activat."
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Metrici"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Limbă"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Colecție Nouă"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Rambursează și anulează comanda"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Actualizare email verificată"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "este între"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Rambursare și anulare"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Se testează metodele de livrare..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Nu s-a putut crea metoda de livrare"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "Au fost atribuite cu succes {entityIdsLength} {entityType} canalului"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Limbi globale"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Administrator nou"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Șterge ciorna"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Sursă"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Nu sunt acțiuni disponibile"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Nu s-a putut actualiza canalul"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "General"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Adaugă adresă nouă"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Atributul a fost actualizat cu succes"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zona a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Valoare"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Client actualizat"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Factor conversie preț"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Comandă vânzător"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Atribut nou"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Ești sigur că vrei să elimini acest grup de opțiuni din produs?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Descriere (alternativă)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Nu s-au găsit etichete"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Monedă implicită"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Nu este necesară plată sau rambursare pentru aceste modificări."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Venit Total"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Următoarea execuție"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Nota este privată"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Dată medie"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Număr invalid"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Nu ați salvat încă nicio vizualizare."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Ești sigur că vrei să ștergi această vizualizare? Această acțiune nu poate fi anulată."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Vizualizează procesul comenzii"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Nu s-a putut duplica vizualizarea"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Folosește ca adresă de livrare implicită"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Editează identificator URL manual"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Adaugă filtre pentru a previzualiza conținutul colecției."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "este mai mic decât"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID rambursare"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Câmpuri personalizate comandă actualizate"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Calculator"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Nu s-a putut elimina grupul de opțiuni din canal: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Vizualizează datele job-ului"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Mută la nivel superior"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Șterge"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Rezumat comenzi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Caută resurse..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Atribut Nou"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Atribuie {entityType} la canal"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Continuă"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promoții"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Mesaj eroare"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Adaugă nivel de stoc pentru altă locație"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Șterge adresa"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Nu s-a putut actualiza atributul"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters trebuie folosit în interiorul unui WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Editează adresă"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Nu s-a putut elimina atributul din canal: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Setează linkul"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Vânzător Nou"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Editează imagine"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Gestionează Variante"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Stoc alocat"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "mai mare sau egal"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Setează nivelul stocului la care această variantă este considerată a fi în afara stocului. Folosirea unei valori negative activează suportul pentru comenzi în așteptare."
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Se salvează..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Vizualizează rezultatul"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Rânduri pe pagină"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Se încarcă colecțiile..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Valoarea atributului a fost actualizată cu succes"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Adaugă resursă"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Client adăugat la grup"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Comenzi vânzător"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Nu s-a putut adăuga valoarea opțiunii"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Adaugă valoare opțiune la {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} articol(e) rambursat(e)"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Nu au fost definite încă grupuri de opțiuni. Adaugă grupuri de opțiuni pentru a crea diferite variante ale produsului tău (ex., Mărime, Culoare, Material)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Email nou:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Nu s-a putut actualiza metoda de plată"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Disponibil:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Creat la"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Nu s-a putut crea varianta produsului"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Limbă: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Nu aveți permisiunea de a vizualiza setările globale ale limbii"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Cota de taxă a fost creată cu succes"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Heading 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Coduri cupon adăugate"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Activă"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Baza de taxare"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Încarcă mai multe"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Rambursare soluționată"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "Cheie API"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "Au fost duplicate cu succes {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Grup de opțiuni nou"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Fără rezultat încă"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Plată soluționată"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Condiții disponibile"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Filtre active"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Șterge tot"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "este mai mare decât"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Închide"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Adaugă plată la comandă"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Se încarcă..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Token-ul este folosit pentru a specifica canalul la efectuarea cererilor API."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Nu s-au găsit adrese"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID livrare"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Selectează plățile de rambursat"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Nu s-au putut șterge {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Prag stoc epuizat"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Nu s-a putut actualiza valoarea"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Nu s-a putut crea cheia API"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Finalizează rambursarea"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Metoda de plată este obligatorie"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Nu s-a putut adăuga clientul la grup"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Gestionează variante"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Vizualizare globală \"{viewName}\" aplicată"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Client înregistrat"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zone"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Caută vânzători..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Promoția a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Opțiune"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Procesul comenzii"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Număr de telefon"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privat"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variantă"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Setările globale au fost actualizate cu succes"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "Cheia API a fost actualizată cu succes"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Aceste limbi vor fi disponibile pentru toate canalele"

--- a/packages/dashboard/src/i18n/locales/ru.po
+++ b/packages/dashboard/src/i18n/locales/ru.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Полное имя"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Выбрать элементы"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Посмотреть изменения"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Код отслеживания"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Выбранные разрешения будут применены к этим каналам."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Опции товара"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Новая налоговая ставка"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Назначить существующую группу опций или создать новую"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Новая роль"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Квартира, офис и т.д."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Больше нет элементов"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Редактировать ссылку"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Добавьте хотя бы один товар в заказ"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Добавьте товары для создания тестового заказа"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Не удалось создать адрес"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Переключить всё"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Редактировать значение JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Использование внешней стратегии аутентификации: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Выберите причину..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Заголовок 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Не удалось добавить платёж"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Обновлено"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Не удалось обновить глобальные настройки"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Заказ успешно выполнен"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Вы уверены, что хотите удалить {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Глобальный порог отсутствия на складе"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Управление языками"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Дублирование... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Успешно удалено"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Удалить из текущего канала"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Удалено {selectionLength} ресурсов"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Налоговая ставка успешно обновлена"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Введите свою причину..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Тип"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Выбрать {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Посмотреть значения"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Удалить строку"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Условия"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Текущий"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Нет выполнений"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Не удалось удалить {1} складскую локацию: {messages}} few {Не удалось удалить {2} складские локации: {messages}} many {Не удалось удалить {2} складских локаций: {messages}} other {Не удалось удалить {2} складских локаций: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "При включении цены, введённые в каталоге товаров, будут включать налог для зоны по умолчанию."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Создайте варианты для вашего товара"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Черновик заказа завершён"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Автообновление: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr "Успешно отменена {fulfilled} задача"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Проверки состояния"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Удалено {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Проверки состояния"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Продавцы"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Опции"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {Успешно отменена {fulfilled} задача} few {Успешно отменены {fulfilled} задачи} many {Успешно отменено {fulfilled} задач} other {Успешно отменено {fulfilled} задач}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Продавец"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "Артикул:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Добавить платёж"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Проверьте этот способ доставки, симулируя заказ, чтобы узнать, подходит ли он и какова будет стоимость доставки."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Изучить Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Складские местоположения"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Обработчик выполнения"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Заказы"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Выбрать роли"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Роль успешно создана"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Вы уверены, что хотите удалить этот вариант?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Все ресурсы работают"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Не удалось создать администратора"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Нет"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Вариант товара успешно обновлён"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Не удалось удалить {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Товар успешно обновлён"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Не удалось обновить страну"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Введите минимум 2 символа для поиска..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Фамилия"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Заголовок ссылки"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Группа клиентов успешно обновлена"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Пользовательские поля изменены"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Место хранения успешно создано"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Неизвестная ошибка"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Сумма возврата не может быть отрицательной"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Посмотреть детали"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Выберите канал для назначения {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Клиент успешно создан"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Последние 7 дней"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Не удалось создать канал"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Режим разработчика"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Новая роль"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Не удалось удалить ресурсы: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Вернуть на склад"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Видимость"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Варианты товара"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Новая группа клиентов"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Создать «{0}»"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Переименовать"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Выберите предпочитаемый язык отображения и настройки локали"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "Успешно удалено {successCount} групп опций из канала"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Способ доставки не подходит для этого заказа"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Не удалось обновить адрес"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Адрес успешно удален"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Налоговая ставка"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Черновик заказа не готов к завершению"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Новая коллекция"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Аналитика"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Запустить"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Не удалось обновить налоговую ставку"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Это содержимое коллекции <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "приватное"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Вариант продукта успешно создан"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Родительский товар"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Город"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Администраторы"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Общая цена: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Перейти на следующую страницу"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Удалить ссылку"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Это поле доступно только для чтения"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Количество заказов"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Заказ успешно обновлён"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Наследовать фильтры"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Управление глобальными сохранёнными представлениями, видимыми для всех пользователей"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Поиск способов оплаты..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Адрес доставки снят для заказа"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Создать {enabledCount} вариантов"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Платёж #{0} переведён в {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Ошибка загрузки истории клиента: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} успешно удалено из канала"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Добавить значение опции"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Глобальные настройки"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "после"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Вариант продукта успешно обновлён"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Редактировать значения фасета"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Добавление..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Переместить коллекции"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Роли"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Вид сеткой"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Не удалось удалить адрес"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Способы доставки недоступны"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Глобальное представление успешно преобразовано в личное"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Выполнение переведено"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Вы уверены, что хотите удалить {selectionLength} ресурсов?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Войти"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Вид списком"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Тестовый заказ"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Выберите клиента для продолжения"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Группа опций успешно назначена"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Запустить тест"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Налоговая ставка: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Пожалуйста, добавьте товары и укажите адрес доставки для запуска теста."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Переключить строку заголовка"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Выбрать адрес"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Проверка соответствия платежа"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Налоговая зона по умолчанию"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Черновик заказа готов к завершению"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Метаданные"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr "Не удалось задать способ доставки для заказа: {0}"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Фильтровать..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Новое значение фасета"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Канал успешно обновлён"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Показать меньше"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Короткая дата"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Доступные валюты"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Выбрать {0} элементов"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Оформлен"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Ротация этого ключа немедленно аннулирует текущий ключ. Все интеграции, использующие его, перестанут работать до обновления нового ключа."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Данные, переданные задаче"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Подтвердить переход"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Цель ссылки"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Завершить черновик"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Название"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Не удалось выполнить заказ"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Итого"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Введите ID транзакции для этого расчёта возврата"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Ваш API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Вы уверены, что хотите удалить этот черновик заказа?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Выполнение создано"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Найдено {0} подходящих способ(ов) доставки"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Размеры"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Показать пароль"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(макс: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Компания"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Добавить столбец после"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Действия"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Скидки"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Введите примечание к возврату"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Строка заказа удалена"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Содержимое:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Ключ"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Подтвердить"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr "Не удалось завершить черновик заказа: {0}"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Не удалось создать коллекцию"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Перейти на первую страницу"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Не удалось создать товар"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Клиент"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Ошибка загрузки истории заказов: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Адрес доставки установлен для заказа"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Фокусная точка"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Один вариант, без опций"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Выберите следующее состояние для заказа"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Локаль"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Запланированные задачи"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Введите ID транзакции"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Обновить данные"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Добавить или удалить значения фасета для {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Это значения фасета для фасета <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Платёж успешно добавлен к заказу"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Адрес выставления счета установлен для заказа"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Не удалось обновить зону"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Пароль"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Не удалось удалить"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Запланированная задача будет выполнена"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Новое место хранения"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Разрешения"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Адрес доставки изменён"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Товары не найдены"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Добавить строку до"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Перейти в {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Этот месяц"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Не удалось создать фасет"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Не удалось отменить позиции заказа"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID транзакции"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Выделено"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Добавить ещё одну группу опций"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr "Не удалось применить промокод к заказу: {0}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Выберите, что сделать с остатками товара"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Обзор Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Каждые 5 секунд"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Коллекция успешно создана"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Цена"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Черновик заказа"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Область действия"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Добавить условие"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Способ доставки подходит для этого заказа"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Администраторы"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Удалено из группы"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Ширина"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Не требуется платёж или возврат"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Скачать как файл .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "При включении акция доступна в магазине"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "При отслеживании уровни запасов вариантов товара будут автоматически корректироваться при продаже. Эту настройку можно переопределить для отдельных вариантов товара."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Способ доставки установлен для заказа"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Не удалось обновить акцию"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Изображения"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Поиск {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Редактировать ресурс"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Отменить платеж"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Очередь задач"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Ресурсы"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Адрес электронной почты"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr "Не удалось удалить промокод из заказа: {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Перегенерировать slug из исходного поля"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Наследовать из глобальных настроек"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Результаты не найдены"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Текущий статус"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Укажите адрес доставки и выберите способ доставки"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Выкл."
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Хранилище настроек"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Очередь"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Новая налоговая ставка"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Платёж переведён"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Осталось:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Дупликатор с кодом «{duplicatorCode}» для {entityName} не найден"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Цены включают налог для зоны по умолчанию"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Итого возврат:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Посмотреть результат задачи"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Проверьте свои способы доставки, симулируя новый заказ."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Элементы не выбраны"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} выбрано"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Страны не найдены"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Варианты успешно созданы"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Генерировать slug автоматически"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Доплата"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Способы оплаты"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Запас"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Клиенты не найдены"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Использовать глобальный порог отсутствия на складе"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Новая группа опций товара"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Состояние платежа успешно обновлено"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Создать новый"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Сумма возврата"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Адрес удалён"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Доступны только роли, назначенные вашей учётной записи."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr "{cancellableCount, plural, one {Отменить {cancellableCount} задачу} few {Отменить {cancellableCount} задачи} many {Отменить {cancellableCount} задач} other {Отменить {cancellableCount} задачи}}"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Товар добавлен к заказу"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Изменить фокусную точку"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Продавцы не найдены"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Ресурс"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Эта группа опций используется ещё одним товаром. Изменения затронут и его.} other {Эта группа опций используется в # товарах. Изменения затронут их все.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Мои сохранённые представления"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Новый канал"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Не удалось создать продавца"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Настройте параметры дублирования для {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Нет вариантов, соответствующих текущему фильтру."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Адреса"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Добавить новое значение опции в группу опций {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Изменение заказа #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Добавить столбец до"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Языки канала"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Не удалось создать группу опций"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Истина"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Выбрать клиента"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Заказ переведён"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "У этого товара есть существующие варианты, но не определены группы опций. Вам нужно добавить группы опций перед созданием новых вариантов."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "до"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Удалить черновик заказа"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Каталог"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Новый способ оплаты"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Акция успешно обновлена"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Не удалось отменить {rejected} задачу} few {Не удалось отменить {rejected} задачи} many {Не удалось отменить {rejected} задач} other {Не удалось отменить {rejected} задач}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Выберите канал"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Язык отображения"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Детали выполнения"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Списать остатки товара"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Сейчас"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Каналы"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Представление успешно преобразовано в глобальное"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "до"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr "Не удалось задать клиента для заказа: {0}"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Размер"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Перевод для {0} не найден"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Новый клиент"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Последние заказы"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ ещё {leftOver}"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Использовать как адрес выставления счёта по умолчанию"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Удалить"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Отключить"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Коллекции"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Добавить вариант"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Не удалось создать страну"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Страны"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Не удалось создать опции товара"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Не удалось переименовать представление"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Доступно"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Обычный"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Фильтры"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Группы клиентов"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Клиенты"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Пример форматирования"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Новая опция"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Лимит использования"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Загрузка глобальных настроек..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Адрес успешно обновлен"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Создано"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Загрузка адресов..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Выберите целевую коллекцию для перемещения {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr "Не удалось удалить адрес выставления счёта заказа: {0}"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Данные клиента обновлены"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "не в"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Применить"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Новая опция товара"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Перейти на последнюю страницу"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Отменить"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr "Не удалось обновить пользовательские поля заказа: {0}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Вариант товара успешно создан"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Возврат этим способом"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Почтовый индекс"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Сначала добавьте опции товара"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Новая налоговая категория"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Добавить опцию"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Частичный возврат завершён"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Установить пользовательские поля"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Коллекции"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Удалить вариант"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Изменения не внесены"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Зона доставки по умолчанию"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Причина:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Адрес доставки"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Перейти в {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Налоговые категории"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Приватные коллекции не видны в магазине"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "При включении товар доступен в магазине"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Запланированная задача не может быть выполнена"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Группы клиентов"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Отключено"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Новая акция"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Адрес доставки по умолчанию"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Требуется возврат"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Выполнить заказ"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "У вас нет разрешения на просмотр настроек канала"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Последние 30 дней"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Нет значений фасета"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Требуется указать причину возврата"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Не удалось удалить группу опций"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Не удалось обновить налоговую категорию"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Возврат успешно проведён"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Обновить"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Заголовок 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Заказ размещён"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Профиль успешно обновлён"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "конец"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Способ оплаты"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Редактировать"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Вариант успешно обновлён"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Фильтровать по названию коллекции"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Заметка добавлена"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Выберите количество для выполнения и настройте обработчик выполнения"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Адрес выставления счета удален из заказа"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Начинается"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Дублировать"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Нет результатов"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Настройки столбцов"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Не удалось удалить {count} складскую локацию} few {Не удалось удалить {count} складские локации} many {Не удалось удалить {count} складских локаций} other {Не удалось удалить {count} складских локаций}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Код"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Не удалось удалить группы опций"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Заказ доставлен"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Перенести в {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Остатки товара"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Удалить из зоны"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Выберите из глобально доступных языков для этого канала"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Вы уверены, что хотите удалить этот адрес?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Не удалось назначить группу опций"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Не удалось обновить ресурс"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Место хранения успешно обновлено"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Подтвердить действие"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Страна успешно обновлена"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Аспекты"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Не удалось добавить заметку"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Не удалось удалить заметку"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Не удалось расширить документ запроса"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Не удалось обновить заметку"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Вернуть стоимость доставки"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Только для чтения"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Не удалось дублировать глобальное представление"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Показано {shown} из {total} • выбрано {selected}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Проверить способ доставки"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Значения фасета"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Ресурс успешно обновлён"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Тема"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} клиентов"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Выберите язык"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Выйти"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Попытки"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Доступные коды валют"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Доступные коды языков"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Хлебные крошки"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Категория"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Каналы"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Дочерние элементы"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Код"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Код купона"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Создан"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Код валюты"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Клиент"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Группа клиентов"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Клиенты"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Пользовательские поля"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Данные"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Код валюты по умолчанию"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Код языка по умолчанию"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Зона доставки по умолчанию"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Налоговая зона по умолчанию"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Описание"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Длительность"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Адрес электронной почты"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Включен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Заканчивается"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Ошибка"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Избранный ресурс"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Имя"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Код обработчика выполнения"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "По умолчанию"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Приватный"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Проведён"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Фамилия"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Название"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Заказ размещён"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID родителя"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Лимит использования на клиента"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Разрешения"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Позиция"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Цена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Цены включают налог"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Цена с налогом"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Варианты товара"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Прогресс"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Название очереди"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Результат"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Повторные попытки"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Продавец"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Проведен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Строки доставки"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Начат"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Начинается"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Состояние"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Уровни запасов"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Токен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Итого"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Итого с налогом"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Тип"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Обновлен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Лимит использования"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Пользователь"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Значение"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Список значений"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Зона"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Метод"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Налоговая сводка"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Устанавливает языки, доступные для всех каналов. Отдельные каналы затем могут поддерживать подмножество этих языков."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Коллекции успешно перемещены"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Зарегистрирован"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr "Не удалось задать адрес доставки для заказа: {0}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Отменить задачу"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Заканчивается"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Страница {0} из {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Ставка"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Размер, цвет и т.д."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Просмотр фасетов"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Зона"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Отменен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Создано"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Доставлен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "В ожидании"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Отправлен"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Сохранить вид"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} выбрано"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Поиск групп опций..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Изменить заказ"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Выбранные элементы"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Значения"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Клиент установлен для заказа"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Аспекты"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Вы уверены, что хотите удалить {count} клиента из этой группы?} few {Вы уверены, что хотите удалить {count} клиента из этой группы?} many {Вы уверены, что хотите удалить {count} клиентов из этой группы?} other {Вы уверены, что хотите удалить {count} клиентов из этой группы?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Запас в наличии"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Не удалось начать перестроение поискового индекса"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Адрес доставки"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Новая зона"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Новый API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Удалить столбец"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Назначить существующую"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "пусто"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Это клиенты из группы клиентов <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Управление глобальными представлениями"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Канал по умолчанию"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Вставить новое изображение с источником, заголовком и размерами"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Не удалось создать значение фасета"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Не удалось обновить вариант продукта"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Забыли пароль?</0><1>Запросить сброс</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Код купона"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Клиент верифицирован"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Глобальные настройки"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Расписание"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Невозможно переместить коллекцию в её собственного потомка"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Новая налоговая категория"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "В текущем канале нет доступных мест хранения"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Канал успешно создан"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Клиент успешно обновлён"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Посмотреть данные"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Удалить представление"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Добавить новый адрес клиенту."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Больше представлений"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Редактировать свойства выбранного изображения"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Применен вид „{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} фасетов успешно удалено из канала"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Новый товар"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Новый ресурс"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Пересчитать доставку"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Выберите, какие опции должны применяться к существующему варианту «{0}»"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Ресурсы"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Это удалит все группы опций из этого товара и вернёт к выбору настройки вариантов."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Адрес выставления счёта"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Добавить значение фасета"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Пожалуйста, выберите целевую коллекцию"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Просмотрите изменения перед их применением к заказу."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Выберите роль"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Заказ отменён"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Скидка"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Все типы"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Только черновики заказов могут быть завершены"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Не удалось обновить товар"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Корректировка {0} строк"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Добавить значения фасета"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "после"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Канал"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Проверки состояния"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Сумма"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Номер телефона"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Новый клиент"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Изображение"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Администратор успешно создан"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Опции товара"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Выбрать страну"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Создание..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Вы уверены, что хотите удалить это глобальное представление? Это действие нельзя отменить, и оно повлияет на всех пользователей."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Принудительно удалить группу опций"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Добавлено"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "История клиента"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Значения фасета успешно обновлены для {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Не удалось удалить клиента из группы"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Система"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Лимит использования на клиента"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Адрес выставления счёта изменён"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Выберите опцию"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Копировать в личные"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Сумма возврата превышает максимальную сумму к возврату {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Удалить глобальное представление"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Создать"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Каждые 30 секунд"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Новая страна"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "С {0} по {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Не удалось создать клиента"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Фокусная точка обновлена"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Значения опций"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Адрес выставления счёта по умолчанию"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Нет клиента"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Не удалось удалить страны из зоны"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Не удалось создать акцию"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Сегодня"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Вчера"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Название опции"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Вы уверены, что хотите удалить {0} {1} из этой зоны?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Добавление {0} доплат(ы)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Ссылка href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Резервное значение: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "История заказов"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Переопределить"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "ID транзакции обязателен"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "соответствует regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Глобальное представление успешно переименовано"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Теги не выбраны"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Назад"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Представление успешно переименовано"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Применить фильтр"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Последний результат"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Добавлено в группу"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Аналитика"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Создать варианты"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Проверка способа доставки..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Тёмная"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Результаты тестирования"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Добавить клиента"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Сохранить изменения"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Адрес обновлён"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Возврат успешно обработан"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Новая зона"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Не удалось обновить позицию коллекции"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Возврат"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Изменить"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Глобальные языки не настроены"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Удаление {0} элемент(ов)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Отслеживать"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Создать вариант"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Значения фасета для {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Сохранить макет"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Сброс пароля подтверждён"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Не удалось удалить представление"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Вы уверены, что хотите покинуть эту страницу? Все несохранённые изменения будут потеряны."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Переключить столбец заголовка"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Новая акция"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Название значения опции"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Последнее использование"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Налоговая категория по умолчанию"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug установлен"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Не удалось обновить фокусную точку"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Зона успешно обновлена"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Регион/Область"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Не удалось обновить группу опций"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Настройки канала по умолчанию"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Не удалось создать налоговую категорию"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Задать критерии фильтрации для столбца {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Страна"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Простой товар"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Очередь задач"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Пожалуйста, подтвердите, что вы сохранили API key перед закрытием."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Подтвердить удаление"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Не удалось изменить заказ"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Включая налог {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Метрики заказов"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Выберите язык отображения"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Методы аутентификации"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "начало"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Не удалось выполнить ротацию API key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "в"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Поиск ролей..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr "Успешно отменено {fulfilled} задач"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Варианты товаров"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Управление глобальными представлениями"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Обработка..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} найдено"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Выберите период"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Товар"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Ротация API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Категория"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Перемещение..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Назначить"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Продавец успешно создан"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Способ доставки успешно обновлён"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Не удалось обновить вариант товара"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Перетащите для изменения порядка"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Зоны"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Выберите, что сделать с остатками товара в {count, plural, one {# складской локации} few {# складских локациях} many {# складских локациях} other {# складских локациях}}, которые вы удаляете. Все выбранные локации перенесут свои остатки в одну выбранную вами локацию или спишут их."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Поиск значений фасетов..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Примечание"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Доступные языки"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Загрузить ещё {0} (осталось {remaining})"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Значения фасета"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Не удалось изменить порядок позиций"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Всего заказов"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Для этого заказа не найдено подходящих способов доставки."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Добавить опцию товара"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Доставка"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions должен использоваться внутри DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Эта группа опций используется существующими вариантами. Принудительное удаление может повлиять на эти варианты. Вы уверены?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Запрошено обновление электронной почты"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Ошибка перехода в состояние"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Группа клиентов успешно создана"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Новое окно"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Платёж авторизован"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Роль успешно обновлена"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Выберите страну"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Не удалось обновить способ доставки"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Удалена {deleted} складская локация} few {Удалены {deleted} складские локации} many {Удалено {deleted} складских локаций} other {Удалено {deleted} складских локаций}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Способы доставки"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Выберите адрес"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Да"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Установить фокусную точку"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "конец"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Выберите валюту"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Обновить содержимое или видимость заметки"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Виджет последних заказов"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Содержимое коллекции {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Способ доставки изменён"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Описание налога"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "меньше или равно"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "не равно"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Обновить"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "например, Размер"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Провести платёж"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Каналы"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Доставка возвращена"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Тип ресурса"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Новое место хранения"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} платеж(ей) возвращено до ошибки. Проверьте историю заказа для подробностей."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Выбрать элемент"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Новый товар"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Управление тегами"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Товары возвращены"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Добавить действие"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Назначить опции существующему варианту"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Дублировать {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Удалить из группы"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Не удалось обновить состояние выполнения"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Создать новый вариант товара с опциями, ценами и запасами"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Приватные фасеты не видны в магазине"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Выберите налоговую категорию"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Создан"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Не выполняется"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Назначено"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Заголовок 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Выбрать доступные языки"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Добавление {0} элемент(ов)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Добавить строку после"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Итого налог"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Статус черновика заказа"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Опции товара успешно созданы"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Загрузка локаций…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Не удалось создать способ оплаты"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Значение фасета успешно создано"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Маркетинг"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Черновик заказа удалён"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "больше чем"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Виджет метрик"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Поиск валют..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Удалить из канала"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Заголовок"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Вставить изображение"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Не удалось обновить продавца"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Страна успешно создана"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Выбрать продавца"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Загрузка тегов..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Фасет успешно создан"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} вариантов"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Не удалось провести платёж"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Нет адреса выставления счёта"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Не удалось удалить {1} складскую локацию} few {Не удалось удалить {2} складские локации} many {Не удалось удалить {2} складских локаций} other {Не удалось удалить {2} складских локаций}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Фасет"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Невозможно удалить из активного канала"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Не установлено"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Принудительно удалить"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Новый канал"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Название группы опций"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "И"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Не удалось создать группу клиентов"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Не удалось создать роль"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Название товара"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Состояние выполнения успешно обновлено"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Товары"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Адрес создан"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API key успешно обновлён"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Добавить группу опций"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Вернуть {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Введите slug вручную"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Нет доступных виджетов"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Не удалось отменить платёж"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Платёж успешно отменён"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Глобальное представление успешно дублировано"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Создано"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Фильтровать варианты..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Добавить цену в другой валюте"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Адрес электронной почты или идентификатор"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Возврат #{0} переведён в {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Клиенты"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Заголовок 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Не удалось обновить место хранения"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Заказ отправлен"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Сохранить адрес"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Сделать глобальным"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Выбрать следующее состояние"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Нет оповещений"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Перемещение {0} коллекций в {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Тест"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "между"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Заметка успешно добавлена"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Заметка успешно удалена"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Заметка успешно обновлена"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Не удалось провести возврат"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Уровень запаса"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Добавить элемент"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API key успешно создан"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Загрузка предпросмотра..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Вернуться к поиску"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Представление успешно дублировано"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Удалить группу опций"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Описание"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Страны"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr "Не удалось удалить позицию заказа: {0}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Улица (строка 2)"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Глобальное представление успешно удалено"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Изменить макет"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Назначить каналу"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Эта неделя"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Группа опций товара успешно создана"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Добавить ручной платёж {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "в"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "Эл. почта"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Не удалось обновить администратора"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Управление вашими личными сохранёнными представлениями для этой таблицы"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Фильтровать по тегам"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Войдите для доступа к панели администратора"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Добавить платёж к заказу ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Ложь"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Светлая"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Сбросить"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "равно"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Создать опции"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Пароль обновлён"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "не содержит"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Группа опций"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Отредактируйте данные адреса ниже."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Налоговая категория успешно создана"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Не удалось переместить коллекции"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Не удалось обновить состояние платежа"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Сводка по вашим заказам"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Загрузить"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Товар с опциями"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Показаны все {0} результатов"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Идентификатор поиска"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ ещё {0}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Группы опций"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Пользовательские поля"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Все возможные статусы заказа и их переходы. Текущий статус выделен."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Заказы"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Виджет сводки заказов"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Добавление товаров"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Организация дополнительного платежа"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Организация оплаты"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Отменён"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Создан"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Доставлен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Черновик"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Изменение"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Частично доставлен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Частично отправлен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Оплата авторизована"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Оплата проведена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Отправлен"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Отслеживаемые ресурсы"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Информация об объекте"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Сумма заказа"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Видно только администраторам"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Кол-во"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Теги"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Суперадминистратор"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Некоторые ресурсы недоступны"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Доступные действия"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr "Не удалось обновить позицию заказа: {0}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Вставить ссылку"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Если включено, фильтры будут унаследованы от родительской коллекции и объединены с фильтрами, установленными для этой коллекции."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Выберите зону"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Проверить способы доставки"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Платёж успешно проведён"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} удалено из зоны"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Включить"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Способы оплаты"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Авторизован"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Отменен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Создан"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Отклонен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Ошибка"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Неудачный"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "В ожидании"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Проведен"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Средняя сумма заказа"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Не удалось создать зону"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Уровни запасов"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Не удалось обновить API key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Строки заказа"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Не удалось переименовать глобальное представление"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Вставить новую гиперссылку с URL и параметрами цели"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Высота"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Требуется возврат в размере {formattedDiff}. Выберите суммы платежей и введите примечание для продолжения."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Цена за единицу"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Шаблон расписания"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Платёж не прошёл"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Добавить канал"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Не удалось обновить группу опций товара"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Поиск каналов..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Добавить группы клиентов"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Доступные языки"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Сбросить выбор"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Нет адреса"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Способ оплаты успешно создан"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Информация о клиенте обновлена"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr "Не удалось удалить черновик заказа: {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Не удалось преобразовать представление в глобальное"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Варианты товаров"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Товары"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Акции"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Не удалось создать вариант продукта"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Старая электронная почта:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Сохраните представление как «Глобальное», чтобы сделать его доступным для всех пользователей."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Не удалось создать варианты"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Устанавливает уровень запасов, при котором этот вариант считается отсутствующим на складе. Использование отрицательного значения включает поддержку предзаказов. Может быть переопределено вариантами товара."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Ротация ключа"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Не удалось создать варианты товара"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Скрыть пароль"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Новый продавец"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "например, Красный, Большой, Хлопок"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Не удалось обновить профиль"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Коды купонов удалены"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Очистить фильтр"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Регионы"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Перетащите файлы сюда для загрузки"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Переключить все видимые варианты"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Верифицирован"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Новая группа опций"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Последнее обновление {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Глобальные представления ещё не созданы."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Не удалось обновить роль"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Это единственный раз, когда полный API key будет отображён. Скопируйте или скачайте его сейчас — позже его нельзя будет получить."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Коллекция успешно обновлена"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Способ оплаты успешно обновлён"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Представление успешно удалено"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Группа опций {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "ИЛИ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Управление тегами"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Код купона удален из заказа"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Никогда"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Не удалось обновить значение фасета"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Удалить группу"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Заказ выполнен"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr "Не удалось задать адрес выставления счёта для заказа: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Нет адреса доставки"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Расширение запроса содержит недопустимый синтаксис GraphQL"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Ошибка расширения запроса"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Ошибка расширения запроса: "
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Расширение запроса недействительно: должно иметь хотя бы одно поле верхнего уровня"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Несоответствие расширения запроса: "
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "публичное"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Налоговая категория успешно обновлена"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Переместить"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Редактировать или удалить существующие теги"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Условия проверки соответствия этого способа доставки не выполнены для текущего заказа и адреса доставки."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Добавить код купона"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Код купона установлен для заказа"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Пользовательские поля"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Новый способ доставки"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Удалить складские локации"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "больше или равно"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} из {1} доступно для выполнения"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "С начала месяца"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Запрос клиента"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Повреждён при доставке"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Недоступен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Другое"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Неверный товар"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Сводка изменений"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Возвраты ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Последнее выполнение"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Детали платежа"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Перестроить поисковый индекс"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Выполняется"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Каждые 60 секунд"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Не удалось обновить группу клиентов"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Метаданные платежа"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Отменить изменение"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "То же окно"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Примените фильтры к таблице и нажмите «Сохранить представление» для начала."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Роли"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Требуется дополнительный платёж"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Не удалось обновить заказ"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "С выбранными..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Не удалось создать место хранения"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "меньше или равно"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Участники группы клиентов {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Регион"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Не отслеживать"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Выполнение #{0} создано"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Выполнение ожидающих обновлений поискового индекса"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Это роль по умолчанию, и её нельзя изменить"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Мои сохранённые представления"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Регион / Область"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Включено"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Элементов на странице"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Редактировать участников"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Запас в наличии"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Фильтровать по {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Оповещения"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Значения опций"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Просмотр изменений"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Не удалось удалить {entityType} из канала"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Вариант успешно удалён"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Редактировать свойства выбранной ссылки"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Продажи"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Выберите целевую коллекцию"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Ваши последние заказы"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Запланированные задачи"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Вы уверены, что хотите удалить этот элемент? Это действие нельзя отменить."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Варианты"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Продавцы"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Настройки"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Хранилище настроек"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Заголовок 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Добро пожаловать в Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Способы доставки"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} к возврату)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Идентификатор"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Не удалось обновить коллекцию"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Цена и налог"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Заказ не найден"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Ошибка"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Заказ изменён"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Запрошен сброс пароля"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Выделенная сумма платежа должна равняться сумме возврата"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "например, Маленький"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Вы уверены, что хотите удалить {0} {entityType} из текущего канала?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Добавить теги..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Не удалось создать группу опций товара"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} элементов выбрано"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Поиск языков..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Складские местоположения"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Перейти на предыдущую страницу"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Содержимое"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr "Не удалось отменить {rejected} задач"
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Не удалось преобразовать глобальное представление в личное"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Результат задачи"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Добавить платёж ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Система"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Название варианта"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Удалить"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Не удалось обновить клиента"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Удалить группы опций?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Это предварительный просмотр содержимого коллекции на основе текущих настроек фильтра. После сохранения коллекции содержимое будет обновлено, чтобы отразить новые настройки фильтра."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} клиент удалён из группы} few {{count} клиента удалено из группы} many {{count} клиентов удалено из группы} other {{count} клиентов удалено из группы}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Налоговые категории"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Налоговые ставки"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Не удалось удалить клиентов из группы"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Не удалось загрузить глобальные настройки"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Выберите позиции для возврата и при необходимости верните на склад"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Сохранить"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "Выбрано {selectedRowCount} из {0} строк(и)."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Просмотр изменений заказа"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Группа опций товара успешно обновлена"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Страница продолжит работу с запросом по умолчанию."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Улица"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Больше нет фасетов"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Начато перестроение поискового индекса"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Позиция коллекции обновлена"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Название группы опций"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Добавить «{newOptionInput}»"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Новый вариант товара"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Возврат переведён"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Использование встроенной стратегии аутентификации"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Не удалось назначить {entityIdsLength} {entityType} каналу"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Язык по умолчанию"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Токен"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Выполнение..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Добавить группу опций к товару"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Предварительный просмотр {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Продавец успешно обновлён"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Не удалось перевести заказ в состояние"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Показать все ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Не удалось создать налоговую ставку"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Я сохранил этот API key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Настройте доступные языки для вашего магазина и каналов"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Товар успешно создан"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Добавить вариант товара"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Введите и нажмите Enter или запятую для добавления..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Редактировать заметку"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Ресурсы не найдены. Попробуйте изменить фильтры."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Добавить опцию"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Сохранить группу опций"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Создать {createCount} вариант(ов)"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Нажмите «Запустить тест» для проверки этого способа доставки."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Администратор успешно обновлен"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Очистить фильтры"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Выполнение #{0} с {1} по {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Не удалось удалить глобальное представление"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Язык по умолчанию"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Статус"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Опции не найдены"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Бинарный"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Группа опций успешно обновлена"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Новый способ доставки"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Каждые 10 секунд"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "без налога:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Добавить запас в место хранения"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Значение опции успешно добавлено"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Коллекция перемещена в новый родительский элемент"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Группа опций удалена"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Перейти в выбранное состояние"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Потребуется дополнительный платёж в размере {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Отслеживать запасы по умолчанию"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "Выбрано {selected} из {total}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Способ доставки успешно создан"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Новая группа клиентов"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Видно клиенту"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Группа опций успешно создана"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Налоговые ставки"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug будет сгенерирован автоматически..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Клиент не найден"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Выбрать {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Новые значения фасета для добавления:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Не удалось обработать возврат"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Имя"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "содержит"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Группы опций не найдены"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Элементы не найдены"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Промежуточный итог"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Выполненные товары ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Значение обновлено"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Не верифицирован"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Количество"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Добавить фильтр"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Налоговая категория"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Профиль"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Тестовые данные обновлены. Нажмите «Запустить тест» для просмотра обновлённых результатов."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "не в"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Строка заказа обновлена"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Новый способ оплаты"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Дублирующееся значение \"{trimmed}\" уже существует"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Причина"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Группы клиентов"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} успешно удалён из канала"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Группы опций"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Добавить доплату"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Текущие значения фасета"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Страница {page} из {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr "Не удалось отменить {rejected} задачу"
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Прошлый месяц"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Добавить страну"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Удалить элемент"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Видео"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "меньше чем"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Не удалось добавить вариант. Убедитесь, что родительский товар включен."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Произошла неизвестная ошибка"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Метрики"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Язык"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Новая коллекция"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Возврат и отмена заказа"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Обновление электронной почты подтверждено"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "между"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Возврат и отмена"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Проверка способов доставки..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Не удалось создать способ доставки"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} успешно назначено каналу"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Глобальные языки"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Новый администратор"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Удалить черновик"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Источник"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Нет доступных действий"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Не удалось обновить канал"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Общие"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Не удалось удалить товар из канала"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Добавить новый адрес"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Фасет успешно обновлён"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Зона успешно создана"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Значение"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Клиент обновлён"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Коэффициент пересчёта цены"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Заказ продавца"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Новый фасет"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Вы уверены, что хотите удалить эту группу опций из товара?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Описание (альтернативный текст)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Теги не найдены"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Валюта по умолчанию"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Для этих изменений не требуется платёж или возврат."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr "{cancellableCount, plural, one {Вы уверены, что хотите отменить {cancellableCount} задачу? Это действие нельзя отменить.} few {Вы уверены, что хотите отменить {cancellableCount} задачи? Это действие нельзя отменить.} many {Вы уверены, что хотите отменить {cancellableCount} задач? Это действие нельзя отменить.} other {Вы уверены, что хотите отменить {cancellableCount} задачи? Это действие нельзя отменить.}}"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Общая выручка"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Следующее выполнение"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Заметка приватная"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Средняя дата"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Недопустимое число"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Вы ещё не сохранили ни одного представления."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Вы уверены, что хотите удалить это представление? Это действие нельзя отменить."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Просмотр процесса заказа"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Не удалось дублировать представление"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Использовать как адрес доставки по умолчанию"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Редактировать slug вручную"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Добавьте фильтры для предварительного просмотра содержимого коллекции."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Группа опций товара"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Промежуточный итог"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "меньше чем"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID возврата"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Пользовательские поля заказа обновлены"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Калькулятор"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Не удалось удалить группу опций из канала: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Посмотреть данные задачи"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Переместить на верхний уровень"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Очистить"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Сводка по заказам"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Поиск ресурсов..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Новый фасет"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Назначить {entityType} каналу"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Продолжить"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Акции"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Сообщение об ошибке"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Добавить уровень запасов для другого местоположения"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Удалить адрес"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Не удалось обновить фасет"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters должен использоваться внутри WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Редактировать адрес"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Не удалось удалить фасет из канала: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Установить ссылку"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Новый продавец"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Редактировать изображение"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Управление вариантами"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Запас выделен"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "больше или равно"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Устанавливает уровень запасов, при котором этот вариант считается отсутствующим на складе. Использование отрицательного значения включает поддержку предзаказов."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Создать опции товара"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Сохранение..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Посмотреть результат"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Строк на странице"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Загрузка коллекций..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Значение фасета успешно обновлено"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Добавить ресурс"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Сохранить изменения"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Клиент добавлен в группу"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Заказы продавца"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Не удалось добавить значение опции"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Добавить значение опции в {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr "Не удалось удалить адрес доставки заказа: {0}"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} товар(ов) возвращено"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Группы опций ещё не определены. Добавьте группы опций для создания разных вариантов вашего товара (например, Размер, Цвет, Материал)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Новая электронная почта:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Не удалось обновить способ оплаты"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Доступно:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Дата создания"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Не удалось создать вариант товара"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Язык: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "У вас нет разрешения на просмотр глобальных языковых настроек"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Налоговая ставка успешно создана"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Заголовок 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Коды купонов добавлены"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Активный"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Налоговая база"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Загрузить ещё"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Возврат проведён"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} успешно дублировано"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Новая группа опций"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Результатов пока нет"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Платёж проведён"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Доступные условия"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Активные фильтры"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Очистить всё"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "больше чем"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Закрыть"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Добавить платёж к заказу"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Загрузка..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Токен используется для указания канала при выполнении API-запросов."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Адреса не найдены"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID выполнения"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Выберите платежи для возврата"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Не удалось удалить {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Порог отсутствия на складе"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Товар успешно удалён из канала"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Не удалось обновить значение"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Не удалось создать API key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Провести возврат"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Способ оплаты обязателен"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Не удалось добавить клиента в группу"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Управление вариантами"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Применен глобальный вид „{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Клиент зарегистрирован"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Зоны"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Поиск продавцов..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Акция успешно создана"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Опция"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Процесс заказа"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Номер телефона"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Приватное"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Вариант"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Глобальные настройки успешно обновлены"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API key успешно обновлён"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Эти языки будут доступны для использования всеми каналами"

--- a/packages/dashboard/src/i18n/locales/sv.po
+++ b/packages/dashboard/src/i18n/locales/sv.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Fullständigt namn"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Välj artiklar"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Visa ändringar"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Spårningskod"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "De valda behörigheterna kommer tillämpas på dessa kanaler."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Produktalternativ"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Ny skattesats"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Tilldela en befintlig alternativgrupp eller skapa en ny"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Ny roll"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Lägenhet, svit, etc."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Inga fler artiklar"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Redigera länk"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Lägg till minst en artikel i beställningen"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Lägg till produkter för att skapa en testbeställning"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Misslyckades att skapa adress"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Växla alla"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Redigera JSON-värde"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Använder extern autentiseringsstrategi: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Välj en anledning..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Rubrik 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Misslyckades att lägga till betalning"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Uppdaterad"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Misslyckades att uppdatera globala inställningar"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Beställning levererad"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Är du säker på att du vill ta bort {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Global utlagd tröskel"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Hantera språk"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Duplicerar... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Borttagen"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Ta bort från nuvarande kanal"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Tog bort {selectionLength} tillgångar"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Skattesats uppdaterad"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Ange anpassad anledning..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Typ"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Välj {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Visa värden"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Ta bort rad"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Villkor"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Inga leveranser"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Det gick inte att ta bort {1} lagerplats: {messages}} other {Det gick inte att ta bort {2} lagerplatser: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "När detta är aktiverat kommer priserna i produktkatalogen inkludera skatt för standardskattzonen."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Skapa varianter för din produkt"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Utkast till beställning slutfört"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Automatisk uppdatering: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Hälsokontroller"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Tog bort {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Hälsokontroller"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Säljare"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Alternativ"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} jobb har avbrutits} other {{fulfilled} jobb har avbrutits}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Säljare"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "Art.nr:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Lägg till betalning"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Testa denna fraktmetod genom att simulera en beställning för att se om den är lämplig och vad fraktkostnaden skulle bli."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Utforska Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Lagerplatser"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Leveranshanterare"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Beställningar"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Välj roller"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Roll skapad"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Är du säker på att du vill ta bort denna variant?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Alla resurser är igång"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Misslyckades med att skapa administratör"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Nej"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Produktvariant uppdaterad"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Misslyckades att ta bort {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Produkt uppdaterad"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Misslyckades att uppdatera land"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Skriv minst 2 tecken för att söka..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Efternamn"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Länktitel"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Kundgrupp uppdaterad"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Anpassade fält ändrade"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Lagerplats skapad"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Okänt fel"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Total återbetalning kan inte vara negativ"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Visa detaljer"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Välj en kanal att tilldela {0} {entityType} till"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Kund skapad"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Senaste 7 dagarna"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Misslyckades att skapa kanal"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Utvecklingsläge"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Ny roll"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Misslyckades att ta bort tillgångar: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Returnera till lager"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Synlighet"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Produktvarianter"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Ny kundgrupp"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Skapa \"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Byt namn"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Välj önskat visningsspråk och regionsinställningar"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} alternativgrupper togs bort från kanal"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Fraktmetod är inte lämplig för denna beställning"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Misslyckades att uppdatera adress"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adress borttagen"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Skattesats"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Beställningsutkastet är inte redo att slutföras"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Ny kollektion"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Insikter"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Kör"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Misslyckades att uppdatera skattesats"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Detta är innehållet i kollektionen <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "privat"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Produktalternativ skapades"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Överordnad produkt"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Stad"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administratörer"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Bruttopris: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Gå till nästa sida"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Ta bort länk"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Det här fältet är skrivskyddat"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Antal beställningar"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Beställning uppdaterad"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Ärv filter"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Hantera globala sparade vyer som är synliga för alla användare"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Sök betalningsmetoder..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Leveransadress borttagen för beställning"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Skapa {enabledCount} varianter"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Betalning #{0} övergick till {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Fel vid laddning av kundhistorik: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} borttagen från kanal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Lägg till alternativvärde"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Globala inställningar"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "är efter"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Produktalternativ uppdaterades"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Redigera facettvärden"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Lägger till..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Flytta kollektioner"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Roller"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Rutnätsvy"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Misslyckades att ta bort adress"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Inga fraktmetoder tillgängliga"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Global vy konverterad till personlig vy"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Leverans övergick"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Är du säker på att du vill ta bort {selectionLength} tillgångar?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Logga in"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Listvy"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Testbeställning"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Välj en kund för att fortsätta"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Alternativgrupp tilldelad"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Kör test"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Skattesats: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Lägg till produkter och fyll i leveransadress för att köra testet."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Växla rubrikrad"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Välj adress"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Kontroll av betalningsberättigande"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Standardskattzon"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Beställningsutkastet är redo att slutföras"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadata"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrera..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Nytt facettvärde"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Kanal uppdaterad"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Visa mindre"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Kort datum"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Tillgängliga valutor"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Välj {0} artiklar"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Placerad"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Genom att rotera denna nyckel ogiltigförklaras den aktuella nyckeln direkt. Alla integrationer som använder den slutar fungera tills de uppdateras med den nya nyckeln."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Data som skickats till jobbet"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Bekräfta navigering"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Länkmål"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Slutför utkast"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Namn"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Misslyckades att leverera beställning"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Totalt"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Ange transaktions-ID för denna återbetalning"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Din API-nyckel"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Är du säker på att du vill ta bort detta utkast till beställning?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Leverans skapad"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Hittade {0} lämplig fraktmetod{1}"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Mått"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Visa lösenord"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(max: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Företag"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Lägg till kolumn efter"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Åtgärder"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Rabatter"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Ange återbetalningsnotering"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Beställningsrad borttagen"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Innehåll:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Nyckel"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Bekräfta"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Misslyckades att skapa kollektion"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Gå till första sidan"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Misslyckades att skapa produkt"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Kund"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Fel vid laddning av beställningshistorik: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Leveransadress angiven för beställning"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Fokuspunkt"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "En variant, inga alternativ"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Välj nästa status för beställningen"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Lokal"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Schemalagda uppgifter"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Ange transaktions-ID"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Uppdatera data"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Lägg till eller ta bort facettvärden för {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Detta är facettvärdena för facetten <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Betalning tillagd till beställning"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Faktureringsadress inställd för beställning"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Misslyckades att uppdatera zon"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Lösenord"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Misslyckades att ta bort"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Schemalagd uppgift kommer köras"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Ny lagerplats"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Behörigheter"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Leveransadress ändrad"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Inga produkter hittades"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Lägg till rad före"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Övergå till {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Denna månad"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Misslyckades att skapa facett"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Misslyckades med att avbryta orderartiklar"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "Transaktions-ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Allokerad"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Lägg till en till alternativgrupp"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Välj vad som ska hända med kvarvarande lagersaldo"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Utforska Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Var 5:e sekund"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Kollektion skapad"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Pris"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Utkast till beställning"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Omfattning"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Lägg till villkor"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Fraktmetod är lämplig för denna beställning"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administratörer"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Borttagen från grupp"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Bredd"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Ingen betalning eller återbetalning krävs"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Ladda ned som .env-fil"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "När aktiverad är kampanjen tillgänglig i butiken"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "När spårad kommer produktvariantens lagernivåer justeras automatiskt vid försäljning. Denna inställning kan åsidosättas av enskilda produktvarianter."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Leveransmetod angiven för beställning"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Misslyckades att uppdatera kampanj"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Bilder"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Sök {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Redigera tillgång"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Avbryt betalning"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Jobbkö"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Tillgångar"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "E-postadress"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Regenerera slug från källfält"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Ärv från globala inställningar"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Inga resultat hittades"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Nuvarande status"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Ange en leveransadress och välj en fraktmetod"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Av"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Inställningslager"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Kö"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Ny skattesats"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Betalning övergick"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Återstår:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Ingen duplicerare hittades med kod \"{duplicatorCode}\" för {entityName}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Priser inkluderar skatt för standardskattzon"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Total återbetalning:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Visa jobbresultat"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Testa dina fraktmetoder genom att simulera en ny beställning."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Inga artiklar valda"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} valda"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Inga länder hittades"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Varianter skapade"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Generera slug automatiskt"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Tillägg"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Betalningsmetoder"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Lager"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Inga kunder hittades"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Använd global utlagd tröskel"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Ny produktalternativgrupp"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Betalningsstatus uppdaterad"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Skapa ny"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Total återbetalning"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adress borttagen"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Endast roller som är tilldelade ditt konto är tillgängliga."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Artikel tillagd i beställning"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Redigera fokuspunkt"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Inga säljare hittades"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Tillgång"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Den här alternativgruppen används av en annan produkt. Ändringar påverkar även den.} other {Den här alternativgruppen delas av # produkter. Ändringar påverkar alla.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Mina sparade vyer"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Ny kanal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Misslyckades att skapa säljare"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Konfigurera dupliceringsinställningar för {0}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Inga varianter matchar det aktuella filtret."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adresser"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Lägg till ett nytt alternativvärde i alternativgruppen {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Beställningsändring #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Lägg till kolumn före"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Kanalspråk"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Misslyckades att skapa alternativgrupp"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Sant"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Välj kund"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Beställning övergick"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Denna produkt har befintliga varianter men inga alternativgrupper definierade. Du behöver lägga till alternativgrupper innan du skapar nya varianter."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "är före"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Ta bort utkast till beställning"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Katalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Ny betalningsmetod"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Kampanj uppdaterad"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Det gick inte att avbryta {rejected} jobb} other {Det gick inte att avbryta {rejected} jobb}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Välj en kanal"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Visningsspråk"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Leveransdetaljer"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Kassera kvarvarande lagersaldo"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Nu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Kanaler"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Vy konverterad till global"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "före"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Storlek"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Ingen översättning hittades för {0}"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Ny kund"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Senaste beställningar"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} till"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Använd som standardfakturaadress"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Ta bort"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Inaktivera"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Kollektioner"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Lägg till variant"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Misslyckades att skapa land"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Länder"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Misslyckades att skapa produktalternativ"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Misslyckades att byta namn på vy"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Tillgänglig"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filter"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Kundgrupper"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Kunder"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Exempelformatering"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Nytt alternativ"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Användningsgräns"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Laddar globala inställningar..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adress uppdaterad"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Skapad"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Laddar adresser..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Välj en målkollektion att flytta {0} till."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Kunduppgifter uppdaterade"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "inte i"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Tillämpa"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Nytt produktalternativ"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Gå till sista sidan"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Avbryt"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Produktvariant skapad"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Återbetalning från denna metod"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Postnummer"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Lägg till produktalternativ först"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Ny skattekategori"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Lägg till alternativ"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Delvis återbetalning slutförd"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Ange anpassade fält"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Kollektioner"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Radera variant"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Inga ändringar gjorda"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Standardfraktzon"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Anledning:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Leveransadress"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Övergå till {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Skattekategorier"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Privata kollektioner är inte synliga i butiken"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "När aktiverad är produkten tillgänglig i butiken"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Schemalagd uppgift kunde inte köras"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Kundgrupper"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Inaktiverad"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Ny kampanj"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Standardleveransadress"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Återbetalning krävs"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Leverera beställning"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Du har inte behörighet att visa kanalinställningar"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Senaste 30 dagarna"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Inga facettvärden"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "En anledning för återbetalningen krävs"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Kunde inte ta bort alternativgrupp"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Misslyckades att uppdatera skattekategori"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Återbetalning genomförd"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Uppdatera"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Rubrik 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Beställning lagd"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profil uppdaterad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "slut"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Betalningsmetod"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Redigera"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variant uppdaterad"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Filtrera efter kollektionsnamn"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Anteckning tillagd"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Välj antal att leverera och konfigurera leveranshanterare"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Faktureringsadress borttagen från beställning"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Börjar"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Duplicera"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Inga resultat"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Kolumninställningar"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Det gick inte att ta bort {count} lagerplats} other {Det gick inte att ta bort {count} lagerplatser}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Kod"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Misslyckades med att ta bort alternativgrupper"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Beställning levererad"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Överför till {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Kvarvarande lagersaldo"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Ta bort från zon"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Välj från globalt tillgängliga språk för denna kanal"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Är du säker på att du vill ta bort denna adress?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Misslyckades med att tilldela alternativgrupp"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Misslyckades att uppdatera tillgång"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Lagerplats uppdaterad"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Bekräfta åtgärd"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Land uppdaterat"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Facetter"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Misslyckades att lägga till anteckning"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Misslyckades att ta bort anteckning"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Misslyckades att förlänga frågedokument"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Misslyckades att uppdatera anteckning"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Återbetala frakt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Skrivskyddad"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Misslyckades att duplicera global vy"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Visar {shown} av {total} • {selected} valda"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Testa fraktmetod"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Facettvärden"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Tillgång uppdaterad"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Tema"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} kunder"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Välj ett språk"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Logga ut"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Försök"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Tillgängliga valutakoder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Tillgängliga språkkoder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Brödsmulor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Kategori"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Kanaler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Underordnade element"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Kod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Kupongkod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Skapad den"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Valutakod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Kund"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Kundgrupp"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Kunder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Anpassade fält"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Data"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Standard valutakod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Standardspråkkod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Standardfraktzon"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Standardskattzon"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Beskrivning"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Varaktighet"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "E-postadress"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Aktiverad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Slutar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Fel"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Utvald tillgång"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Förnamn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Leveranshanterarkod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Standard"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Privat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Genomförd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Efternamn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Namn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Beställning lagd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "Överordnat ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Användningsgräns per kund"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Behörigheter"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Position"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Pris"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Priser inkluderar skatt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Pris med skatt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Produktvarianter"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Framsteg"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Könamn"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Resultat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Återförsök"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Säljare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Avklarad den"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Fraktrader"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Startad den"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Börjar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Tillstånd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Lagernivåer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Totalt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Totalt med skatt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Typ"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Uppdaterad den"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Användningsgräns"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Användare"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Värde"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Värdelista"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Zon"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Metod"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Skattesammanfattning"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Anger språk som är tillgängliga för alla kanaler. Enskilda kanaler kan sedan stödja en delmängd av dessa språk."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Samlingar flyttades framgångsrikt"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Registrerad"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Avbryt jobb"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Slutar"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Sida {0} av {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Sats"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Storlek, färg etc."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Bläddra bland fasetter"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Zon"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Avbruten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Skapad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Levererad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Väntar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Skickad"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Spara vy"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} valda"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Sök alternativgrupper..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Ändra beställning"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Valda artiklar"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Värden"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Kund angiven för beställning"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Facetter"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Är du säker på att du vill ta bort {count} kund från denna grupp?} other {Är du säker på att du vill ta bort {count} kunder från denna grupp?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Lager tillgängligt"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Återuppbyggnad av sökindex kunde inte startas"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Leveransadress"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Ny zon"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Ny API-nyckel"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Ta bort kolumn"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Tilldela befintlig"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "är null"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Detta är kunderna i kundgruppen <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Hantera globala vyer"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Standardkanal"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Infoga en ny bild med källa, titel och dimensioner"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Misslyckades att skapa facettvärde"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Kunde inte uppdatera produktalternativ"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Glömt lösenord?</0><1>Begär återställning</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Kupongkod"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Kund verifierad"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Globala inställningar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Schema"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Kan inte flytta en samling till sin egen underordnade"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Ny skattekategori"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Inga lagerplatser tillgängliga på nuvarande kanal"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Kanal skapad"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Kund uppdaterad"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Visa data"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Ta bort vy"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Lägg till en ny adress till kunden."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Fler vyer"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Redigera egenskaper för den valda bilden"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Tillämpade vy \"{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} facetter borttagna från kanal"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Ny produkt"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Ny tillgång"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Beräkna om frakt"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Välj vilka alternativ som ska gälla för befintlig variant \"{0}\""
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Tillgångar"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Detta tar bort alla alternativgrupper från produkten och återgår till variantval."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Fakturaadress"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Lägg till facettvärde"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Välj en målkollektion"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Granska ändringarna innan de tillämpas på beställningen."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Välj en roll"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Beställning avbruten"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Rabatt"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Alla typer"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Endast utkastbeställningar kan slutföras"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Misslyckades att uppdatera produkt"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Justerar {0} rader"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Lägg till facettvärden"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "efter"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Kanal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Hälsokontroller"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Belopp"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Telefonnummer"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Ny kund"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Bild"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administratör har skapats"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Produktalternativ"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Välj land"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Skapar..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Är du säker på att du vill ta bort denna globala vy? Denna åtgärd kan inte ångras och kommer påverka alla användare."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Tvinga borttagning av alternativgrupp"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Tillagd"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Kundhistorik"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Facettvärden uppdaterade för {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Misslyckades att ta bort kund från grupp"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Användningsgräns per kund"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Fakturaadress ändrad"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Välj ett alternativ"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Kopiera till personlig"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Total återbetalning överstiger maximalt återbetalningsbart belopp på {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Ta bort global vy"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Skapa"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Var 30:e sekund"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Nytt land"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "Från {0} till {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Misslyckades att skapa kund"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Fokuspunkt uppdaterad"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Alternativvärden"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Standardfakturaadress"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Ingen kund"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Misslyckades med att ta bort länder från zonen"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Misslyckades att skapa kampanj"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Idag"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Igår"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Alternativnamn"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Är du säker på att du vill ta bort {0} {1} från denna zon?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Lägger till {0} tillägg"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Länk href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Reservvärde: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Beställningshistorik"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Åsidosätt"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "Transaktions-ID krävs"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "matchar regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Global vy namnändrad"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Inga taggar valda"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Tillbaka"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Vy namnändrad"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Tillämpa filter"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Senaste resultat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Tillagd i grupp"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Insikter"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Skapa varianter"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Testar fraktmetod..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Mörk"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Testresultat"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Lägg till kund"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Spara ändringar"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adress uppdaterad"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Återbetalning behandlad framgångsrikt"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Ny zon"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Misslyckades med att uppdatera samlingsposition"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Återbetalning"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Ändra"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Inga globala språk konfigurerade"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Tar bort {0} artikel/artiklar"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Spåra"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Skapa variant"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Facettvärden för {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Spara layout"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Återställning av lösenord verifierad"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Misslyckades att ta bort vy"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Är du säker på att du vill lämna denna sida? Alla osparade ändringar kommer förloras."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Växla rubrikkolumn"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Ny kampanj"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Alternativvärdesnamn"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Senast använd"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Är standardskattekategori"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug är angiven"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Misslyckades att uppdatera fokuspunkt"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Zon uppdaterad"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Region/Provins"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Misslyckades med att uppdatera alternativgrupp"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Kanalinställningar"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Misslyckades att skapa skattekategori"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Ange filterkriterier för kolumnen {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Land"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Enkel produkt"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Jobbkö"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Bekräfta att du har sparat API-nyckeln innan du stänger."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Bekräfta borttagning"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Misslyckades att ändra beställning"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Inkluderar moms på {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Beställningsmått"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Välj visningsspråk"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Autentiseringsmetoder"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "start"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Misslyckades med att rotera API-nyckel"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "i"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Sök roller..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Produktvarianter"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Hantera globala vyer"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Bearbetar..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} hittades"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Välj datumintervall"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Produkt"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Rotera API-nyckel"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Kategori"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Flyttar..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Tilldela"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Säljare skapad"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Fraktmetod uppdaterades"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Misslyckades att uppdatera produktvariant"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Dra för att ändra ordning"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Zoner"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Välj vad som ska hända med det lagersaldo som finns kvar på {count, plural, one {# lagerplats} other {# lagerplatser}} som du tar bort. Alla valda lagerplatser överför sitt kvarvarande saldo till den enda lagerplats du väljer, eller så kasseras det."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Sök fasettvärden..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Anteckning"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Tillgängliga språk"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Ladda {0} fler ({remaining} kvar)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Facettvärden"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Misslyckades med att ändra ordning på artiklar"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Totalt antal beställningar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Inga lämpliga fraktmetoder hittades för denna beställning."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Lägg till produktalternativ"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Frakt"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions måste användas inom en DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Denna alternativgrupp används av befintliga varianter. Att tvinga borttagning kan påverka dessa varianter. Är du säker?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "E-postuppdatering begärd"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Fel vid övergång till status"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Kundgrupp skapad"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Nytt fönster"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Betalning auktoriserad"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Roll uppdaterad"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Välj ett land"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Kunde inte uppdatera fraktmetod"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} lagerplats togs bort} other {{deleted} lagerplatser togs bort}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Fraktmetoder"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Välj en adress"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Ja"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Ange fokuspunkt"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "slut"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Välj en valuta"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Uppdatera anteckningens innehåll eller synlighet"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Senaste beställningar-widget"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Kollektionsinnehåll för {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Fraktmetod ändrad"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Skattebeskrivning"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "är mindre än eller lika med"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "är inte lika med"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Uppdatera"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "t.ex. Storlek"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Genomför betalning"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Kanaler"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Frakt återbetald"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Tillgångstyp"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Ny lagerplats"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} betalning(ar) återbetalades före felet. Kontrollera orderhistoriken för detaljer."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Välj artikel"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Ny produkt"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Hantera taggar"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Artiklar återbetalade"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Lägg till åtgärd"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Tilldela alternativ till befintlig variant"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Duplicera {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Ta bort från grupp"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Misslyckades att uppdatera leveransstatus"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Skapa en ny produktvariant med alternativ, pris och lager"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Privata facetter är inte synliga i butiken"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Välj en skattekategori"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Skapad"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Körs inte"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Tilldelad"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Rubrik 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Välj tillgängliga språk"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Lägger till {0} artikel/artiklar"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Lägg till rad efter"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Totalt skatt"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Utkastbeställningsstatus"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Produktalternativ skapade"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Läser in lagerplatser…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Misslyckades att skapa betalningsmetod"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Facettvärde skapat"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marknadsföring"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Utkast till beställning borttaget"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "större än"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Mätwidget"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Sök valutor..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Ta bort från kanal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Titel"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Infoga bild"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Misslyckades att uppdatera säljare"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Land skapat"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Välj säljare"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Laddar taggar..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Facett skapad"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} varianter"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Misslyckades att genomföra betalning"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Ingen fakturaadress"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Det gick inte att ta bort {1} lagerplats} other {Det gick inte att ta bort {2} lagerplatser}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Facett"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Kan inte ta bort från aktiv kanal"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Ej angiven"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Tvinga borttagning"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Ny kanal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Alternativgruppsnamn"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "OCH"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Misslyckades att skapa kundgrupp"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Misslyckades att skapa roll"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Produktnamn"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Leveransstatus uppdaterad"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Produkter"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adress skapad"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API-nyckel har roterats"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Lägg till alternativgrupp"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Återbetala {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Ange slug manuellt"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Inga widgetar tillgängliga"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Misslyckades att avbryta betalning"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Betalning avbruten"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Global vy duplicerad"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Skapad av"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Filtrera varianter..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Lägg till ett pris i en annan valuta"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "E-postadress eller identifierare"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Återbetalning #{0} övergick till {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Kunder"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Rubrik 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Misslyckades att uppdatera lagerplats"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Beställning skickad"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Spara adress"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Gör global"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Välj nästa status"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Inga varningar"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Flyttar {0} kollektion{1} till {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "mellan"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Anteckning tillagd"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Anteckning borttagen"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Anteckning uppdaterad"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Misslyckades att genomföra återbetalning"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Lagernivå"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Lägg till artikel"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API-nyckel skapad"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Laddar förhandsgranskning..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Tillbaka till sökning"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Vy duplicerad"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Ta bort alternativgrupp"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Beskrivning"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Länder"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Gatuadress 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Global vy borttagen"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Redigera layout"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Tilldela till kanal"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Denna vecka"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Produktalternativgrupp har skapats"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Lägg till manuell betalning på {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "är i"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-post"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Misslyckades med att uppdatera administratör"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Hantera dina personliga sparade vyer för denna tabell"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Filtrera efter taggar"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Logga in för att få åtkomst till adminpanelen"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Lägg till betalning till beställning ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Falskt"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Ljus"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Återställ"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "är lika med"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Skapa alternativ"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Lösenord uppdaterat"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "innehåller inte"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Alternativgrupp"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Redigera adressuppgifterna nedan."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Skattekategori skapad"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Misslyckades att flytta kollektioner"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Misslyckades att uppdatera betalningsstatus"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Översikt över dina beställningar"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Ladda upp"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Produkt med alternativ"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Visar alla {0} resultat"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Sök-ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} till"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Alternativgrupper"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Anpassade fält"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Alla möjliga ordertillstånd och deras övergångar. Aktuellt tillstånd är markerat."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Beställningar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Beställningssammanfattning-widget"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Lägger till artiklar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Ordnar ytterligare betalning"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Ordnar betalning"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Avbruten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Skapad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Levererad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Utkast"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Modifierar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Delvis levererad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Delvis skickad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Betalning auktoriserad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Betalning genomförd"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Skickad"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Övervakade resurser"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Entitetsinformation"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Ordersumma"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Synlig endast för administratörer"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Antal"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Taggar"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Superadministratör"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Vissa resurser är nere"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Tillgängliga åtgärder"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Infoga länk"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Om aktiverad kommer filtren ärvas från överordnad kollektion och kombineras med filtren på denna kollektion."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Välj en zon"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Testa fraktmetoder"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Betalning genomförd"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "Tog bort {0} {1} från zonen"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Aktivera"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Betalningsmetoder"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Auktoriserad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Avbruten"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Skapad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Avvisad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Fel"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Misslyckades"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Väntar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Avklarad"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Genomsnittligt ordervärde"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Misslyckades att skapa zon"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Lagernivåer"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Misslyckades med att uppdatera API-nyckel"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Beställningsrader"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Misslyckades att byta namn på global vy"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Infoga en ny hyperlänk med URL och målalternativ"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Höjd"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "En återbetalning på {formattedDiff} krävs. Välj betalningsbelopp och ange en anteckning för att fortsätta."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Enhetspris"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Schemamönster"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Betalning misslyckades"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Lägg till kanal"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Kunde inte uppdatera produktalternativgrupp"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Sök kanaler..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Lägg till kundgrupper"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Tillgängliga språk"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Återställ markering"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Ingen adress"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Betalningsmetod skapad"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Kundinformation uppdaterad"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Misslyckades att konvertera vy till global"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Produktvarianter"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Produkter"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Kampanjer"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Kunde inte skapa produktalternativ"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Gammal e-post:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Spara en vy som \"Global\" för att göra den tillgänglig för alla användare."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Misslyckades med att skapa varianter"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Anger lagernivån vid vilken denna variant anses vara slut i lager. Användning av negativt värde aktiverar restorderstöd. Kan åsidosättas av produktvarianter."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Rotera nyckel"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Det gick inte att skapa produktvarianter"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Dölj lösenord"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Ny säljare"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "t.ex. Röd, Stor, Bomull"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Misslyckades att uppdatera profil"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Kupongkoder borttagna"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Rensa filter"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Regioner"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Släpp filer här för att ladda upp"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Växla alla synliga varianter"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Verifierad"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Ny alternativgrupp"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Senast uppdaterad {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Inga globala vyer har skapats ännu."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Misslyckades att uppdatera roll"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Detta är enda tillfället då hela API-nyckeln visas. Kopiera eller ladda ned den nu — den kan inte hämtas senare."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Kollektion uppdaterad"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Betalningsmetod uppdaterad"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Vy borttagen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Alternativgrupp {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "ELLER"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Hantera taggar"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Kupongkod borttagen från beställning"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Aldrig"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Misslyckades att uppdatera facettvärde"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Ta bort grupp"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Beställning levererad"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Ingen leveransadress"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Frågeförlängning innehåller ogiltig GraphQL-syntax"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Frågeförlängningsfel"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Frågeförlängningsfel:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Frågeförlängning är ogiltig: måste ha minst ett toppnivåfält"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Felmatchning av frågeförlängning:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "publik"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Skattekategori uppdaterad"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Flytta"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Redigera eller ta bort befintliga taggar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Denna fraktmetods berättigandevillkor är inte uppfyllda för nuvarande beställning och leveransadress."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Lägg till kupongkod"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Kupongkod inställd för beställning"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Anpassade fält"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Ny fraktmetod"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Ta bort lagerplatser"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "är större än eller lika med"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Förhandsvisning"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} av {1} tillgängliga att leverera"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Månad hittills"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Kundförfrågan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Skadad vid frakt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Inte tillgänglig"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Övrigt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Fel vara"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Sammanfattning av ändringar"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Återbetalningar ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Senast kördes"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Betalningsdetaljer"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Återuppbygg sökindex"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Körs"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Var 60:e sekund"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Misslyckades att uppdatera kundgrupp"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Betalningsmetadata"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Avbryt ändring"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Samma fönster"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Tillämpa filter på tabellen och klicka \"Spara vy\" för att komma igång."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Roller"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Ytterligare betalning krävs"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Misslyckades att uppdatera beställning"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Med valda..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Misslyckades att skapa lagerplats"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "mindre än eller lika med"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Kundgruppsmedlemmar för {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Region"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Spåra inte"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Leverans #{0} skapad"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Kör väntande sökindesuppdateringar"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Detta är en standardroll och kan inte ändras"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Mina sparade vyer"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Region / Provins"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Antal per sida"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Redigera medlemmar"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Lager tillgängligt"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Filtrera efter {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Varningar"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Alternativvärden"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Förhandsgranska ändringar"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Misslyckades med att ta bort {entityType} från kanal"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variant borttagen"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Redigera egenskaper för den valda länken"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Försäljning"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Välj en målkollektion"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Dina senaste beställningar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Schemalagda uppgifter"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Är du säker på att du vill ta bort denna artikel? Denna åtgärd kan inte ångras."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Varianter"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Säljare"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Inställningar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Inställningslager"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Rubrik 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Välkommen till Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Fraktmetoder"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} återbetalningsbart)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identifierare"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Misslyckades att uppdatera kollektion"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Pris och skatt"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Beställning hittades inte"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Fel"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Beställning ändrad"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Återställning av lösenord begärd"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Det tilldelade betalningsbeloppet måste vara lika med återbetalningstotalen"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "t.ex. Liten"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Är du säker på att du vill ta bort {0} {entityType} från nuvarande kanal?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Lägg till taggar..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Kunde inte skapa produktalternativgrupp"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} artiklar valda"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Sök språk..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Lagerplatser"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Gå till föregående sida"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Innehåll"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Misslyckades att konvertera global vy till personlig vy"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Resultatet av jobbet"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Lägg till betalning ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "System"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Variantnamn"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Misslyckades att uppdatera kund"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Ta bort alternativgrupper?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Detta är en förhandsvisning av samlingens innehåll baserat på aktuella filterinställningar. När du sparar samlingen kommer innehållet att uppdateras för att återspegla de nya filterinställningarna."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} kund borttagen från gruppen} other {{count} kunder borttagna från gruppen}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Skattekategorier"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Skattesatser"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Det gick inte att ta bort kunder från gruppen"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Misslyckades att ladda globala inställningar"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Välj artiklar att återbetala och eventuellt returnera till lager"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Spara"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{selectedRowCount} av {0} rad(er) markerade."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Förhandsgranska beställningsändringar"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Produktalternativgrupp har uppdaterats"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Sidan kommer fortsätta med standardfrågan."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Gatuadress"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Inga fler fasetter"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Återuppbyggnad av sökindex startad"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Samlingsposition uppdaterad"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Alternativgruppsnamn"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Lägg till \"{newOptionInput}\""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Ny produktvariant"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Återbetalning övergick"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Använder inbyggd autentiseringsstrategi"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Misslyckades med att tilldela {entityIdsLength} {entityType} till kanal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Standardspråk"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Levererar..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Lägg till alternativgrupp till produkt"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Förhandsvisning av {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Säljare uppdaterad"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Misslyckades att överföra beställning till status"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Visa alla ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Misslyckades att skapa skattesats"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Jag har sparat denna API-nyckel"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Konfigurera tillgängliga språk för din butik och kanaler"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Produkt skapad"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Lägg till produktvariant"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Skriv och tryck Enter eller komma för att lägga till..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Redigera anteckning"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Inga tillgångar hittades. Försök justera filtren."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Lägg till alternativ"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Spara alternativgrupp"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Skapa {createCount} varianter"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Klicka \"Kör test\" för att testa denna fraktmetod."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administratör har uppdaterats"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Rensa filter"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Leverans #{0} från {1} till {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Misslyckades att ta bort global vy"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Standardspråk"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Inga alternativ hittades"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Binär"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Alternativgrupp uppdaterad"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Ny fraktmetod"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Var 10:e sekund"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "exkl. skatt:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Lägg till lager till plats"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Alternativvärde tillagt"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Samling flyttad till ny förälder"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Alternativgrupp borttagen"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Övergå till vald status"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "En ytterligare betalning på {formattedDiff} kommer krävas."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Spåra lager som standard"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{selected} av {total} valda"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Fraktmetod skapades"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Ny kundgrupp"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Synlig för kund"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Alternativgrupp skapad"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Skattesatser"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug kommer genereras automatiskt..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Kund hittades inte"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Välj {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Nya facettvärden att lägga till:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Misslyckades med att behandla återbetalning"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Förnamn"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "innehåller"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Inga alternativgrupper hittades"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Inga artiklar hittades"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Delsumma"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Levererade artiklar ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Värde uppdaterat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Overifierad"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Antal"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Lägg till filter"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Skattekategori"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Testdata har uppdaterats. Klicka \"Kör test\" för att se uppdaterade resultat."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "är inte i"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Beställningsrad uppdaterad"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Ny betalningsmetod"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Dubblettvärdet \"{trimmed}\" finns redan"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Anledning"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Kundgrupper"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} togs bort från kanal"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Alternativgrupper"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Lägg till tillägg"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Nuvarande facettvärden"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Sida {page} av {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Förra månaden"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Lägg till land"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Ta bort artikel"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "mindre än"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Varianten kunde inte läggas till. Se till att den överordnade produkten är aktiverad."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Ett okänt fel uppstod"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Mätvärden"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Språk"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Ny kollektion"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Återbetala och avbryt order"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "E-postuppdatering verifierad"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "är mellan"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Återbetala och avbryt"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Testar fraktmetoder..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Kunde inte skapa fraktmetod"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} tilldelad till kanal"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Globala språk"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Ny administratör"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Ta bort utkast"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Källa"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Inga åtgärder tillgängliga"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Misslyckades att uppdatera kanal"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Allmänt"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Misslyckades med att ta bort produkt från kanal"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Lägg till ny adress"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Facett uppdaterad"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Zon skapad"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Värde"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Kund uppdaterad"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Prisomräkningsfaktor"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Säljarorder"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Ny facett"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Är du säker på att du vill ta bort denna alternativgrupp från produkten?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Beskrivning (alt)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Inga taggar hittades"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Standardvaluta"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Ingen betalning eller återbetalning krävs för dessa ändringar."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Total omsättning"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Nästa körning"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Anteckning är privat"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Medellångt datum"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Ogiltigt nummer"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Du har inte sparat några vyer ännu."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Är du säker på att du vill ta bort denna vy? Denna åtgärd kan inte ångras."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Visa orderprocess"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Misslyckades att duplicera vy"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Använd som standardleveransadress"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Redigera slug manuellt"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Lägg till filter för att förhandsgranska samlingens innehåll."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Produktalternativgrupp"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Delsumma"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "är mindre än"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "Återbetalnings-ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Anpassade orderfält uppdaterade"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Kalkylator"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Misslyckades med att ta bort alternativgrupp från kanal: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Visa jobbdata"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Flytta till toppnivå"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Rensa"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Beställningsöversikt"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Sök tillgångar..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Ny facett"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Tilldela {entityType} till kanal"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Fortsätt"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Kampanjer"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Felmeddelande"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Lägg till lagernivå för en annan plats"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Ta bort adress"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Misslyckades att uppdatera facett"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters måste användas inom en WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Redigera adress"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Misslyckades att ta bort facett från kanal: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Ange länk"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Ny säljare"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Redigera bild"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Hantera varianter"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Lager allokerat"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "större än eller lika med"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Anger lagernivån vid vilken denna variant anses vara slut i lager. Användning av negativt värde aktiverar restorderstöd."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Skapa produktalternativ"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Sparar..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Visa resultat"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Rader per sida"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Laddar kollektioner..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Facettvärde uppdaterat"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Lägg till tillgång"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Spara ändringar"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Kund tillagd i grupp"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Säljarordrar"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Misslyckades att lägga till alternativvärde"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Lägg till alternativvärde till {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} artikel/artiklar återbetalade"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Inga alternativgrupper definierade ännu. Lägg till alternativgrupper för att skapa olika varianter av din produkt (t.ex. Storlek, Färg, Material)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Ny e-post:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Misslyckades att uppdatera betalningsmetod"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Tillgängligt:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Skapad den"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Misslyckades att skapa produktvariant"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Språk: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Du har inte behörighet att visa globala språkinställningar"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Skattesats skapad"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Rubrik 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Kupongkoder tillagda"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Aktiv"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Skattebas"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Ladda fler"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Återbetalning genomförd"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} duplicerad"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Ny alternativgrupp"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Inget resultat ännu"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Betalning genomförd"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Tillgängliga villkor"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Aktiva filter"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Rensa alla"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "är större än"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Stäng"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Lägg till betalning till beställning"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Laddar..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Token används för att ange kanal vid API-förfrågningar."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Inga adresser hittades"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "Leverans-ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Välj betalningar att återbetala"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Misslyckades att ta bort {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Utlagd tröskel"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt borttagen från kanal"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Misslyckades med att uppdatera värde"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Misslyckades med att skapa API-nyckel"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Genomför återbetalning"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Betalningsmetod krävs"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Misslyckades att lägga till kund i grupp"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Hantera varianter"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Tillämpade global vy \"{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Kund registrerad"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Zoner"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Sök säljare..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Kampanj skapad"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Alternativ"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Orderprocess"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Privat"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variant"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Globala inställningar uppdaterade"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API-nyckel uppdaterad"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Dessa språk kommer vara tillgängliga för alla kanaler att använda"

--- a/packages/dashboard/src/i18n/locales/tr.po
+++ b/packages/dashboard/src/i18n/locales/tr.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Ad Soyad"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Öğe seç"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Değişiklikleri görüntüle"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Takip kodu"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Seçilen izinler bu kanallara uygulanacaktır."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Ürün seçenekleri"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Yeni Vergi Oranı"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Mevcut bir seçenek grubu atayın veya yeni bir tane oluşturun"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Yeni rol"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Daire, suit, vb."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Başka öğe yok"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Bağlantıyı düzenle"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Siparişe en az bir ürün ekleyin"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Test siparişi oluşturmak için ürün ekleyin"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Adres oluşturulamadı"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Tümünü değiştir"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "JSON değerini düzenle"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Harici kimlik doğrulama stratejisi kullanılıyor: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Bir neden seçin..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Başlık 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Ödeme eklenemedi"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Güncellendi"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Genel ayarlar güncellenemedi"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Sipariş başarıyla teslim edildi"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "{0} {entityName} silmek istediğinizden emin misiniz?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Genel stok tükenmesi eşiği"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Dilleri Yönet"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Çoğaltılıyor... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Başarıyla silindi"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Mevcut kanaldan kaldır"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} varlık silindi"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Vergi oranı başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Özel neden girin..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Tür"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "{0} seç"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Değerleri görüntüle"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Satırı sil"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Koşullar"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Güncel"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Teslimat yok"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {{1} stok konumu silinemedi: {messages}} other {{2} stok konumu silinemedi: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Bu etkinleştirildiğinde, ürün kataloğuna girilen fiyatlara varsayılan vergi bölgesi için vergi dahil edilecektir."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Ürününüz için varyantlar oluşturun"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Taslak sipariş tamamlandı"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Otomatik yenileme: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Sağlık kontrolleri"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} silindi"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Sağlık Kontrolleri"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Satıcılar"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Seçenekler"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} görev başarıyla iptal edildi} other {{fulfilled} görev başarıyla iptal edildi}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Satıcı"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "Stok Kodu:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Ödeme ekle"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Bu kargo yöntemini uygun olup olmadığını ve kargo maliyetinin ne olacağını görmek için bir sipariş simüle ederek test edin."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Enterprise Edition'ı Keşfet"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Stok Konumları"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Teslimat işleyicisi"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Siparişler"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Rol seçin"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Rol başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Bu varyantı silmek istediğinizden emin misiniz?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Tüm kaynaklar çalışıyor"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Yönetici oluşturulamadı"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Hayır"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Ürün varyantı başarıyla güncellendi"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "{failed} {entityName} silinemedi: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Ürün başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Ülke güncellenemedi"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Aramak için en az 2 karakter yazın..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Soyad"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Bağlantı başlığı"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Müşteri grubu başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Özel alanlar değiştirildi"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Stok konumu başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Bilinmeyen hata"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "İade toplamı negatif olamaz"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Detayları görüntüle"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "{0} {entityType} atamak için bir kanal seçin"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Müşteri başarıyla oluşturuldu"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Son 7 gün"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Kanal oluşturulamadı"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Geliştirici Modu"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Yeni Rol"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Varlıklar silinemedi: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Stoka iade et"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Görünürlük"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Ürün varyantları"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Yeni müşteri grubu"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "\"{0}\" oluştur"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Yeniden adlandır"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Tercih ettiğiniz görüntüleme dilini ve yerel ayarları seçin"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} seçenek grubu kanaldan başarıyla kaldırıldı"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Kargo yöntemi bu sipariş için uygun değildir"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Adres güncellenemedi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Adres başarıyla silindi"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Vergi oranı"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Sipariş taslağı tamamlanmaya hazır değil"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Yeni koleksiyon"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "İçgörüler"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Çalıştır"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Vergi oranı güncellenemedi"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Bu, <0>{collectionName}</0> koleksiyonunun içeriğidir."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "özel"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Ürün seçeneği başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Üst ürün"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Şehir"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Yöneticiler"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Brüt fiyat: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Sonraki sayfaya git"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Bağlantıyı kaldır"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Bu alan salt okunurdur"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Sipariş Sayısı"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Sipariş başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Filtreleri miras al"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Tüm kullanıcılar tarafından görülebilen genel kaydedilmiş görünümleri yönetin"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Ödeme yöntemlerini ara..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Sipariş için kargo adresi kaldırıldı"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "{enabledCount} varyant oluştur"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Ödeme #{0}, {1} durumuna geçti"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Müşteri geçmişi yüklenirken hata: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} kanaldan başarıyla kaldırıldı"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Seçenek değeri ekle"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Genel Ayarlar"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "sonrasında"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Ürün seçeneği başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Özellik değerlerini düzenle"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Ekleniyor..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Koleksiyonları Taşı"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Roller"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Izgara görünümü"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Adres silinemedi"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Kullanılabilir kargo yöntemi yok"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Genel görünüm başarıyla kişisel görünüme dönüştürüldü"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Teslimat geçiş yaptı"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "{selectionLength} varlığı silmek istediğinizden emin misiniz?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Oturum aç"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Liste görünümü"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Test Siparişi"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Devam etmek için bir müşteri seçin"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Seçenek grubu başarıyla atandı"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Testi Çalıştır"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Vergi oranı: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Testi çalıştırmak için lütfen ürün ekleyin ve kargo adresini doldurun."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Başlık satırını değiştir"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Adres seç"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Ödeme uygunluk kontrolü"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Varsayılan vergi bölgesi"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Sipariş taslağı tamamlanmaya hazır"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metadata"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrele..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Yeni özellik değeri"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Kanal başarıyla güncellendi"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Daha az göster"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Kısa tarih"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Mevcut para birimleri"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "{0} Öğe Seç"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Verilme Tarihi"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Bu anahtarı döndürmek, mevcut anahtarı hemen geçersiz kılacaktır. Bu anahtarı kullanan tüm entegrasyonlar yeni anahtarla güncellenene kadar çalışmayı durduracaktır."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "İşe aktarılan veriler"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Gezinmeyi onayla"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Bağlantı hedefi"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Taslağı tamamla"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Ad"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Sipariş teslim edilemedi"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Toplam"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Bu iade ödemesi için işlem ID'sini girin"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "API Anahtarınız"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Bu taslak siparişi silmek istediğinizden emin misiniz?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Teslimat oluşturuldu"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "{0} uygun kargo yöntemi bulundu"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Boyutlar"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Şifreyi göster"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(maks: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Şirket"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Sonrasına sütun ekle"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "İşlemler"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "İndirimler"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "İade notu girin"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Sipariş satırı kaldırıldı"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "İçerik:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Anahtar"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Onayla"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Koleksiyon oluşturulamadı"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "İlk sayfaya git"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Ürün oluşturulamadı"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Müşteri"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Sipariş geçmişi yüklenirken hata: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Sipariş için kargo adresi ayarlandı"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Odak Noktası"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Tek varyant, seçenek yok"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Sipariş için sonraki durumu seçin"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Yerel ayar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Zamanlanmış Görevler"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "İşlem ID'sini girin"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Verileri yenile"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "{0} {entityType} için özellik değerlerini ekle veya kaldır"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Bunlar <0>{facetName}</0> özelliği için özellik değerleridir."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Ödeme siparişe başarıyla eklendi"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Sipariş için fatura adresi ayarlandı"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Bölge güncellenemedi"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Şifre"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Silinemedi"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Zamanlanmış görev çalıştırılacak"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Yeni stok konumu"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "İzinler"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Kargo adresi değiştirildi"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Ürün bulunamadı"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Öncesine satır ekle"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "{suggestedState} durumuna geç"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Bu ay"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Özellik oluşturulamadı"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Sipariş öğeleri iptal edilemedi"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "İşlem ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Tahsis edildi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Başka bir seçenek grubu ekle"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Kalan stokla ne yapılacağını seçin"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Platform & Cloud'u Keşfedin"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Her 5 saniyede"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Koleksiyon başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Fiyat"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Taslak sipariş"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Kapsam"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Koşul ekle"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Kargo yöntemi bu sipariş için uygundur"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Yöneticiler"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Gruptan kaldırıldı"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Genişlik"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Ödeme veya iade gerekmiyor"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr ".env dosyası olarak indir"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Etkinleştirildiğinde promosyon mağazada kullanılabilir"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "İzlendiğinde, ürün varyantı stok seviyeleri satıldığında otomatik olarak ayarlanacaktır. Bu ayar, tek tek ürün varyantları tarafından geçersiz kılınabilir."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Sipariş için kargo yöntemi ayarlandı"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Promosyon güncellenemedi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Görseller"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "{name} ara..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Varlığı düzenle"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Ödemeyi iptal et"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "İş Kuyruğu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Varlıklar"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "E-posta adresi"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Kaynak alandan slug'ı yeniden oluştur"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Genel ayarlardan miras al"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Sonuç bulunamadı"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Mevcut durum"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Teslimat adresi belirleyin ve kargo yöntemi seçin"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Kapalı"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Ayarlar Deposu"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Kuyruk"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Yeni vergi oranı"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Ödeme geçiş yaptı"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Kalan:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "{entityName} için \"{duplicatorCode}\" kodlu çoğaltıcı bulunamadı"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Fiyatlara varsayılan vergi bölgesi için vergi dahildir"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Toplam iade:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "İş sonucunu görüntüle"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Yeni bir sipariş simüle ederek kargo yöntemlerinizi test edin."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Öğe seçilmedi"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} seçildi"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Ülke bulunamadı"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Varyantlar başarıyla oluşturuldu"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Slug'ı otomatik oluştur"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Ek ücret"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Ödeme Yöntemleri"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Stok"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Müşteri bulunamadı"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Genel stok tükenmesi eşiğini kullan"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Yeni ürün seçenek grubu"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Ödeme durumu başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Yeni oluştur"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "İade toplamı"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Adres silindi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Yalnızca hesabınıza atanmış roller kullanılabilir."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Ürün siparişe eklendi"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Odak noktasını düzenle"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Satıcı bulunamadı"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Varlık"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Bu seçenek grubu başka bir ürün tarafından da kullanılmaktadır. Değişiklikler onu da etkileyecektir.} other {Bu seçenek grubu # ürün tarafından paylaşılmaktadır. Değişiklikler hepsini etkileyecektir.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Kaydedilmiş Görünümlerim"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Yeni kanal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Satıcı oluşturulamadı"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "{0}s için çoğaltma ayarlarını yapılandırın"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Geçerli filtreyle eşleşen varyant yok."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Adresler"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "{groupName} seçenek grubuna yeni bir seçenek değeri ekleyin"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Sipariş değişikliği #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Öncesine sütun ekle"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Kanal Dilleri"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Seçenek grubu oluşturulamadı"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Doğru"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Müşteri seç"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Sipariş geçiş yaptı"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "Bu ürünün mevcut varyantları var ancak seçenek grubu tanımlanmamış. Yeni varyantlar oluşturmadan önce seçenek grupları eklemeniz gerekir."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "öncesinde"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Taslak siparişi sil"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Katalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Yeni ödeme yöntemi"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Promosyon başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {{rejected} görev iptal edilemedi} other {{rejected} görev iptal edilemedi}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Bir kanal seçin"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Görüntüleme dili"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Teslimat detayları"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Kalan stoku at"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Şimdi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Kanallar"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Görünüm başarıyla genele dönüştürüldü"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "önce"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Boyut"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "{0} için çeviri bulunamadı"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Yeni Müşteri"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Son Siparişler"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} daha"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Varsayılan fatura adresi olarak kullan"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Sil"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Devre dışı bırak"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Koleksiyonlar"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Varyant ekle"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Ülke oluşturulamadı"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Ülkeler"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Ürün seçenekleri oluşturulamadı"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Görünüm yeniden adlandırılamadı"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Mevcut"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Normal"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtreler"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Müşteri Grupları"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Müşteriler"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Örnek Biçimlendirme"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Yeni seçenek"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Kullanım sınırı"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Genel ayarlar yükleniyor..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Adres başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Oluşturuldu"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Adresler yükleniyor..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "{0} öğesini taşımak için bir hedef koleksiyon seçin."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Müşteri bilgileri güncellendi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "içinde değil"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Uygula"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Yeni ürün seçeneği"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Son sayfaya git"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "İptal"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Ürün varyantı başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Bu yöntemden iade"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Posta Kodu"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Önce ürün seçenekleri ekleyin"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Yeni vergi kategorisi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Seçenek ekle"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Kısmi iade tamamlandı"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Özel alanları ayarla"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Koleksiyonlar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Varyantı sil"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Değişiklik yapılmadı"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Varsayılan kargo bölgesi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Sebep:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Kargo adresi"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "{0} durumuna geç"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Vergi Kategorileri"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Özel koleksiyonlar mağazada görünmez"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Etkinleştirildiğinde ürün mağazada satışa sunulur"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Zamanlanmış görev çalıştırılamadı"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Müşteri Grupları"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Devre dışı"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Yeni promosyon"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Varsayılan Kargo Adresi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "İade gerekli"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Siparişi teslim et"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Kanal ayarlarını görüntüleme izniniz yok"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Son 30 gün"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Özellik değeri yok"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "İade için bir neden gereklidir"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Seçenek grubu kaldırılamadı"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Vergi kategorisi güncellenemedi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "İade başarıyla tamamlandı"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Güncelle"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Başlık 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Sipariş verildi"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profil başarıyla güncellendi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "bitiş"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Ödeme yöntemi"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Düzenle"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Varyant başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Koleksiyon adına göre filtrele"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Not eklendi"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Teslim edilecek miktarları seçin ve teslimat işleyicisini yapılandırın"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Siparişten fatura adresi kaldırıldı"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Başlangıç"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Çoğalt"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Sonuç yok"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Sütun ayarları"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {{count} stok konumu silinemedi} other {{count} stok konumu silinemedi}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Kod"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Seçenek grupları kaldırılamadı"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Sipariş teslim edildi"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "{name} konumuna aktar"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Kalan stok"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Bölgeden kaldır"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Bu kanal için genel olarak kullanılabilir dillerden seçin"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Bu adresi silmek istediğinizden emin misiniz?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Seçenek grubu atanamadı"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Varlık güncellenemedi"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Stok konumu başarıyla güncellendi"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "İşlemi Onayla"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Ülke başarıyla güncellendi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Özellikler"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Not eklenemedi"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Not silinemedi"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Sorgu belgesi uzatılamadı"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Not güncellenemedi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Kargo iadesi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Salt Okunur"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Genel görünüm çoğaltılamadı"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "{total} öğeden {shown} gösteriliyor • {selected} seçili"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Kargo Yöntemini Test Et"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Özellik Değerleri"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Varlık başarıyla güncellendi"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Tema"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} müşteri"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Bir dil seçin"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Çıkış yap"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Denemeler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Mevcut para birimi kodları"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Mevcut dil kodları"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "İçerik haritası"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Kategori"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Kanallar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Alt öğeler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Kod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Kupon kodu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Oluşturulma tarihi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Para birimi kodu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Müşteri"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Müşteri grubu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Müşteriler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Özel alanlar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Veri"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Varsayılan para birimi kodu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Varsayılan dil kodu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Varsayılan kargo bölgesi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Varsayılan vergi bölgesi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Açıklama"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Süre"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "E-posta adresi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Etkin"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Bitiş"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Hata"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Öne çıkan varlık"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Ad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Teslimat işleyici kodu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Varsayılan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Özel"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Tamamlandı"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Soyad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Ad"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Sipariş verildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "Üst ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Müşteri başına kullanım sınırı"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "İzinler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Konum"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Fiyat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Fiyatlara vergi dahil"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Vergili fiyat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Ürün varyantları"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "İlerleme"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Kuyruk adı"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Sonuç"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Yeniden denemeler"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Satıcı"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Kapatılma tarihi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Kargo satırları"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Başlangıç tarihi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Başlangıç"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Durum"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Stok seviyeleri"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Toplam"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Vergili toplam"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Tür"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Güncellenme tarihi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Kullanım sınırı"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Kullanıcı"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Değer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Değer listesi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Bölge"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Yöntem"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Vergi özeti"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Tüm kanallar için kullanılabilir dilleri ayarlar. Tek tek kanallar daha sonra bu dillerin bir alt kümesini destekleyebilir."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Koleksiyonlar başarıyla taşındı"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Kayıtlı"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "İşi İptal Et"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Bitiş"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Sayfa {0} / {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Oran"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Boyut, renk, vb."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Fasetlere göz at"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Bölge"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "İptal edildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Oluşturuldu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Teslim edildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Beklemede"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Gönderildi"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Görünümü Kaydet"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} seçildi"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Seçenek gruplarını ara..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Siparişi değiştir"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Seçili Öğeler"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Değerler"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Sipariş için müşteri ayarlandı"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Özellikler"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Bu gruptan {count} müşteriyi kaldırmak istediğinizden emin misiniz?} other {Bu gruptan {count} müşteriyi kaldırmak istediğinizden emin misiniz?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Eldeki Stok"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Arama indeksi yeniden oluşturma başlatılamadı"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Kargo Adresi"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Yeni bölge"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Yeni API Anahtarı"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Sütunu sil"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Mevcut olanı ata"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "boş"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Bunlar <0>{customerGroupName}</0> müşteri grubundaki müşterilerdir."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Genel görünümleri yönet"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Varsayılan kanal"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Kaynak, başlık ve boyutlarla yeni bir görsel ekleyin"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Özellik değeri oluşturulamadı"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Ürün seçeneği güncellenemedi"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Şifrenizi mi unuttunuz?</0><1>Sıfırlama talep et</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Kupon kodu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Müşteri doğrulandı"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Genel Ayarlar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Zamanlama"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Bir koleksiyon kendi alt öğesine taşınamaz"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Yeni Vergi Kategorisi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "Mevcut kanalda kullanılabilir stok konumu yok"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Kanal başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Müşteri başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Verileri görüntüle"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Görünümü Sil"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Müşteriye yeni bir adres ekleyin."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Daha fazla görünüm"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Seçili görselin özelliklerini düzenleyin"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Görünüm \"{viewName}\" uygulandı"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} özellik kanaldan başarıyla kaldırıldı"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Yeni Ürün"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Yeni varlık"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Kargoyu yeniden hesapla"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Mevcut varyant \"{0}\" için hangi seçeneklerin uygulanması gerektiğini seçin"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Varlıklar"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Bu, bu üründeki tüm seçenek gruplarını kaldıracak ve varyant kurulum seçimine geri dönecektir."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Fatura adresi"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Özellik değeri ekle"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Lütfen hedef koleksiyon seçin"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Değişiklikleri siparişe uygulamadan önce gözden geçirin."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Bir rol seçin"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Sipariş iptal edildi"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "İndirim"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Tüm türler"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Yalnızca taslak siparişler tamamlanabilir"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Ürün güncellenemedi"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "{0} satır ayarlanıyor"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Özellik değerleri ekle"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "sonra"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Kanal"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Sağlık Kontrolleri"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Tutar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Telefon Numarası"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Yeni müşteri"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Görsel"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Yönetici başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Ürün Seçenekleri"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Ülke seç"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Oluşturuluyor..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Bu genel görünümü silmek istediğinizden emin misiniz? Bu işlem geri alınamaz ve tüm kullanıcıları etkileyecektir."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Seçenek grubunu zorla kaldır"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Eklendi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Müşteri geçmişi"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "{entityIdsLength} {entityType} için özellik değerleri başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Müşteri gruptan kaldırılamadı"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Sistem"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Müşteri başına kullanım sınırı"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Fatura adresi değiştirildi"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Bir seçenek seçin"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Kişisele Kopyala"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "İade toplamı maksimum iade edilebilir tutar olan {0} tutarını aşıyor"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Genel Görünümü Sil"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Oluştur"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Her 30 saniyede"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Yeni ülke"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "{0} ile {1} arası"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Müşteri oluşturulamadı"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Odak noktası güncellendi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Seçenek değerleri"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Varsayılan Fatura Adresi"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Müşteri yok"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Ülkeler bölgeden kaldırılamadı"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Promosyon oluşturulamadı"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Bugün"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Dün"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Seçenek adı"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "{0} {1} öğesini bu bölgeden kaldırmak istediğinizden emin misiniz?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "{0} ek ücret ekleniyor"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Bağlantı href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Yedek: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Sipariş geçmişi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Geçersiz kıl"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "İşlem ID gereklidir"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "regex ile eşleşir"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Genel görünüm başarıyla yeniden adlandırıldı"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Etiket seçilmedi"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Geri"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Görünüm başarıyla yeniden adlandırıldı"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Filtre uygula"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Son Sonuç"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Gruba eklendi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "İçgörüler"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Varyant Oluştur"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Kargo yöntemi test ediliyor..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Koyu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Test Sonuçları"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Müşteri ekle"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Değişiklikleri Kaydet"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Adres güncellendi"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "İade başarıyla işlendi"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Yeni Bölge"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Koleksiyon konumu güncellenemedi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "İade"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Değiştir"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Genel dil yapılandırılmamış"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "{0} öğe kaldırılıyor"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "İzle"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Varyant oluştur"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "{facetName} için özellik değerleri"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Düzeni Kaydet"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Şifre sıfırlama doğrulandı"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Görünüm silinemedi"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Bu sayfadan ayrılmak istediğinizden emin misiniz? Kaydedilmemiş değişiklikler kaybolacak."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Başlık sütununu değiştir"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Yeni Promosyon"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Seçenek değeri adı"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Son kullanım"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Varsayılan vergi kategorisi"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug ayarlandı"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Odak noktası güncellenemedi"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Bölge başarıyla güncellendi"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "İl/Bölge"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Seçenek grubu güncellenemedi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Kanal varsayılanları"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Vergi kategorisi oluşturulamadı"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "{columnId} sütunu için filtre kriterlerini belirleyin"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Ülke"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Basit ürün"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "İş Kuyruğu"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Kapatmadan önce API anahtarını kaydettiğinizi lütfen onaylayın."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Silmeyi onayla"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Sipariş değiştirilemedi"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "%{taxRate} vergi dahil"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Sipariş metrikleri"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Görüntüleme dili seçin"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Kimlik doğrulama yöntemleri"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "başlangıç"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "API anahtarı döndürülemedi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "içinde"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Rolleri ara..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Ürün Varyantları"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Genel Görünümleri Yönet"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "İşleniyor..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} bulundu"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Tarih aralığı seçin"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Ürün"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "API Anahtarını Döndür"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Kategori"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Taşınıyor..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Ata"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Satıcı başarıyla oluşturuldu"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Kargo yöntemi başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Ürün varyantı güncellenemedi"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Yeniden sıralamak için sürükleyin"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Bölgeler"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Sildiğiniz {count, plural, one {# stok konumunda} other {# stok konumunda}} kalan stokla ne yapılacağını seçin. Seçili tüm konumlar kalan stoklarını seçtiğiniz tek konuma aktarır veya stok atılır."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Faset değerlerini ara..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Not"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Mevcut diller"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "{0} tane daha yükle ({remaining} kalan)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Özellik değerleri"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Öğeler yeniden sıralanamadı"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Toplam Sipariş"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Bu sipariş için uygun kargo yöntemi bulunamadı."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Ürün seçeneği ekle"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Kargo"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions bir DashboardBaseWidget içinde kullanılmalıdır"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Bu seçenek grubu mevcut varyantlar tarafından kullanılmaktadır. Zorla kaldırma bu varyantları etkileyebilir. Emin misiniz?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "E-posta güncelleme talebi alındı"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Duruma geçiş hatası"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Müşteri grubu başarıyla oluşturuldu"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Yeni pencere"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Ödeme yetkilendirildi"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Rol başarıyla güncellendi"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Bir ülke seçin"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Kargo yöntemi güncellenemedi"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} stok konumu silindi} other {{deleted} stok konumu silindi}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Kargo Yöntemleri"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Bir adres seçin"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Evet"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Odak Noktasını Ayarla"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "bitiş"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Bir para birimi seçin"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Not içeriğini veya görünürlüğünü güncelleyin"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Son Siparişler Widget'ı"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "{collectionName} için koleksiyon içeriği"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Kargo yöntemi değiştirildi"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Vergi açıklaması"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "küçük eşittir"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "eşit değildir"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Yenile"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "örn. Beden"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Ödemeyi tamamla"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Kanallar"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Kargo iade edildi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Varlık türü"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Yeni Stok Konumu"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "Hatadan önce {successfulRefundCount} ödeme iade edildi. Ayrıntılar için sipariş geçmişini kontrol edin."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Öğe seç"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Yeni ürün"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Etiketleri Yönet"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Ürünler iade edildi"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Eylem ekle"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Mevcut varyanta seçenekler ata"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "{0} çoğalt"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Gruptan kaldır"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Teslimat durumu güncellenemedi"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Seçenekler, fiyatlandırma ve stokla yeni bir ürün varyantı oluşturun"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Özel özellikler mağazada görünmez"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Bir vergi kategorisi seçin"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Oluşturuldu"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Çalışmıyor"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Atanmış"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Başlık 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Mevcut Dilleri Seç"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "{0} öğe ekleniyor"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Sonrasına satır ekle"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Toplam vergi"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Taslak sipariş durumu"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Ürün seçenekleri başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Konumlar yükleniyor…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Ödeme yöntemi oluşturulamadı"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Özellik değeri başarıyla oluşturuldu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Pazarlama"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Taslak sipariş silindi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "büyüktür"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Metrik Widget'ı"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Para birimlerini ara..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Kanaldan kaldır"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Başlık"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Görsel ekle"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Satıcı güncellenemedi"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Ülke başarıyla oluşturuldu"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Satıcı seç"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Etiketler yükleniyor..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Özellik başarıyla oluşturuldu"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} varyant"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Ödeme tamamlanamadı"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Fatura adresi yok"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {{1} stok konumu silinemedi} other {{2} stok konumu silinemedi}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Özellik"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Etkin kanaldan kaldırılamaz"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Ayarlanmadı"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Zorla kaldır"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Yeni Kanal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Seçenek Grubu Adı"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "VE"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Müşteri grubu oluşturulamadı"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Rol oluşturulamadı"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Ürün adı"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Teslimat durumu başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Ürünler"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Adres oluşturuldu"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API anahtarı başarıyla döndürüldü"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Seçenek grubu ekle"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "{0} iade et"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Slug'ı manuel olarak girin"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Kullanılabilir widget yok"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Ödeme iptal edilemedi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Ödeme başarıyla iptal edildi"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Genel görünüm başarıyla çoğaltıldı"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Oluşturan"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Varyantları filtrele..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Başka bir para biriminde fiyat ekle"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "E-posta Adresi veya tanımlayıcı"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "İade #{0}, {1} durumuna geçti"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Müşteriler"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Başlık 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Stok konumu güncellenemedi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Sipariş gönderildi"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Adresi Kaydet"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Genel Yap"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Sonraki durumu seç"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Uyarı yok"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "{0} koleksiyon {2}'ye taşınıyor"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "arasında"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Not başarıyla eklendi"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Not başarıyla silindi"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Not başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "İade tamamlanamadı"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Stok seviyesi"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Öğe ekle"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API anahtarı başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Önizleme yükleniyor..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Aramaya dön"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Görünüm başarıyla çoğaltıldı"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Seçenek grubunu kaldır"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Açıklama"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Ülkeler"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Sokak Adresi 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Genel görünüm başarıyla silindi"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Düzeni Düzenle"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Kanala ata"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Bu hafta"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Ürün seçenek grubu başarıyla oluşturuldu"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "{0} tutarında manuel ödeme ekle"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "içinde"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "E-posta"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Yönetici güncellenemedi"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Bu tablo için kişisel kaydedilmiş görünümlerinizi yönetin"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Etiketlere göre filtrele"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Yönetici panosuna erişmek için oturum açın"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Siparişe ödeme ekle ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Yanlış"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Açık"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "eşittir"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Seçenekler oluştur"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Şifre güncellendi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "içermez"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Seçenek Grubu"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Aşağıdaki adres bilgilerini düzenleyin."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Vergi kategorisi başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Koleksiyonlar taşınamadı"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Ödeme durumu güncellenemedi"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Sipariş özetiniz"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Yükle"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Seçenekli ürün"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Tüm {0} sonuç gösteriliyor"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Arama Kimliği"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} daha"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Seçenek Grupları"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Özel alanlar"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Tüm olası sipariş durumları ve geçişleri. Mevcut durum vurgulanmıştır."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Siparişler"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Sipariş Özeti Widget'ı"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Ürünler Ekleniyor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Ek ödeme düzenleniyor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Ödeme Düzenleniyor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "İptal Edildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Oluşturuldu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Teslim edildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Taslak"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Değiştiriliyor"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Kısmen teslim edildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Kısmen gönderildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Ödeme Yetkilendirildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Ödeme Tamamlandı"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Gönderildi"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "İzlenen Kaynaklar"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Varlık Bilgisi"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Sipariş Toplamı"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Sadece yöneticilere görünür"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Adet"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Etiketler"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Süper Yönetici"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Bazı kaynaklar çalışmıyor"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Kullanılabilir eylemler"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Bağlantı ekle"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Etkinleştirilirse, filtreler üst koleksiyondan miras alınacak ve bu koleksiyondaki filtrelerle birleştirilecektir."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Bir bölge seçin"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Kargo yöntemlerini test et"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Ödeme başarıyla tamamlandı"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} bölgeden kaldırıldı"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Etkinleştir"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Ödeme Yöntemleri"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Yetkilendirildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "İptal edildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Oluşturuldu"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Reddedildi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Hata"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Başarısız"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Beklemede"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Kapatıldı"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Ortalama Sipariş Değeri"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Bölge oluşturulamadı"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Stok seviyeleri"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "API anahtarı güncellenemedi"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Sipariş satırları"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Genel görünüm yeniden adlandırılamadı"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "URL ve hedef seçenekleriyle yeni bir köprü ekleyin"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Yükseklik"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} tutarında iade gerekiyor. Ödeme tutarlarını seçin ve devam etmek için not girin."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Birim fiyat"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Zamanlama Deseni"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Ödeme başarısız oldu"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Kanal ekle"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Ürün seçenek grubu güncellenemedi"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Kanalları ara..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Müşteri grupları ekle"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Mevcut Diller"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Seçimi sıfırla"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Adres yok"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Ödeme yöntemi başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Müşteri bilgileri güncellendi"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Görünüm genele dönüştürülemedi"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Ürün Varyantları"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Ürünler"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Promosyonlar"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Ürün seçeneği oluşturulamadı"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Eski e-posta:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Tüm kullanıcıların erişimine açmak için bir görünümü \"Genel\" olarak kaydedin."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Varyantlar oluşturulamadı"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Bu varyantın stokta olmadığı kabul edilen stok seviyesini ayarlar. Negatif değer kullanmak sipariş öncesi desteğini etkinleştirir. Ürün varyantları tarafından geçersiz kılınabilir."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Anahtarı Döndür"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Ürün varyantları oluşturulamadı"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Şifreyi gizle"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Yeni satıcı"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "örn. Kırmızı, Büyük, Pamuk"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Profil güncellenemedi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Kupon kodları kaldırıldı"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Filtreyi temizle"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Bölgeler"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Yüklemek için dosyaları buraya bırakın"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Tüm görünür varyantları aç/kapat"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Doğrulandı"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Yeni seçenek grubu"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Son güncelleme {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Henüz genel görünüm oluşturulmamış."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Rol güncellenemedi"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Tam API anahtarı yalnızca bu kez görüntülenecektir. Şimdi kopyalayın veya indirin — daha sonra alınamaz."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Koleksiyon başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Ödeme yöntemi başarıyla güncellendi"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Görünüm başarıyla silindi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Seçenek grubu {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "VEYA"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Etiketleri yönet"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Kupon kodu siparişten kaldırıldı"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Hiçbir zaman"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Özellik değeri güncellenemedi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Grubu kaldır"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Sipariş teslim edildi"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Kargo adresi yok"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Sorgu uzatma geçersiz GraphQL sözdizimi içeriyor"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Sorgu uzatma hatası"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Sorgu uzatma hatası:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Sorgu uzatma geçersiz: en az bir üst düzey alan olmalı"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Sorgu uzatma uyuşmazlığı:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "genel"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Vergi kategorisi başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Taşı"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Mevcut etiketleri düzenle veya sil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Bu kargo yönteminin uygunluk kontrolü koşulları mevcut sipariş ve kargo adresi için karşılanmamaktadır."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Kupon kodu ekle"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Sipariş için kupon kodu ayarlandı"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Özel Alanlar"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Yeni Kargo Yöntemi"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Stok konumlarını sil"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "büyük eşittir"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Önizleme"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{1} adetten {0} adedi karşılanabilir"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Ay başından bugüne"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Müşteri talebi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Kargoda hasar gördü"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Mevcut değil"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Diğer"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Yanlış ürün"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Değişiklik özeti"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "İadeler ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Son Çalıştırılma"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Ödeme detayları"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Arama indeksini yeniden oluştur"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Çalışıyor"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Her 60 saniyede"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Müşteri grubu güncellenemedi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Ödeme metadata"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Değişikliği iptal et"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Aynı pencere"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Tabloya filtre uygulayın ve başlamak için \"Görünümü Kaydet\"e tıklayın."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Roller"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Ek ödeme gerekli"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Sipariş güncellenemedi"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Seçiliyle..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Stok konumu oluşturulamadı"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "küçük eşittir"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "{customerGroupName} için müşteri grubu üyeleri"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "İl"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "İzleme"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Teslimat #{0} oluşturuldu"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Bekleyen arama dizini güncellemeleri çalıştırılıyor"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Bu varsayılan bir Rol'dür ve değiştirilemez"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Kaydedilmiş görünümlerim"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "İl / Bölge"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Etkin"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Sayfa başına öğe"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Üyeleri düzenle"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Eldeki stok"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "{columnId} ile filtrele"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Uyarılar"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Seçenek Değerleri"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Değişiklikleri önizle"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "{entityType} kanaldan kaldırılamadı"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Varyant başarıyla silindi"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Seçili bağlantının özelliklerini düzenleyin"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Satışlar"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Bir hedef koleksiyon seçin"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Son siparişleriniz"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Zamanlanmış Görevler"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Bu öğeyi silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Varyantlar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Satıcılar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Ayarlar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Ayarlar Deposu"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Başlık 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Vendure'a hoş geldiniz"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Kargo Yöntemleri"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} iade edilebilir)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Tanımlayıcı"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Koleksiyon güncellenemedi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Fiyat ve vergi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Sipariş bulunamadı"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Hata"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Sipariş değiştirildi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Şifre sıfırlama talebi alındı"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Tahsis edilen ödeme tutarı iade toplamına eşit olmalıdır"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "örn. Küçük"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "{0} {entityType} öğesini mevcut kanaldan kaldırmak istediğinizden emin misiniz?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Etiket ekle..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Ürün seçenek grubu oluşturulamadı"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} öğe seçildi"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Dilleri ara..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Stok Konumları"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Önceki sayfaya git"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "İçerik"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Genel görünüm kişisel görünüme dönüştürülemedi"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "İşin sonucu"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Ödeme ekle ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Sistem"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Varyant adı"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Kaldır"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Müşteri güncellenemedi"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Seçenek grupları kaldırılsın mı?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Bu, mevcut filtre ayarlarına dayalı koleksiyon içeriğinin bir önizlemesidir. Koleksiyonu kaydettikten sonra, içerik yeni filtre ayarlarını yansıtacak şekilde güncellenecektir."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} müşteri gruptan kaldırıldı} other {{count} müşteri gruptan kaldırıldı}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Vergi Kategorileri"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Vergi Oranları"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Müşteriler gruptan kaldırılamadı"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Genel ayarlar yüklenemedi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "İade edilecek öğeleri seçin ve isteğe bağlı olarak stoka iade edin"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Kaydet"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "{0} satırdan {selectedRowCount} tanesi seçildi."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Sipariş değişikliklerini önizle"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Ürün seçenek grubu başarıyla güncellendi"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Sayfa varsayılan sorgu ile devam edecek."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Sokak Adresi"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Başka faset yok"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Arama indeksi yeniden oluşturma başlatıldı"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Koleksiyon konumu güncellendi"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Seçenek grubu adı"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "「{newOptionInput}」ekle"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Yeni ürün varyantı"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "İade geçiş yaptı"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Yerel kimlik doğrulama stratejisi kullanılıyor"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} kanala atanamadı"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Varsayılan Dil"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Teslim ediliyor..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Ürüne seçenek grubu ekle"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "{0} önizlemesi"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Satıcı başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Sipariş duruma geçirilemedi"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Tümünü göster ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Vergi oranı oluşturulamadı"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Bu API anahtarını kaydettim"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Mağazanız ve kanallarınız için mevcut dilleri yapılandırın"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Ürün başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Ürün varyantı ekle"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Yazın ve eklemek için Enter veya virgül tuşuna basın..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Notu Düzenle"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Varlık bulunamadı. Filtrelerinizi ayarlamayı deneyin."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Seçenek Ekle"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Seçenek grubunu kaydet"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "{createCount} varyant oluştur"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Bu kargo yöntemini test etmek için \"Testi Çalıştır\"a tıklayın."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Yönetici başarıyla güncellendi"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Filtreleri temizle"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "{1} ile {2} arası teslimat #{0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Genel görünüm silinemedi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Varsayılan dil"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Durum"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Seçenek bulunamadı"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "İkili"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Seçenek grubu başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Yeni kargo yöntemi"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Her 10 saniyede"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "vergi hariç:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Konuma Stok Ekle"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Seçenek değeri başarıyla eklendi"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Koleksiyon yeni üst öğeye taşındı"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Seçenek grubu kaldırıldı"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Seçili duruma geç"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "{formattedDiff} tutarında ek ödeme gerekli olacak."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Varsayılan olarak envanteri izle"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{total} öğeden {selected} seçili"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Kargo yöntemi başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Yeni Müşteri Grubu"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Müşteriye görünür"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Seçenek grubu başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Vergi Oranları"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug otomatik oluşturulacak..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Müşteri bulunamadı"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "{0} seç"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Eklenecek yeni özellik değerleri:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "İade işlenemedi"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Ad"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "içerir"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Seçenek grubu bulunamadı"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Öğe bulunamadı"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Ara toplam"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Teslim edilen ürünler ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Değer güncellendi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Doğrulanmamış"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Miktar"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Filtre ekle"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Vergi kategorisi"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Test verileri güncellendi. Güncellenmiş sonuçları görmek için \"Testi Çalıştır\"a tıklayın."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "içinde değil"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Sipariş satırı güncellendi"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Yeni Ödeme Yöntemi"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Yinelenen değer \"{trimmed}\" zaten mevcut"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Sebep"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Müşteri grupları"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} kanaldan başarıyla kaldırıldı"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Seçenek Grupları"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Ek ücret ekle"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Mevcut özellik değerleri"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "{totalPages} sayfanın {page}. sayfası"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Geçen ay"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Ülke Ekle"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Öğeyi kaldır"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "küçüktür"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Varyant eklenemedi. Ana ürünün etkin olduğundan emin olun."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Bilinmeyen bir hata oluştu"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Metrikler"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Dil"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Yeni Koleksiyon"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "İade et ve siparişi iptal et"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "E-posta güncelleme doğrulandı"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "arasında"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "İade et ve iptal et"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Kargo yöntemleri test ediliyor..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Kargo yöntemi oluşturulamadı"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} kanala başarıyla atandı"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Genel Diller"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Yeni yönetici"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Taslağı sil"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Kaynak"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Kullanılabilir işlem yok"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Kanal güncellenemedi"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Genel"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Ürün kanaldan kaldırılamadı"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Yeni adres ekle"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Özellik başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Bölge başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Değer"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Müşteri güncellendi"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Fiyat dönüşüm faktörü"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Satıcı siparişi"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Yeni özellik"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Bu seçenek grubunu üründen kaldırmak istediğinizden emin misiniz?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Açıklama (alt)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Etiket bulunamadı"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Varsayılan para birimi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Bu değişiklikler için ödeme veya iade gerekmez."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Toplam Gelir"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Sonraki Çalıştırma"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Not özel"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Orta tarih"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Geçersiz sayı"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Henüz herhangi bir görünüm kaydetmediniz."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Bu görünümü silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Sipariş sürecini görüntüle"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Görünüm çoğaltılamadı"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Varsayılan kargo adresi olarak kullan"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Slug'ı manuel olarak düzenle"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Koleksiyon içeriğini önizlemek için filtre ekleyin."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Ürün Seçenek Grubu"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Ara toplam"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "küçüktür"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "İade ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Sipariş özel alanları güncellendi"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Hesaplayıcı"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Seçenek grubu kanaldan kaldırılamadı: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "İş verilerini görüntüle"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Üst düzeye taşı"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Temizle"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Sipariş Özeti"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Varlıkları ara..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Yeni Özellik"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "{entityType} öğesini kanala ata"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Devam et"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Promosyonlar"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Hata mesajı"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Başka bir konum için stok seviyesi ekle"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Adresi Sil"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Özellik güncellenemedi"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters bir WidgetFiltersProvider içinde kullanılmalıdır"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Adresi Düzenle"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Özellik kanaldan kaldırılamadı: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Bağlantı ayarla"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Yeni Satıcı"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Görseli düzenle"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Varyantları Yönet"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Stok tahsis edildi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "büyük eşittir"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Bu varyantın stokta olmadığı kabul edilen stok seviyesini ayarlar. Negatif değer kullanmak sipariş öncesi desteğini etkinleştirir."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Ürün seçenekleri oluştur"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Kaydediliyor..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Sonucu görüntüle"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Sayfa başına satır"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Koleksiyonlar yükleniyor..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Özellik değeri başarıyla güncellendi"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Varlık ekle"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Değişiklikleri kaydet"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Müşteri gruba eklendi"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Satıcı siparişleri"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Seçenek değeri eklenemedi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "{groupName}'e seçenek değeri ekle"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} ürün iade edildi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Henüz seçenek grubu tanımlanmamış. Ürününüzün farklı varyantlarını oluşturmak için seçenek grupları ekleyin (örn. Beden, Renk, Malzeme)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Yeni e-posta:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Ödeme yöntemi güncellenemedi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Mevcut:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Oluşturulma tarihi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Ürün varyantı oluşturulamadı"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Dil: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Genel dil ayarlarını görüntüleme izniniz yok"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Vergi oranı başarıyla oluşturuldu"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Başlık 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Kupon kodları eklendi"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Etkin"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Vergi matrahı"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Daha fazla yükle"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "İade tamamlandı"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} başarıyla çoğaltıldı"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Yeni Seçenek Grubu"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Henüz sonuç yok"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Ödeme tamamlandı"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Kullanılabilir koşullar"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Etkin filtreler"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Tümünü temizle"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "büyüktür"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Kapat"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Siparişe ödeme ekle"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Yükleniyor..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Token, API istekleri yaparken kanalı belirtmek için kullanılır."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Adres bulunamadı"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "Teslimat ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "İade edilecek ödemeleri seçin"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "{failed} {entityName} silinemedi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Stok tükenmesi eşiği"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Ürün kanaldan başarıyla kaldırıldı"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Değer güncellenemedi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "API anahtarı oluşturulamadı"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "İadeyi tamamla"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Ödeme yöntemi gereklidir"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Müşteri gruba eklenemedi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Varyantları yönet"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Genel görünüm \"{viewName}\" uygulandı"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Müşteri kaydedildi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Bölgeler"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Satıcıları ara..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Promosyon başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Seçenek"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Sipariş süreci"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Telefon numarası"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Özel"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Varyant"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Genel ayarlar başarıyla güncellendi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API anahtarı başarıyla güncellendi"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Bu diller tüm kanalların kullanımına açık olacaktır"

--- a/packages/dashboard/src/i18n/locales/uk.po
+++ b/packages/dashboard/src/i18n/locales/uk.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "Повне ім'я"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Вибрати елементи"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "Переглянути зміни"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Код відстеження"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Вибрані дозволи будуть застосовані до цих каналів."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Опції товару"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Нова податкова ставка"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Призначити існуючу групу опцій або створити нову"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Нова роль"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Квартира, офіс тощо"
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Більше немає елементів"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Редагувати посилання"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Додайте принаймні один товар до замовлення"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Додайте товари для створення тестового замовлення"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Не вдалося створити адресу"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Перемкнути все"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "Редагувати значення JSON"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Використання зовнішньої стратегії аутентифікації: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Виберіть причину..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Заголовок 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "Не вдалося додати платіж"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Оновлено"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Не вдалося оновити глобальні налаштування"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Замовлення успішно виконано"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "Ви впевнені, що хочете видалити {0} {entityName}?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Глобальний поріг відсутності на складі"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Керування мовами"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Дублювання... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Успішно видалено"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "Видалити з поточного каналу"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "Видалено {selectionLength} ресурсів"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Податкову ставку успішно оновлено"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Введіть власну причину..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Тип"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "Вибрати {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Переглянути значення"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Видалити рядок"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Умови"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Поточний"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Немає виконань"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {Не вдалося видалити {1} складську локацію: {messages}} few {Не вдалося видалити {2} складські локації: {messages}} many {Не вдалося видалити {2} складських локацій: {messages}} other {Не вдалося видалити {2} складських локацій: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "При увімкненні ціни, введені в каталозі товарів, включатимуть податок для зони за замовчуванням."
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "Створіть варіанти для вашого товару"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Чернетку замовлення завершено"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Автооновлення: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "Перевірки стану"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "Видалено {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "Перевірки стану"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Продавці"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Опції"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {Успішно скасовано {fulfilled} завдання} few {Успішно скасовано {fulfilled} завдання} many {Успішно скасовано {fulfilled} завдань} other {Успішно скасовано {fulfilled} завдань}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Продавець"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "Артикул:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "Додати платіж"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Перевірте цей спосіб доставки, симулюючи замовлення, щоб дізнатися, чи підходить він і яка буде вартість доставки."
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "Дослідити Enterprise Edition"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Місця зберігання"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Обробник виконання"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Замовлення"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Вибрати ролі"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Роль успішно створено"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Ви впевнені, що хочете видалити цей варіант?"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "Усі ресурси працюють"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Не вдалося створити адміністратора"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Ні"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Варіант товару успішно оновлено"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "Не вдалося видалити {failed} {entityName}: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Товар успішно оновлено"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Не вдалося оновити країну"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Введіть принаймні 2 символи для пошуку..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Прізвище"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Заголовок посилання"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Групу клієнтів успішно оновлено"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Користувацькі поля змінено"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Місце зберігання успішно створено"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Невідома помилка"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Сума повернення не може бути від'ємною"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Переглянути деталі"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "Виберіть канал для призначення {0} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Клієнта успішно створено"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "Останні 7 днів"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Не вдалося створити канал"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Режим розробника"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Нова роль"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Не вдалося видалити ресурси: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Повернути на склад"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Видимість"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Варіанти товару"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Нова група клієнтів"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "Створити «{0}»"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Перейменувати"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Оберіть бажану мову відображення та налаштування локалі"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "Успішно видалено {successCount} груп опцій з каналу"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Спосіб доставки не підходить для цього замовлення"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Не вдалося оновити адресу"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Адресу успішно видалено"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Податкова ставка"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Чернетка замовлення не готова до завершення"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Нова колекція"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Аналітика"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Запустити"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Не вдалося оновити податкову ставку"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Це вміст колекції <0>{collectionName}</0>."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "приватне"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Варіант продукту успішно створено"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Батьківський товар"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Місто"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Адміністратори"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Загальна ціна: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Перейти на наступну сторінку"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Видалити посилання"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Це поле доступне лише для читання"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Кількість замовлень"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Замовлення успішно оновлено"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Успадкувати фільтри"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Керування глобальними збереженими поданнями, видимими для всіх користувачів"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "Пошук способів оплати..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Адресу доставки знято для замовлення"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "Створити {enabledCount} варіантів"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "Платіж #{0} переведено до {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Помилка завантаження історії клієнта: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} {entityType} успішно видалено з каналу"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Додати значення опції"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Глобальні налаштування"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "після"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Варіант продукту успішно оновлено"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Редагувати значення фасетів"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Додавання..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "Перемістити колекції"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Ролі"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Вигляд сіткою"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Не вдалося видалити адресу"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Способи доставки недоступні"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Глобальне подання успішно перетворено на особисте"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Виконання переведено"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "Ви впевнені, що хочете видалити {selectionLength} ресурсів?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Увійти"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Вигляд списком"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Тестове замовлення"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Оберіть клієнта для продовження"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Групу опцій успішно призначено"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Запустити тест"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Податкова ставка: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Будь ласка, додайте товари та вкажіть адресу доставки для запуску тесту."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Перемкнути рядок заголовка"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Вибрати адресу"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "Перевірка відповідності платежу"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Податкова зона за замовчуванням"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Чернетка замовлення готова до завершення"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Метадані"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Фільтрувати..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Нове значення фасету"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Канал успішно оновлено"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Показати менше"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Коротка дата"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Доступні валюти"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "Вибрати {0} елементів"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Оформлено"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Ротація цього ключа негайно анулює поточний ключ. Усі інтеграції, що його використовують, перестануть працювати до оновлення новим ключем."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Дані, передані завданню"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Підтвердити перехід"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Ціль посилання"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Завершити чернетку"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Назва"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Не вдалося виконати замовлення"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Разом"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Введіть ID транзакції для цього розрахунку повернення"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Ваш API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Ви впевнені, що хочете видалити цю чернетку замовлення?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Виконання створено"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "Знайдено {0} підходящих способ(ів) доставки"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "Розміри"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Показати пароль"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(макс: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Компанія"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Додати стовпець після"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Дії"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Знижки"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Введіть примітку до повернення"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Рядок замовлення видалено"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Вміст:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Ключ"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Підтвердити"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "Не вдалося створити колекцію"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Перейти на першу сторінку"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Не вдалося створити товар"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Клієнт"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Помилка завантаження історії замовлень: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Адресу доставки встановлено для замовлення"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Фокусна точка"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Один варіант, без опцій"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Виберіть наступний стан для замовлення"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Локаль"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Заплановані завдання"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Введіть ID транзакції"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Оновити дані"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "Додати або видалити значення фасетів для {0} {entityType}"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Це значення фасетів для фасету <0>{facetName}</0>."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Платіж успішно додано до замовлення"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Адреса для виставлення рахунків встановлена для замовлення"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Не вдалося оновити зону"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Пароль"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "Не вдалося видалити"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Заплановане завдання буде виконано"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Нове місце зберігання"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Дозволи"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Адресу доставки змінено"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Товари не знайдено"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Додати рядок до"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "Перейти до {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Цей місяць"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Не вдалося створити фасет"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Не вдалося скасувати позиції замовлення"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "ID транзакції"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Виділено"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "Додати ще одну групу опцій"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Виберіть, що зробити із залишками товару"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Огляд Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Кожні 5 секунд"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "Колекцію успішно створено"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Ціна"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Чернетка замовлення"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Область дії"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Додати умову"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Спосіб доставки підходить для цього замовлення"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Адміністратори"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Видалено з групи"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Ширина"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "Не потрібен платіж або повернення"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "Завантажити як файл .env"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "При увімкненні акція доступна у магазині"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "При відстеженні рівні запасів варіантів товару будуть автоматично коригуватися при продажу. Це налаштування можна перевизначити для окремих варіантів товару."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Спосіб доставки встановлено для замовлення"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Не вдалося оновити акцію"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Зображення"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "Пошук {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Редагувати ресурс"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "Скасувати платіж"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Черга завдань"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Ресурси"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Адреса електронної пошти"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Перегенерувати slug з вихідного поля"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Успадкувати з глобальних налаштувань"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Результати не знайдено"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "Поточний статус"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Встановіть адресу доставки та оберіть спосіб доставки"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "Вимк."
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Сховище налаштувань"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Черга"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Нова податкова ставка"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "Платіж переведено"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Залишилося:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "Дуплікатор з кодом «{duplicatorCode}» для {entityName} не знайдено"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Ціни включають податок для зони за замовчуванням"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Разом повернення:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Переглянути результат завдання"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Перевірте свої способи доставки, симулюючи нове замовлення."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Елементи не вибрано"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} вибрано"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Країни не знайдено"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Варіанти успішно створено"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Генерувати slug автоматично"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Доплата"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "Способи оплати"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Запас"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Клієнти не знайдено"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Використовувати глобальний поріг відсутності на складі"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "Нова група опцій товару"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "Стан платежу успішно оновлено"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Створити новий"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Сума повернення"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Адресу видалено"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Доступні лише ролі, призначені вашому обліковому запису."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Товар додано до замовлення"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "Редагувати фокусну точку"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "Продавці не знайдено"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "Ресурс"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Ця група опцій використовується ще одним товаром. Зміни вплинуть і на нього.} other {Ця група опцій використовується у # товарах. Зміни вплинуть на всі.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Мої збережені подання"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Новий канал"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Не вдалося створити продавця"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "Налаштувати параметри дублювання для {0}s"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Немає варіантів, що відповідають поточному фільтру."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Адреси"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "Додати нове значення опції до групи опцій {groupName}"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Зміна замовлення #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Додати стовпець до"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Мови каналу"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Не вдалося створити групу опцій"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "Істина"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Вибрати клієнта"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Замовлення переведено"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "У цього товару є існуючі варіанти, але не визначено групи опцій. Вам потрібно додати групи опцій перед створенням нових варіантів."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "до"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Видалити чернетку замовлення"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Каталог"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Новий спосіб оплати"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Акцію успішно оновлено"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {Не вдалося скасувати {rejected} завдання} few {Не вдалося скасувати {rejected} завдання} many {Не вдалося скасувати {rejected} завдань} other {Не вдалося скасувати {rejected} завдань}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Виберіть канал"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Мова відображення"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Деталі виконання"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Списати залишки товару"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Зараз"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Канали"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Подання успішно перетворено на глобальне"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "до"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "Розмір"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "Переклад для {0} не знайдено"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Новий клієнт"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "Останні замовлення"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ ще {leftOver}"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Використовувати як адресу виставлення рахунку за замовчуванням"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "Видалити"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "Вимкнути"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "Колекції"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Додати варіант"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Не вдалося створити країну"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Країни"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "Не вдалося створити опції товару"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Не вдалося перейменувати подання"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Доступно"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Звичайний"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Фільтри"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Групи клієнтів"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Клієнти"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Приклад форматування"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Нова опція"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Ліміт використання"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Завантаження глобальних налаштувань..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Адресу успішно оновлено"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Створено"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Завантаження адрес..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "Виберіть цільову колекцію для переміщення {0}."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Дані клієнта оновлено"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "не у"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Застосувати"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Нова опція товару"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Перейти на останню сторінку"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Скасувати"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Варіант товару успішно створено"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Повернення цим способом"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Поштовий індекс"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "Спочатку додайте опції товару"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Нова податкова категорія"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "Додати опцію"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Часткове повернення завершено"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Встановити користувацькі поля"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "Колекції"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Видалити варіант"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Зміни не внесено"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Зона доставки за замовчуванням"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Причина:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Адреса доставки"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "Перейти до {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Податкові категорії"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Приватні колекції не видимі в магазині"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "При увімкненні товар доступний у магазині"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Заплановане завдання не може бути виконане"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Групи клієнтів"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "Вимкнено"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Нова акція"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Адреса доставки за замовчуванням"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Потрібне повернення"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Виконати замовлення"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "У вас немає дозволу на перегляд налаштувань каналу"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "Останні 30 днів"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Немає значень фасетів"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Потрібно вказати причину повернення"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Не вдалося видалити групу опцій"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Не вдалося оновити податкову категорію"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Повернення успішно проведено"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Оновити"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "Заголовок 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Замовлення розміщено"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Профіль успішно оновлено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "кінець"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "Спосіб оплати"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Редагувати"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Варіант успішно оновлено"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "Фільтрувати за назвою колекції"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Примітку додано"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Виберіть кількість для виконання та налаштуйте обробник виконання"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Адреса для виставлення рахунків видалена із замовлення"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Починається"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Дублювати"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Немає результатів"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Налаштування стовпців"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {Не вдалося видалити {count} складську локацію} few {Не вдалося видалити {count} складські локації} many {Не вдалося видалити {count} складських локацій} other {Не вдалося видалити {count} складських локацій}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Код"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Не вдалося видалити групи опцій"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Замовлення доставлено"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "Перенести до {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Залишки товару"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Видалити із зони"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Виберіть з глобально доступних мов для цього каналу"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Ви впевнені, що хочете видалити цю адресу?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Не вдалося призначити групу опцій"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Не вдалося оновити ресурс"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Місце зберігання успішно оновлено"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Підтвердити дію"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Країну успішно оновлено"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Фасети"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Не вдалося додати примітку"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Не вдалося видалити примітку"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "Не вдалося розширити документ запиту"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Не вдалося оновити примітку"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Повернути вартість доставки"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Лише для читання"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Не вдалося дублювати глобальне подання"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "Показано {shown} з {total} • вибрано {selected}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Перевірити спосіб доставки"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Значення фасетів"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Ресурс успішно оновлено"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Тема"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} клієнтів"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Виберіть мову"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Вийти"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Спроби"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Доступні коди валют"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Доступні коди мов"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Хлібні крихти"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Категорія"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Канали"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Дочірні елементи"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Код"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Код купона"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Створено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Код валюти"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Клієнт"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Група клієнтів"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Клієнти"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Користувацькі поля"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Дані"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Код валюти за замовчуванням"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Код мови за замовчуванням"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Зона доставки за замовчуванням"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Податкова зона за замовчуванням"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Опис"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Тривалість"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Адреса електронної пошти"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Увімкнено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Закінчується"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Помилка"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Обраний ресурс"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Ім'я"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Код обробника виконання"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "За замовчуванням"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Приватний"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Проведено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Прізвище"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Назва"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Замовлення розміщено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "ID батьківського елемента"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Ліміт використання на клієнта"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Дозволи"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Позиція"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Ціна"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Ціни включають податок"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Ціна з податком"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Варіанти товару"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Прогрес"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Назва черги"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Результат"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Повторні спроби"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Продавець"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Проведено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Рядки доставки"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Розпочато"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Починається"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Стан"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Рівні запасів"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Токен"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Разом"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Разом з податком"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Тип"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Оновлено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Ліміт використання"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Користувач"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Значення"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Список значень"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Зона"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Метод"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Податкове зведення"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Встановлює мови, доступні для всіх каналів. Окремі канали потім можуть підтримувати підмножину цих мов."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "Колекції успішно переміщено"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Зареєстровано"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Скасувати завдання"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Закінчується"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "Сторінка {0} з {1}"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Ставка"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "Розмір, колір тощо"
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Перегляд фасетів"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Зона"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Скасовано"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Створено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Доставлено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Очікування"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Відправлено"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Зберегти вигляд"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} вибрано"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Пошук груп опцій..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Змінити замовлення"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Вибрані елементи"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Значення"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Клієнта встановлено для замовлення"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Фасети"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Ви впевнені, що хочете видалити {count} клієнта з цієї групи?} few {Ви впевнені, що хочете видалити {count} клієнтів із цієї групи?} many {Ви впевнені, що хочете видалити {count} клієнтів із цієї групи?} other {Ви впевнені, що хочете видалити {count} клієнтів із цієї групи?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Запас у наявності"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Не вдалося розпочати перебудову пошукового індексу"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Адреса доставки"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Нова зона"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Новий API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Видалити стовпець"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Призначити існуючу"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "порожнє"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Це клієнти з групи клієнтів <0>{customerGroupName}</0>."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Керування глобальними поданнями"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Канал за замовчуванням"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Вставити нове зображення з джерелом, заголовком та розмірами"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Не вдалося створити значення фасету"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Не вдалося оновити варіант продукту"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>Забули пароль?</0><1>Запросити скидання</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Код купона"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Клієнта верифіковано"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Глобальні налаштування"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Розклад"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Неможливо перемістити колекцію в її власного нащадка"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Нова податкова категорія"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "У поточному каналі немає доступних місць зберігання"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Канал успішно створено"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Клієнта успішно оновлено"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Переглянути дані"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Видалити подання"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Додати нову адресу клієнту."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Більше подань"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Редагувати властивості вибраного зображення"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "Застосовано подання \"{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "{successCount} фасетів успішно видалено з каналу"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Новий товар"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Новий ресурс"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Перерахувати доставку"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "Виберіть, які опції мають застосовуватися до існуючого варіанту «{0}»"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Ресурси"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Це видалить усі групи опцій з цього товару та поверне до вибору налаштування варіантів."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Адреса виставлення рахунку"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Додати значення фасету"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Будь ласка, виберіть цільову колекцію"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Перегляньте зміни перед їх застосуванням до замовлення."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Виберіть роль"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Замовлення скасовано"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Знижка"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Усі типи"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Лише чернетки замовлень можуть бути завершені"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Не вдалося оновити товар"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "Коригування {0} рядків"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Додати значення фасетів"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "після"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Канал"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "Перевірки стану"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Сума"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Номер телефону"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Новий клієнт"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Зображення"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Адміністратора успішно створено"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Опції товару"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Вибрати країну"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Створення..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Ви впевнені, що хочете видалити це глобальне подання? Цю дію неможливо скасувати, і вона вплине на всіх користувачів."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Примусово видалити групу опцій"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Додано"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Історія клієнта"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "Значення фасетів успішно оновлено для {entityIdsLength} {entityType}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Не вдалося видалити клієнта з групи"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Система"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Ліміт використання на клієнта"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Адресу виставлення рахунку змінено"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Виберіть опцію"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Копіювати до особистих"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Сума повернення перевищує максимальну суму до повернення {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Видалити глобальне подання"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Створити"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Кожні 30 секунд"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Нова країна"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "З {0} по {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Не вдалося створити клієнта"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "Фокусну точку оновлено"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Значення опцій"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Адреса виставлення рахунку за замовчуванням"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Немає клієнта"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Не вдалося видалити країни із зони"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Не вдалося створити акцію"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Сьогодні"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Вчора"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "Назва опції"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Ви впевнені, що хочете видалити {0} {1} з цієї зони?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "Додавання {0} доплат(и)"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Посилання href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Резервне значення: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Історія замовлень"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Перевизначити"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "ID транзакції обов'язковий"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "відповідає regex"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Глобальне подання успішно перейменовано"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Теги не вибрано"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Назад"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Подання успішно перейменовано"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Застосувати фільтр"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Останній результат"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Додано до групи"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Аналітика"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "Створити варіанти"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Перевірка способу доставки..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Темна"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Результати тестування"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Додати клієнта"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Зберегти зміни"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Адресу оновлено"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Повернення успішно оброблено"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Нова зона"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Не вдалося оновити позицію колекції"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Повернення"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Змінити"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Глобальні мови не налаштовано"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "Видалення {0} елемент(ів)"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Відстежувати"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Створити варіант"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "Значення фасетів для {facetName}"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Зберегти макет"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Скидання пароля підтверджено"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Не вдалося видалити подання"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Ви впевнені, що хочете покинути цю сторінку? Усі незбережені зміни буде втрачено."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Перемкнути стовпець заголовка"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Нова акція"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Назва значення опції"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Останнє використання"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Податкова категорія за замовчуванням"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug встановлено"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "Не вдалося оновити фокусну точку"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Зону успішно оновлено"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Регіон/Область"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Не вдалося оновити групу опцій"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Налаштування каналу за замовчуванням"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Не вдалося створити податкову категорію"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "Задати критерії фільтрації для стовпця {columnId}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Країна"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Простий товар"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Черга завдань"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Будь ласка, підтвердіть, що ви зберегли API key перед закриттям."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "Підтвердити видалення"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Не вдалося змінити замовлення"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "Включаючи податок {taxRate}%"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Метрики замовлень"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Виберіть мову відображення"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Методи автентифікації"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "початок"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "Не вдалося виконати ротацію API key"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "у"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Пошук ролей..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Варіанти товару"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Керування глобальними поданнями"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Обробка..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} знайдено"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Виберіть період"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Товар"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "Ротація API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Категорія"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Переміщення..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Призначити"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Продавця успішно створено"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Спосіб доставки успішно оновлено"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Не вдалося оновити варіант товару"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Перетягніть для зміни порядку"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Зони"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "Виберіть, що зробити із залишками товару в {count, plural, one {# складській локації} few {# складських локаціях} many {# складських локаціях} other {# складських локаціях}}, які ви видаляєте. Усі вибрані локації перенесуть свої залишки до однієї вибраної вами локації або спишуть їх."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Пошук значень фасетів..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Примітка"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Доступні мови"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Завантажити ще {0} (залишилось {remaining})"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Значення фасетів"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Не вдалося змінити порядок позицій"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Усього замовлень"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Для цього замовлення не знайдено підходящих способів доставки."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Додати опцію товару"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Доставка"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions має використовуватися всередині DashboardBaseWidget"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Ця група опцій використовується наявними варіантами. Примусове видалення може вплинути на ці варіанти. Ви впевнені?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Запитано оновлення електронної пошти"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Помилка переходу до стану"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Групу клієнтів успішно створено"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Нове вікно"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "Платіж авторизовано"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Роль успішно оновлено"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Виберіть країну"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Не вдалося оновити спосіб доставки"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {Видалено {deleted} складську локацію} few {Видалено {deleted} складські локації} many {Видалено {deleted} складських локацій} other {Видалено {deleted} складських локацій}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Способи доставки"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Виберіть адресу"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Так"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Встановити фокусну точку"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "кінець"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Виберіть валюту"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Оновити вміст або видимість примітки"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "Віджет останніх замовлень"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "Вміст колекції {collectionName}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Спосіб доставки змінено"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Опис податку"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "менше або дорівнює"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "не дорівнює"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "Оновити"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "наприклад, Розмір"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "Провести платіж"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Канали"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Доставку повернено"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Тип ресурсу"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Нове місце зберігання"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "{successfulRefundCount} платіж(ів) повернено до помилки. Перевірте історію замовлення для деталей."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Вибрати елемент"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Новий товар"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Керування тегами"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Товари повернено"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Додати дію"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "Призначити опції існуючому варіанту"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "Дублювати {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Видалити з групи"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Не вдалося оновити стан виконання"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Створити новий варіант товару з опціями, цінами та запасами"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Приватні фасети не видимі в магазині"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Виберіть податкову категорію"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "Створено"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Не виконується"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Призначено"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Заголовок 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Вибрати доступні мови"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "Додавання {0} елемент(ів)"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Додати рядок після"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Разом податок"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Статус чернетки замовлення"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "Опції товару успішно створено"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Завантаження локацій…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "Не вдалося створити спосіб оплати"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Значення фасету успішно створено"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Маркетинг"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Чернетку замовлення видалено"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "більше ніж"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Віджет метрик"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Пошук валют..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Видалити з каналу"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Заголовок"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Вставити зображення"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Не вдалося оновити продавця"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Країну успішно створено"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Вибрати продавця"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Завантаження тегів..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Фасет успішно створено"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} варіантів"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Не вдалося провести платіж"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Немає адреси виставлення рахунку"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {Не вдалося видалити {1} складську локацію} few {Не вдалося видалити {2} складські локації} many {Не вдалося видалити {2} складських локацій} other {Не вдалося видалити {2} складських локацій}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Фасет"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Неможливо видалити з активного каналу"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Не встановлено"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Примусово видалити"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Новий канал"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Назва групи опцій"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "І"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Не вдалося створити групу клієнтів"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Не вдалося створити роль"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Назва товару"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Стан виконання успішно оновлено"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Товари"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Адресу створено"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API key успішно оновлено"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Додати групу опцій"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "Повернути {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Введіть slug вручну"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Немає доступних віджетів"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "Не вдалося скасувати платіж"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "Платіж успішно скасовано"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Глобальне подання успішно дубльовано"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Створено"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Фільтрувати варіанти..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Додати ціну в іншій валюті"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Адреса електронної пошти або ідентифікатор"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Повернення #{0} переведено до {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Клієнти"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Заголовок 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Не вдалося оновити місце зберігання"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Замовлення відправлено"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Зберегти адресу"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Зробити глобальним"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Вибрати наступний стан"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Немає сповіщень"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "Переміщення {0} колекцій до {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Тест"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "між"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Примітку успішно додано"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Примітку успішно видалено"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Примітку успішно оновлено"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Не вдалося провести повернення"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Рівень запасу"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Додати елемент"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API key успішно створено"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Завантаження попереднього перегляду..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Повернутися до пошуку"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Подання успішно дубльовано"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Видалити групу опцій"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Опис"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Країни"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Вулиця (рядок 2)"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Глобальне подання успішно видалено"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Редагувати макет"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Призначити каналу"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Цей тиждень"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "Групу опцій товару успішно створено"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "Додати ручний платіж {0}"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "у"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "Електронна пошта"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Не вдалося оновити адміністратора"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Керування вашими особистими збереженими поданнями для цієї таблиці"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Фільтрувати за тегами"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Увійдіть для доступу до панелі адміністратора"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "Додати платіж до замовлення ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Хибність"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Світла"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Скинути"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "дорівнює"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "Створити опції"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Пароль оновлено"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "не містить"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Група опцій"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Відредагуйте дані адреси нижче."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Податкову категорію успішно створено"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "Не вдалося перемістити колекції"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "Не вдалося оновити стан платежу"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Підсумок ваших замовлень"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Завантажити"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Товар з опціями"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Показано всі {0} результатів"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Ідентифікатор пошуку"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ ще {0}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Групи опцій"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Користувацькі поля"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Усі можливі статуси замовлення та їх переходи. Поточний статус виділено."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Замовлення"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Віджет зведення замовлень"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Додавання товарів"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Організація додаткового платежу"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "Організація оплати"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Скасовано"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Створено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Доставлено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Чернетка"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "Модифікація"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Частково доставлено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Частково відправлено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "Оплата авторизована"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "Оплата проведена"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Відправлено"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "Відстежувані ресурси"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Інформація про об'єкт"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Сума замовлення"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Видимо лише адміністраторам"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "К-сть"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Теги"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Суперадміністратор"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "Деякі ресурси недоступні"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Доступні дії"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Вставити посилання"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Якщо увімкнено, фільтри будуть успадковані від батьківської колекції та об'єднані з фільтрами, встановленими для цієї колекції."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Виберіть зону"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Перевірити способи доставки"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "Платіж успішно проведено"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "{0} {1} видалено із зони"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Увімкнути"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "Способи оплати"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Авторизовано"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Скасовано"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Створено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Відхилено"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Помилка"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Невдалий"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Очікування"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Проведено"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "Середня вартість замовлення"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Не вдалося створити зону"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Рівні запасів"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "Не вдалося оновити API key"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Рядки замовлення"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Не вдалося перейменувати глобальне подання"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "Вставити нове гіперпосилання з URL та параметрами цілі"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Висота"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "Потрібне повернення в розмірі {formattedDiff}. Виберіть суми платежів та введіть примітку для продовження."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Ціна за одиницю"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Шаблон розкладу"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "Платіж не пройшов"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Додати канал"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "Не вдалося оновити групу опцій товару"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Пошук каналів..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Додати групи клієнтів"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Доступні мови"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Скинути вибір"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Немає адреси"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "Спосіб оплати успішно створено"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Інформацію про клієнта оновлено"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Не вдалося перетворити подання на глобальне"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Варіанти товару"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Товари"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Акції"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Не вдалося створити варіант продукту"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Стара електронна пошта:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Збережіть подання як «Глобальне», щоб зробити його доступним для всіх користувачів."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Не вдалося створити варіанти"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Встановлює рівень запасів, при якому цей варіант вважається відсутнім на складі. Використання від'ємного значення вмикає підтримку попередніх замовлень. Може бути перевизначено варіантами товару."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Ротація ключа"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "Не вдалося створити варіанти товару"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Приховати пароль"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Новий продавець"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "наприклад, Червоний, Великий, Бавовна"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Не вдалося оновити профіль"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Коди купонів видалено"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Очистити фільтр"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Регіони"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Перетягніть файли сюди для завантаження"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Перемкнути всі видимі варіанти"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Верифіковано"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Нова група опцій"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "Останнє оновлення {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Глобальні подання ще не створено."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Не вдалося оновити роль"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "Це єдиний раз, коли повний API key буде відображено. Скопіюйте або завантажте його зараз — пізніше його не можна буде отримати."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "Колекцію успішно оновлено"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "Спосіб оплати успішно оновлено"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Подання успішно видалено"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "Група опцій {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "АБО"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Керування тегами"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Код купона видалено із замовлення"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Ніколи"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Не вдалося оновити значення фасету"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "Видалити групу"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Замовлення виконано"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Немає адреси доставки"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "Розширення запиту містить недійсний синтаксис GraphQL"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "Помилка розширення запиту"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "Помилка розширення запиту:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "Розширення запиту недійсне: має бути принаймні одне поле верхнього рівня"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "Невідповідність розширення запиту:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "публічне"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Податкову категорію успішно оновлено"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Перемістити"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Редагувати або видалити існуючі теги"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Умови перевірки відповідності цього способу доставки не виконано для поточного замовлення та адреси доставки."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Додати код купона"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Код купона встановлено для замовлення"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Користувацькі поля"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Новий спосіб доставки"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Видалити складські локації"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "більше або дорівнює"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Попередній перегляд"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{0} з {1} доступно для виконання"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "З початку місяця"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Запит клієнта"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Пошкоджено при доставці"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Недоступний"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Інше"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Неправильний товар"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "Зведення змін"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Повернення ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Останнє виконання"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "Деталі платежу"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Перебудувати пошуковий індекс"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Виконується"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Кожні 60 секунд"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Не вдалося оновити групу клієнтів"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "Метадані платежу"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "Скасувати зміну"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Те ж вікно"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Застосуйте фільтри до таблиці та натисніть «Зберегти подання» для початку."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Ролі"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Потрібен додатковий платіж"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Не вдалося оновити замовлення"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "З вибраними..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Не вдалося створити місце зберігання"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "менше або дорівнює"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "Учасники групи клієнтів {customerGroupName}"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Регіон"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Не відстежувати"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Виконання #{0} створено"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Виконання очікуючих оновлень пошукового індексу"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Це роль за замовчуванням, і її не можна змінити"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Мої збережені подання"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Регіон / Область"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Елементів на сторінці"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "Редагувати учасників"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Запас у наявності"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "Фільтрувати за {columnId}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Сповіщення"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Значення опцій"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "Попередній перегляд змін"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "Не вдалося видалити {entityType} з каналу"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Варіант успішно видалено"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Редагувати властивості вибраного посилання"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Продажі"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Виберіть цільову колекцію"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "Ваші останні замовлення"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Заплановані завдання"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Ви впевнені, що хочете видалити цей елемент? Цю дію неможливо скасувати."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Варіанти"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Продавці"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Налаштування"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Сховище налаштувань"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "Заголовок 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Ласкаво просимо до Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Способи доставки"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} до повернення)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Ідентифікатор"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "Не вдалося оновити колекцію"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Ціна та податок"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Замовлення не знайдено"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Помилка"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Замовлення змінено"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Запитано скидання пароля"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Виділена сума платежу повинна дорівнювати сумі повернення"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "наприклад, Малий"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Ви впевнені, що хочете видалити {0} {entityType} з поточного каналу?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Додати теги..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "Не вдалося створити групу опцій товару"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} елементів вибрано"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Пошук мов..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Місця зберігання"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Перейти на попередню сторінку"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Вміст"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Не вдалося перетворити глобальне подання на особисте"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Результат завдання"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "Додати платіж ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Система"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Назва варіанта"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Видалити"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Не вдалося оновити клієнта"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Видалити групи опцій?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Це попередній перегляд вмісту колекції на основі поточних налаштувань фільтра. Після збереження колекції вміст буде оновлено, щоб відобразити нові налаштування фільтра."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} клієнта видалено з групи} few {{count} клієнтів видалено з групи} many {{count} клієнтів видалено з групи} other {{count} клієнтів видалено з групи}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Податкові категорії"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Податкові ставки"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Не вдалося видалити клієнтів із групи"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Не вдалося завантажити глобальні налаштування"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Виберіть позиції для повернення та за бажанням поверніть на склад"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Зберегти"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "Вибрано {selectedRowCount} з {0} рядків."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Попередній перегляд змін замовлення"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "Групу опцій товару успішно оновлено"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Сторінка продовжить роботу із запитом за замовчуванням."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Вулиця"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Більше немає фасетів"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Розпочато перебудову пошукового індексу"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "Позицію колекції оновлено"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "Назва групи опцій"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "Додати «{newOptionInput}»"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Новий варіант товару"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Повернення переведено"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Використання вбудованої стратегії аутентифікації"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "Не вдалося призначити {entityIdsLength} {entityType} каналу"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Мова за замовчуванням"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Токен"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Виконання..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Додати групу опцій до товару"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "Попередній перегляд {0}"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Продавця успішно оновлено"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Не вдалося перевести замовлення до стану"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Показати все ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Не вдалося створити податкову ставку"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Я зберіг цей API key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Налаштуйте доступні мови для вашого магазину та каналів"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Товар успішно створено"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Додати варіант товару"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Введіть і натисніть Enter або кому для додавання..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Редагувати примітку"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Ресурси не знайдено. Спробуйте змінити фільтри."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Додати опцію"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Зберегти групу опцій"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "Створити {createCount} варіант(ів)"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Натисніть «Запустити тест» для перевірки цього способу доставки."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Адміністратора успішно оновлено"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Очистити фільтри"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "Виконання #{0} з {1} по {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Не вдалося видалити глобальне подання"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Мова за замовчуванням"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Статус"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Опцій не знайдено"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Бінарний"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Групу опцій успішно оновлено"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Новий спосіб доставки"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Кожні 10 секунд"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "без податку:"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "Додати запас до місця зберігання"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Значення опції успішно додано"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "Колекцію переміщено до нового батьківського елемента"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Групу опцій видалено"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Перейти до вибраного стану"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "Буде потрібен додатковий платіж у розмірі {formattedDiff}."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Відстежувати запаси за замовчуванням"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "Вибрано {selected} з {total}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Спосіб доставки успішно створено"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Нова група клієнтів"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Видимо клієнту"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Групу опцій успішно створено"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Податкові ставки"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug буде згенеровано автоматично..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Клієнта не знайдено"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "Вибрати {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Нові значення фасетів для додавання:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Не вдалося обробити повернення"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Ім'я"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "містить"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Групи опцій не знайдено"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Елементи не знайдено"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Проміжний підсумок"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Виконані товари ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Значення оновлено"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Не верифіковано"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Кількість"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Додати фільтр"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Податкова категорія"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Профіль"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Тестові дані оновлено. Натисніть «Запустити тест» для перегляду оновлених результатів."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "не у"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Рядок замовлення оновлено"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Новий спосіб оплати"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "Дублююче значення \"{trimmed}\" вже існує"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Причина"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Групи клієнтів"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} успішно видалено з каналу"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Групи опцій"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Додати доплату"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Поточні значення фасету"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "Сторінка {page} з {totalPages}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "Минулий місяць"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Додати країну"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Видалити елемент"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Відео"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "менше ніж"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Не вдалося додати варіант. Переконайтеся, що батьківський продукт увімкнено."
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "Сталася невідома помилка"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Метрики"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Мова"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Нова колекція"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Повернути та скасувати замовлення"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Оновлення електронної пошти підтверджено"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "між"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Повернути та скасувати"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Перевірка способів доставки..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Не вдалося створити спосіб доставки"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} {entityType} успішно призначено каналу"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Глобальні мови"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Новий адміністратор"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Видалити чернетку"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Джерело"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Немає доступних дій"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Не вдалося оновити канал"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Загальні"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "Не вдалося видалити товар з каналу"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Додати нову адресу"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Фасет успішно оновлено"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Зону успішно створено"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Значення"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Клієнта оновлено"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Коефіцієнт перерахунку ціни"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Замовлення продавця"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Новий фасет"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Ви впевнені, що хочете видалити цю групу опцій з товару?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Опис (альтернативний текст)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Теги не знайдено"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Валюта за замовчуванням"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Для цих змін не потрібен платіж або повернення."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Загальний дохід"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Наступне виконання"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Примітка приватна"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "Середня дата"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Недійсне число"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Ви ще не зберегли жодного подання."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Ви впевнені, що хочете видалити це подання? Цю дію неможливо скасувати."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Переглянути процес замовлення"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Не вдалося дублювати подання"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Використовувати як адресу доставки за замовчуванням"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Редагувати slug вручну"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "Додайте фільтри для попереднього перегляду вмісту колекції."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "Група опцій товару"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Проміжний підсумок"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "менше ніж"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "ID повернення"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Користувацькі поля замовлення оновлено"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Калькулятор"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Не вдалося видалити групу опцій з каналу: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Переглянути дані завдання"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Перемістити на верхній рівень"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Очистити"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Підсумок замовлень"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Пошук ресурсів..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Новий фасет"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "Призначити {entityType} каналу"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Продовжити"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Акції"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Повідомлення про помилку"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Додати рівень запасів для іншого місця"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Видалити адресу"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Не вдалося оновити фасет"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters має використовуватися всередині WidgetFiltersProvider"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Редагувати адресу"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Не вдалося видалити фасет з каналу: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Встановити посилання"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Новий продавець"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Редагувати зображення"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Керування варіантами"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Запас виділено"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "більше або дорівнює"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Встановлює рівень запасів, при якому цей варіант вважається відсутнім на складі. Використання від'ємного значення вмикає підтримку попередніх замовлень."
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "Створити опції товару"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Збереження..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Переглянути результат"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Рядків на сторінці"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "Завантаження колекцій..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Значення фасету успішно оновлено"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Додати ресурс"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "Зберегти зміни"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Клієнта додано до групи"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Замовлення продавця"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Не вдалося додати значення опції"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "Додати значення опції до {groupName}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} товар(ів) повернено"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Групи опцій ще не визначено. Додайте групи опцій для створення різних варіантів вашого товару (наприклад, Розмір, Колір, Матеріал)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Нова електронна пошта:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "Не вдалося оновити спосіб оплати"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Доступно:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Дата створення"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Не вдалося створити варіант товару"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Мова: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "У вас немає дозволу на перегляд глобальних мовних налаштувань"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Податкову ставку успішно створено"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Заголовок 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Коди купонів додано"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Активний"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Податкова база"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Завантажити ще"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Повернення проведено"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} {entityName} успішно дубльовано"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Нова група опцій"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Результатів поки немає"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "Платіж проведено"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Доступні умови"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Активні фільтри"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Очистити все"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "більше ніж"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Закрити"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Додати платіж до замовлення"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Завантаження..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Токен використовується для вказівки каналу при виконанні API-запитів."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Адреси не знайдено"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "ID виконання"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Виберіть платежі для повернення"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "Не вдалося видалити {failed} {entityName}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Поріг відсутності на складі"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Товар успішно видалено з каналу"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Не вдалося оновити значення"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "Не вдалося створити API key"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Провести повернення"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "Спосіб оплати обов'язковий"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Не вдалося додати клієнта до групи"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Керування варіантами"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "Застосовано глобальне подання \"{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Клієнта зареєстровано"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Зони"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Пошук продавців..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Акцію успішно створено"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Опція"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Процес замовлення"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Номер телефону"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Приватне"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Варіант"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Глобальні налаштування успішно оновлено"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API key успішно оновлено"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Ці мови будуть доступні для використання всіма каналами"

--- a/packages/dashboard/src/i18n/locales/uz.po
+++ b/packages/dashboard/src/i18n/locales/uz.po
@@ -13,5974 +13,5974 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "To'liq ism"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "Elementlarni tanlang"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "O'zgarishlarni ko'rish"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "Kuzatuv kodi"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "Tanlangan ruxsatlar ushbu kanallarga qo'llaniladi."
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "Mahsulot variantlari"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "Yangi soliq stavkasi"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "Mavjud optsiya guruhini biriktiring yoki yangisini yarating"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "Yangi rol"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "Kvartira, ofis va h.k."
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "Boshqa elementlar yo'q"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "Havolani tahrirlash"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "Buyurtmaga kamida bitta element qo'shing"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "Test buyurtma uchun mahsulot qo'shing"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "Manzil yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "Hammasini almashtirish"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "JSON qiymatini tahrirlash"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "Tashqi autentifikatsiya strategiyasi: {strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "Sababni tanlang..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "Sarlavha 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "To'lov qo'shib bo'lmadi"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "Yangilandi"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "Global sozlamalarni yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "Buyurtma muvaffaqiyatli bajarildi"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "{0} {entityName} o'chirilsinmi?"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "Global zaxira tugashi chegarasi"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "Tillarni boshqarish"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "Nusxalanmoqda... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "Muvaffaqiyatli o'chirildi"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "{selectionLength} ta asset o'chirildi"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "Soliq stavkasi yangilandi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "Maxsus sababni kiriting..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "Turi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "{0} ni tanlang"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "Qiymatlarni ko'rish"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "Qatorni o'chirish"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "Shartlar"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "Joriy"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "Bajarishlar yo'q"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, one {{1} ta ombor joylashuvini o'chirib bo'lmadi: {messages}} other {{2} ta ombor joylashuvini o'chirib bo'lmadi: {messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "Bu yoqilganda, mahsulot katalogidagi narxlar standart soliq hududi solig'iga kiritiladi."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "Qoralama buyurtma yakunlandi"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "Avtomatik yangilash: {0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr "{fulfilled} ta ish bekor qilindi"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "{deleted} {entityName} o'chirildi"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "Sotuvchilar"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "Optsiyalar"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, one {{fulfilled} ta vazifa muvaffaqiyatli bekor qilindi} other {{fulfilled} ta vazifa muvaffaqiyatli bekor qilindi}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "Sotuvchi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "To'lov qo'shish"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "Buyurtmani simulyatsiya qilib, ushbu yetkazib berish usuli mosligini va narxini sinab ko'ring."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "Zaxira joylashuvlari"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "Bajarish ishlovchisi"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "Buyurtmalar"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "Rollarni tanlang"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "Rol yaratildi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "Ushbu variant o'chirilsinmi?"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "Administrator yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "Yo'q"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "Mahsulot varianti yangilandi"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "{failed} {entityName} o'chirib bo'lmadi: {allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "Mahsulot yangilandi"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "Mamlakatni yangilab bo'lmadi"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "Qidirish uchun kamida 2 ta belgi kiriting..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "Familiya"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "Havola sarlavhasi"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "Mijozlar guruhi yangilandi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "Maxsus maydonlar o'zgartirildi"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "Zaxira joylashuvi yaratildi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "Noma'lum xato"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "Pul qaytarish jami manfiy bo'lishi mumkin emas"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "Tafsilotlarni ko'rish"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "{0} {entityType} ni biriktirish uchun kanalni tanlang"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "Mijoz yaratildi"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "So'nggi 7 kun"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "Kanal yaratib bo'lmadi"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "Dasturchi rejimi"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "Yangi rol"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "Assetlarni o'chirib bo'lmadi: {message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "Zaxiraga qaytarish"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "Ko'rinish"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "Mahsulot variantlari"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "Yangi mijozlar guruhi"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "\"{0}\" ni yaratish"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "Qayta nomlash"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "Afzal ko'rgan ekran tili va lokal sozlamalarni tanlang"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "{successCount} ta optsiya guruhi kanaldan olib tashlandi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "Yetkazib berish usuli ushbu buyurtma uchun mos emas"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "Manzilni yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "Manzil o'chirildi"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "Soliq stavkasi"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr "{fulfilled, plural, one {{0}} other {{1}}}"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "Buyurtma qoralamasi yakunlanishga tayyor emas"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "Yangi to'plam"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "Tahlillar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "Ishga tushirish"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "Soliq stavkasini yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "Bu <0>{collectionName}</0> to'plamining tarkibi."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "maxfiy"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "Mahsulot varianti yaratildi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "Asosiy mahsulot"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "Shahar"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "Administratorlar"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "Yalpi narx: <0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "Keyingi sahifaga o'tish"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "Havolani olib tashlash"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "Bu maydon faqat o'qish uchun"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "Buyurtmalar soni"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "Buyurtma yangilandi"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "Filtrlarni meros qilib olish"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "Barcha foydalanuvchilarga ko'rinadigan global saqlangan ko'rinishlarni boshqarish"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "To'lov usullarini qidirish..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "Buyurtma uchun yetkazib berish manzili o'rnatilmagan"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "{enabledCount} ta variant yaratish"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "To'lov #{0} {1} holatiga o'tdi"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "Mijoz tarixini yuklashda xato: {0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "{selectionLength} ta {entityType} kanaldan olib tashlandi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "Optsiya qiymatini qo'shish"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "Global sozlamalar"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "keyin"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "Mahsulot varianti yangilandi"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "Faset qiymatlarini tahrirlash"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "Qo'shilmoqda..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "To'plamlarni ko'chirish"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "Rollar"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "Jadval ko'rinishi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "Manzilni o'chirib bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "Yetkazib berish usullari mavjud emas"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "Global ko'rinish shaxsiyga aylantirildi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "Bajarish o'tkazildi"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "{selectionLength} ta asset o'chirilsinmi?"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "Kirish"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "Ro'yxat ko'rinishi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "Sinov buyurtmasi"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "Davom etish uchun mijozni tanlang"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "Optsiya guruhi tayinlandi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "Sinovni ishga tushirish"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "Soliq stavkasi: {taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "Sinov uchun mahsulot qo'shing va yetkazib berish manzilini to'ldiring."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "Sarlavha qatorini almashtirish"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "Manzilni tanlang"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "To'lov muvofiqligi tekshiruvchisi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "Standart soliq hududi"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "Buyurtma qoralamasi yakunlashga tayyor"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "Metama'lumotlar"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr "Yetkazib berish usulini o'rnatib bo'lmadi: {0}"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "Filtrlash..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "Yangi faset qiymati"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "Kanal yangilandi"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "Kamroq ko'rsatish"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "Qisqa sana"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "Mavjud valyutalar"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "{0} ta element tanlang"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "Joylashtirilgan sana"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "Bu kalitni almashtirish joriy kalitni darhol bekor qiladi. Undan foydalanayotgan integratsiyalar yangi kalit bilan yangilanmaguncha ishlamaydi."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "Vazifaga uzatilgan ma'lumotlar"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "Navigatsiyani tasdiqlash"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "Havola maqsadi"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "Qoralamani yakunlash"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "Nomi"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "Buyurtmani bajarib bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "Jami"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "Ushbu pul qaytarish uchun tranzaksiya ID raqamini kiriting"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "Sizning API kalitingiz"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "Ushbu qoralama buyurtma o'chirilsinmi?"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "Bajarish yaratildi"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "{0} ta mos yetkazib berish usuli{1} topildi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "O'lchamlar"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "Parolni ko'rsatish"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(maksimal: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "Kompaniya"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "Keyin ustun qo'shish"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "Amallar"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "Chegirmalar"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "Pul qaytarish izohini kiriting"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "Buyurtma qatori olib tashlandi"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "Tarkib:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "Kalit"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "Tasdiqlash"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr "Qoralama buyurtmani yakunlab bo'lmadi: {0}"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "To'plamni yaratib bo'lmadi"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "Birinchi sahifaga o'tish"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "Mahsulotni yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "Mijoz"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "Buyurtma tarixini yuklashda xatolik: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "Buyurtma uchun yetkazib berish manzili o'rnatildi"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "Fokus nuqtasi"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "Yagona variant, optsiyalarsiz"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "Buyurtma uchun keyingi holatni tanlang"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "Til"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "Rejalashtirilgan vazifalar"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "Tranzaksiya ID raqamini kiriting"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "Ma'lumotlarni yangilash"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "{0} {entityType} uchun faset qiymatlarini qo'shing yoki olib tashlang"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "Bular <0>{facetName}</0> faseti qiymatlari."
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "Buyurtmaga to'lov qo'shildi"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "Buyurtma uchun hisob-kitob manzili o'rnatildi"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "Hududni yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "Parol"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "O'chirib bo'lmadi"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "Rejalashtirilgan vazifa bajariladi"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "Yangi zaxira joylashuvi"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "Ruxsatlar"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "Yetkazib berish manzili o'zgartirildi"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "Mahsulotlar topilmadi"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "Oldin qator qo'shish"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "{suggestedState} holatiga o'tkazish"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "Bu oy"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "Fasetni yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "Buyurtma elementlarini bekor qilib bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "Tranzaksiya ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "Ajratilgan"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr "Buyurtma uchun kupon kodini o'rnatib bo'lmadi: {0}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "Qolgan zaxira bilan nima qilishni tanlang"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "Platforma va Cloudni o'rganing"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "Har 5 soniyada"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "To'plam yaratildi"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "Narx"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "Qoralama buyurtma"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "Qamrov"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "Shart qoʻshish"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "Yetkazib berish usuli ushbu buyurtmaga mos"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "Administratorlar"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "Guruhdan olib tashlandi"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "Eni"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "To'lov yoki pul qaytarish talab qilinmaydi"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr ".env fayli sifatida yuklab olish"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "Yoqilganda, aksiya do'konda mavjud bo'ladi"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "Kuzatilganda, mahsulot varianti zaxira darajalari sotuvda avtomatik o'zgaradi. Bu sozlamani alohida mahsulot variantlari bekor qilishi mumkin."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "Buyurtma uchun yetkazib berish usuli o'rnatildi"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "Aksiyani yangilab bo'lmadi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "Rasmlar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API kalitlari"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "{name} qidirish..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "Assetni tahrirlash"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "To'lovni bekor qilish"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "Vazifalar navbati"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "Assetlar"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "Elektron pochta manzili"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr "Buyurtmadan kupon kodini olib tashlab bo'lmadi: {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "Manba maydonidan Slugni qayta yaratish"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "Global sozlamalardan meros olish"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "Natijalar topilmadi"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "Yetkazib berish manzilini o'rnating va usulini tanlang"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "O'chirilgan"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "Sozlamalar do'koni"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "Navbat"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "Yangi soliq stavkasi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "To'lov o'tkazildi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "Qolgan:"
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "{entityName}lar uchun \"{duplicatorCode}\" kodli dublikator topilmadi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "Narxlar standart soliq hududi uchun soliqni o'z ichiga oladi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "Jami pul qaytarish:"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "Ish natijasini ko'rish"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "Yangi buyurtmani simulyatsiya qilib yetkazib berish usullarini sinab ko'ring."
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "Hech qanday element tanlanmagan"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr ", {0} ta tanlangan"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "Mamlakatlar topilmadi"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "Variantlar muvaffaqiyatli yaratildi"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "Slugni avtomatik yaratish"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "Qo'shimcha to'lov"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "To'lov usullari"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "Zaxira"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "Mijozlar topilmadi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "Global zaxira tugashi chegarasidan foydalanish"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "To'lov holati yangilandi"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "Yangi yaratish"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "Pul qaytarish jami"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "Manzil o'chirildi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "Faqat hisobingizga biriktirilgan rollar mavjud."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr "{cancellableCount, plural, one {{cancellableCount} ta ishni bekor qilish} other {{cancellableCount} ta ishni bekor qilish}}"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "Element buyurtmaga qo'shildi"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {Ushbu optsiya guruhidan yana bitta mahsulot foydalanadi. O'zgartirishlar unga ham ta'sir qiladi.} other {Ushbu optsiya guruhi # ta mahsulotda umumiy. O'zgartirishlar barchasiga ta'sir qiladi.}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "Saqlangan ko'rinishlarim"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "Yangi kanal"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "Sotuvchini yaratib bo'lmadi"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "{0}lar uchun nusxalash sozlamalari"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "Joriy filtrga mos variant yo'q."
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "Manzillar"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "{groupName} guruhiga yangi optsiya qiymatini qo'shish"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "Buyurtma o'zgartirishi #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "Oldidan ustun qo'shish"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "Kanal tillari"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "Optsiya guruhini yaratib bo'lmadi"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "To'g'ri"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "Mijozni tanlash"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "Buyurtma o'tkazildi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "oldin"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "Qoralama buyurtmani o'chirish"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "Katalog"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "Yangi to'lov usuli"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "Aksiya muvaffaqiyatli yangilandi"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, one {{rejected} ta vazifani bekor qilib bo'lmadi} other {{rejected} ta vazifani bekor qilib bo'lmadi}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "Kanalni tanlang"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "Ko'rsatish tili"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "Bajarish tafsilotlari"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "Qolgan zaxirani bekor qilish"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "Hozir"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "Kanallar"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "Ko'rinish global qilib o'zgartirildi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "oldin"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr "Buyurtmaga mijozni o'rnatib bo'lmadi: {0}"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "O'lcham"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "{0} uchun tarjima topilmadi"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "Yangi mijoz"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "So'nggi buyurtmalar"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ yana {leftOver} ta"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "Standart hisob-kitob manzili sifatida ishlatish"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "O'chirish"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "O'chirib qo'yish"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "To'plamlar"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "Variant qo'shish"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "Mamlakatni yaratib bo'lmadi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "Mamlakatlar"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "Ko'rinish nomini o'zgartirib bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "Mavjud"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "Oddiy"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "Filtrlar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "Mijozlar guruhlari"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "Mijozlar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "Namuna formatlash"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "Yangi parametr"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "Foydalanish chegarasi"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "Global sozlamalar yuklanmoqda..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "Manzil yangilandi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "Yaratilgan"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "Manzillar yuklanmoqda..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "{0}ni ko'chirish uchun maqsadli to'plamni tanlang."
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr "Buyurtma hisob-kitob manzilini bekor qilib bo'lmadi: {0}"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "Mijoz tafsilotlari yangilandi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "ichida emas"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "Qo'llash"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "Yangi mahsulot parametri"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "Oxirgi sahifaga o'tish"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "Bekor qilish"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr "Buyurtmaning maxsus maydonlarini yangilab bo'lmadi: {0}"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "Mahsulot varianti muvaffaqiyatli yaratildi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "Ushbu usuldan pul qaytarish"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "Pochta indeksi"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "Yangi soliq toifasi"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "Qisman pul qaytarish bajarildi"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "Maxsus maydonlarni o'rnatish"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "To'plamlar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "Variantni o'chirish"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "Hech qanday o'zgartirish kiritilmadi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "Standart yetkazib berish hududi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "Sabab:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "Yetkazib berish manzili"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "{0}ga o'tkazish"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "Soliq toifalari"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "Maxfiy to'plamlar do'konda ko'rinmaydi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "Yoqilganda mahsulot do'konda mavjud bo'ladi"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "Rejalashtirilgan vazifani bajarib bo'lmadi"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "Mijozlar guruhlari"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "O'chirilgan"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "Yangi aksiya"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "Standart yetkazib berish manzili"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "Pul qaytarish talab qilinadi"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "Buyurtmani bajarish"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "Sizda kanal sozlamalarini ko'rish uchun ruxsat yo'q"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "So'nggi 30 kun"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "Faset qiymatlari yo'q"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "Pul qaytarish uchun sabab talab qilinadi"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "Optsiya guruhini olib tashlab bo'lmadi"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "Soliq toifasini yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "Pul qaytarish muvaffaqiyatli hisoblashildi"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "Yangilash"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "2-sarlavha"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "Buyurtma berildi"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "Profil muvaffaqiyatli yangilandi"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "To'lov usuli"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "Tahrirlash"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "Variant muvaffaqiyatli yangilandi"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "To'plam nomi bo'yicha filtrlash"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "Eslatma qo'shildi"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "Bajarish uchun miqdorlarni tanlang va bajarish ishlovchisini sozlang"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "Buyurtma hisob-kitob manzili bekor qilindi"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "Boshlanadi"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "Nusxalash"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "Natijalar yo'q"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "Ustun sozlamalari"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, one {{count} ta ombor joylashuvini o'chirib bo'lmadi} other {{count} ta ombor joylashuvini o'chirib bo'lmadi}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "Kod"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "Optsiya guruhlarini olib tashlab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "Buyurtma yetkazib berildi"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "{name} ga o'tkazish"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "Qolgan zaxira"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "Hududdan olib tashlash"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "Ushbu kanal uchun global mavjud tillardan tanlang"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "Ushbu manzilni o'chirishni xohlaysizmi?"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "Optsiya guruhini biriktirib bo'lmadi"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "Assetni yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "Zaxira joylashuvi yangilandi"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "Amalni tasdiqlash"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "Mamlakat yangilandi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "Fasetlar"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "Eslatma qo'shib bo'lmadi"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "Eslatmani o'chirib bo'lmadi"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "So'rov hujjatini kengaytirib bo'lmadi"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "Eslatmani yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "Yetkazib berish uchun pul qaytarish"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "Faqat o'qish uchun"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "Global ko'rinishni nusxalab bo'lmadi"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "{total} dan {shown} ko'rsatilmoqda • {selected} tanlangan"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "Yetkazib berish usulini sinash"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "Faset qiymatlari"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "Asset yangilandi"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "Mavzu"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} mijoz"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API kalitlari"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "Tilni tanlang"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "Chiqish"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "Urinishlar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "Mavjud valyuta kodlari"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "Mavjud til kodlari"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "Yo'l ko'rsatkichlari"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "Toifa"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "Kanallar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "Quyi elementlar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "Kod"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "Kupon kodi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "Yaratilgan sana"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "Valyuta kodi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "Mijoz"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "Mijozlar guruhi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "Mijozlar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "Maxsus maydonlar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "Ma'lumotlar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "Standart valyuta kodi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "Standart til kodi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "Standart yetkazib berish hududi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "Standart soliq hududi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "Tavsif"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "Davomiyligi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "Elektron pochta manzili"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "Yoqilgan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "Tugash vaqti"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "Xato"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "Asosiy asset"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "Ism"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "Bajarish ishlovchisi kodi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "Standartmi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "Maxfiymi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "Hisob-kitob qilinganmi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "Familiya"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "Nomi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "Buyurtma berilgan vaqt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "Asosiy ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "Har bir mijoz uchun foydalanish chegarasi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "Ruxsatlar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "Joylashuv"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "Narx"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "Narxlar soliqni o'z ichiga oladi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "Soliqli narx"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "Mahsulot variantlari"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "Jarayon"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "Navbat nomi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "Natija"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "Qayta urinishlar"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "Sotuvchi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "Hisob-kitob qilingan vaqt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "Yetkazib berish qatorlari"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "Boshlangan vaqt"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "Boshlanish vaqti"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "Holat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "Zaxira darajalari"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "Token"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "Jami"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "Soliqli jami"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "Turi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "Yangilangan sana"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "Foydalanish chegarasi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "Foydalanuvchi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "Qiymat"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "Qiymatlar ro'yxati"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "Hudud"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "Usul"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "Soliq xulosasi"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "Barcha kanallar uchun mavjud tillarni belgilaydi. Alohida kanallar bu tillarning bir qismini qo'llab-quvvatlashi mumkin."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "To'plamlar ko'chirildi"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "Ro'yxatdan o'tgan"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr "Buyurtma uchun yetkazib berish manzilini o'rnatib bo'lmadi: {0}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "Ishni bekor qilish"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "Tugaydi"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "{1} dan {0} sahifa"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "Stavka"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "O'lcham, rang va h.k."
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "Fasetlarni ko'rib chiqish"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "Hudud"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "Bekor qilingan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "Yaratilgan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "Yetkazilgan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "Kutilmoqda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "Jo'natilgan"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "Ko'rinishni saqlash"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "{0} tanlangan"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "Optsiya guruhlarini qidirish..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "Buyurtmani o'zgartirish"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "Tanlangan elementlar"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "Qiymatlar"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "Buyurtma uchun mijoz o'rnatildi"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "Fasetlar"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, one {Ushbu guruhdan {count} ta mijozni olib tashlashni xohlaysizmi?} other {Ushbu guruhdan {count} ta mijozni olib tashlashni xohlaysizmi?}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "Mavjud zaxira"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "Qidiruv indeksini qayta qurish boshlanmadi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "Yetkazib berish manzili"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "Yangi hudud"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "Yangi API kaliti"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "Ustunni oʻchirish"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "Mavjudini biriktirish"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "boʻsh"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "Bular <0>{customerGroupName}</0> guruhidagi mijozlar."
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "Global koʻrinishlarni boshqarish"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "Standart kanal"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "Manba, sarlavha va oʻlchamlar bilan yangi rasm qoʻshish"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "Faset qiymatini yaratib boʻlmadi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "Mahsulot opsiyasini yangilab boʻlmadi"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "Kupon kodi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "Mijoz tasdiqlandi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "Global sozlamalar"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "Jadval"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "Toʻplamni oʻzining avlodiga koʻchirib boʻlmaydi"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "Yangi soliq toifasi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "Kanal yaratildi"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "Mijoz yangilandi"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "Maʼlumotlarni koʻrish"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "Koʻrinishni oʻchirish"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Mijozga yangi manzil qoʻshish."
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "Koʻproq koʻrinishlar"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "Tanlangan rasm xususiyatlarini tahrirlash"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "\"{viewName}\" ko'rinishi qo'llanildi"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "Kanaldan {successCount} faset olib tashlandi"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "Yangi mahsulot"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "Yangi asset"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "Yetkazib berishni qayta hisoblash"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "Assetlar"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Bu mahsulotdagi barcha optsiya guruhlarini olib tashlaydi va variant sozlash tanloviga qaytaradi."
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "Hisob-faktura manzili"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "Faset qiymatini qoʻshish"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "Maqsadli toʻplamni tanlang"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "Buyurtmaga qoʻllashdan oldin oʻzgarishlarni koʻrib chiqing."
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "Rolni tanlang"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "Buyurtma bekor qilindi"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "Chegirma"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "Barcha turlar"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "Faqat qoralama buyurtmalarni yakunlash mumkin"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "Mahsulotni yangilab boʻlmadi"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "{0} qator sozlanmoqda"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "Faset qiymatlarini qoʻshish"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "keyin"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "Kanal"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "Miqdor"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "Telefon raqami"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "Yangi mijoz"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "Rasm"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "Administrator yaratildi"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "Mahsulot opsiyalari"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "Mamlakatni tanlang"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "Yaratilmoqda..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "Ushbu global koʻrinishni oʻchirasizmi? Bu amalni bekor qilib boʻlmaydi va barcha foydalanuvchilarga taʼsir qiladi."
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "Optsiya guruhini majburan olib tashlash"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "Qoʻshildi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "Mijoz tarixi"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "{entityIdsLength} {entityType} uchun faset qiymatlari yangilandi"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "Mijozni guruhdan olib tashlab boʻlmadi"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "Tizim"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "Har bir mijoz uchun foydalanish chegarasi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "Hisob-faktura manzili oʻzgartirildi"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "Opsiyani tanlang"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "Shaxsiyga nusxalash"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "Pul qaytarish jami {0} maksimal qaytariladigan miqdordan oshib ketadi"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "Global koʻrinishni oʻchirish"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "Yaratish"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "Har 30 soniyada"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "Yangi mamlakat"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "{0} dan {1} gacha"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "Mijozni yaratib boʻlmadi"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "Optsiya qiymatlari"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "Standart hisob-faktura manzili"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "Mijoz yoʻq"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "Hududdan mamlakatlarni olib tashlab boʻlmadi"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "Aksiyani yaratib boʻlmadi"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "Bugun"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "Kecha"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "Ushbu hududdan {0} {1} ni olib tashlaysizmi?"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "{0} ustama qoʻshilmoqda"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "Havola href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "Zaxira: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "Buyurtma tarixi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "Bekor qilish"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "Tranzaksiya ID talab qilinadi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "regex bilan mos keladi"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "Global koʻrinish nomi oʻzgartirildi"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "Hech qanday teg tanlanmagan"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "Orqaga"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "Koʻrinish nomi oʻzgartirildi"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "Filtrni qoʻllash"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "Oxirgi natija"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "Guruhga qoʻshildi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "Tahlillar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "Yetkazib berish usuli sinovdan oʻtkazilmoqda..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "Qorongʻi"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "Sinov natijalari"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "Mijoz qoʻshish"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "Oʻzgarishlarni saqlash"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "Manzil yangilandi"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "Pul qaytarish amalga oshirildi"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "Yangi hudud"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "Toʻplam holatini yangilab boʻlmadi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "Pul qaytarish"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "Oʻzgartirish"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "Hech qanday global til sozlanmagan"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "{0} element olib tashlanmoqda"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "Kuzatish"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "Variant yaratish"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "{facetName} uchun faset qiymatlari"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "Maketni saqlash"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "Parolni tiklash tasdiqlandi"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "Koʻrinishni oʻchirib boʻlmadi"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "Ushbu sahifadan chiqasizmi? Saqlanmagan oʻzgarishlar yoʻqoladi."
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "Sarlavha ustunini almashtirish"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "Yangi aksiya"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "Optsiya qiymati nomi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "Oxirgi ishlatilgan"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "Standart soliq toifasimi"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug oʻrnatilgan"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr ""
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "Hudud yangilandi"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "Shtat/Viloyat"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "Optsiya guruhini yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "Kanal standartlari"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "Soliq toifasini yaratib bo'lmadi"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "{columnId} ustuni uchun filtr mezonlarini belgilang"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "Mamlakat"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "Oddiy mahsulot"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "Vazifalar navbati"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "Yopishdan oldin API kalitini saqlaganingizni tasdiqlang."
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "O'chirishni tasdiqlang"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "Buyurtmani o'zgartirib bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "{taxRate}% soliqni o'z ichiga oladi"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "Buyurtma ko'rsatkichlari"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "Ko'rsatish tilini tanlang"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "Autentifikatsiya usullari"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "boshlanish"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "API kalitini almashtirib bo'lmadi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "ichida"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "Rollarni qidirish..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr "{fulfilled} ta vazifa bekor qilindi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "Mahsulot variantlari"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "Global ko'rinishlarni boshqarish"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "Qayta ishlanmoqda..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "{totalItems} {0} topildi"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "Sana oralig'ini tanlang"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "Mahsulot"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "API kalitini almashtirish"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "Toifa"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "Ko'chirilmoqda..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "Tayinlash"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "Sotuvchi yaratildi"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "Yetkazib berish usuli yangilandi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "Mahsulot variantini yangilab bo'lmadi"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "Qayta tartiblash uchun torting"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "Hududlar"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "O'chirilayotgan {count, plural, one {# ombor joylashuvida} other {# ombor joylashuvida}} qolgan zaxira bilan nima qilishni tanlang. Barcha tanlangan joylashuvlar qolgan zaxirasini siz tanlagan yagona joylashuvga o'tkazadi yoki uni bekor qiladi."
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "Faset qiymatlarini qidirish..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "Eslatma"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "Mavjud tillar"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "Yana {0} ta yuklash ({remaining} ta qoldi)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "Faset qiymatlari"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "Elementlarni qayta tartiblab bo'lmadi"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "Jami buyurtmalar"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "Bu buyurtma uchun mos yetkazib berish usullari topilmadi."
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "Mahsulot tanlovini qo'shish"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "Yetkazib berish"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions DashboardBaseWidget ichida ishlatilishi kerak"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "Bu optsiya guruhi mavjud variantlarda ishlatilmoqda. Majburiy olib tashlash ularga ta'sir qilishi mumkin. Ishonchingiz komilmi?"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "Elektron pochtani yangilash so'raldi"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "Holatga o'tishda xatolik"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "Mijozlar guruhi yaratildi"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "Yangi oyna"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "To'lov tasdiqlandi"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "Rol yangilandi"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "Mamlakatni tanlang"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "Yetkazib berish usulini yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, one {{deleted} ta ombor joylashuvi o'chirildi} other {{deleted} ta ombor joylashuvi o'chirildi}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "Yetkazib berish usullari"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "Manzilni tanlang"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "Ha"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "Fokal nuqtani belgilash"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "tugash"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "Valyutani tanlang"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "Eslatma mazmuni yoki ko'rinishini yangilang"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "So'nggi buyurtmalar vidjeti"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "{collectionName} uchun to'plam mazmuni"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "Yetkazib berish usuli o'zgartirildi"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "Soliq tavsifi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "quyidagidan kichik yoki teng"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "quyidagiga teng emas"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "To'lovni yakunlash"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "Kanallar"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "Yetkazib berish puli qaytarildi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "Asset turi"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "Yangi zaxira joylashuvi"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "Nosozlikdan oldin {successfulRefundCount} ta to'lov qaytarildi. Tafsilotlar uchun buyurtma tarixini tekshiring."
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "Elementni tanlash"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "Yangi mahsulot"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Teglarni boshqarish"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "Elementlar qaytarildi"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "Amal qoʻshish"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "{0} larni nusxalash"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "Guruhdan olib tashlash"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "Bajarish holatini yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "Tanlovlar, narx va zaxira bilan yangi mahsulot varianti yarating"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "Maxfiy fasetlar do'konda ko'rinmaydi"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "Soliq toifasini tanlang"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "Ishlamayapti"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "Tayinlangan"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "Sarlavha 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "Mavjud tillarni tanlang"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "{0} ta element qo'shilmoqda"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "Keyin qator qo'shish"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "Jami soliq"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "Qoralama buyurtma holati"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "Joylashuvlar yuklanmoqda…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "To'lov usulini yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "Faset qiymati yaratildi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "Marketing"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "Qoralama buyurtma o'chirildi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "quyidagidan katta"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "Ko'rsatkichlar vidjeti"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "Valyutalarni qidirish..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "Kanaldan olib tashlash"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "Sarlavha"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "Rasm kiritish"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "Sotuvchini yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "Mamlakat yaratildi"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "Sotuvchini tanlang"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "Teglar yuklanmoqda..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "Faset yaratildi"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} ta variant"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "To'lovni yakunlab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "Hisob-kitob manzili yo'q"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, one {{1} ta ombor joylashuvini o'chirib bo'lmadi} other {{2} ta ombor joylashuvini o'chirib bo'lmadi}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "Faset"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr "{rejected, plural, one {{0}} other {{1}}}"
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "Faol kanaldan olib tashlab bo'lmaydi"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "Belgilanmagan"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "Majburiy olib tashlash"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "Yangi kanal"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "Optsiya guruhi nomi"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "VA"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "Mijozlar guruhini yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "Rolni yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "Mahsulot nomi"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "Bajarish holati yangilandi"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "Mahsulotlar"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "Manzil yaratildi"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API kaliti almashtirildi"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "Optsiya guruhi qo'shish"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "{0} pul qaytarish"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "Slug'ni qo'lda kiriting"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "Mavjud vidjetlar yo'q"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "To'lovni bekor qilib bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "To'lov bekor qilindi"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "Global ko'rinish nusxalandi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "Yaratgan"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "Variantlarni filtrlash..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "Boshqa valyutada narx qo'shish"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "Email manzili yoki identifikator"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "Pul qaytarish #{0} {1} holatiga o'tdi"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "Mijozlar"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "Sarlavha 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "Zaxira joylashuvini yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "Buyurtma jo'natildi"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "Manzilni saqlash"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "Global qilish"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "Keyingi holatni tanlang"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "Ogohlantirishlar yo'q"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "{0} ta to'plam{1} {2} ichiga ko'chirilmoqda"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "Test"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "oralig'ida"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "Eslatma qo'shildi"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "Eslatma o'chirildi"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "Eslatma yangilandi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "Pul qaytarishni yakunlab bo'lmadi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "Zaxira darajasi"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "Element qo'shish"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API kaliti yaratildi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "Ko'rib chiqish yuklanmoqda…"
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "Qidiruvga qaytish"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "Ko'rinish nusxalandi"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "Optsiya guruhini olib tashlash"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "Tavsif"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "Mamlakatlar"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr "Buyurtma qatorini olib tashlab bo'lmadi: {0}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "Ko'cha manzili 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "Global ko'rinish o'chirildi"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "Tartibni tahrirlash"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "Kanalga biriktirish"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "Bu hafta"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "{0} miqdorida qo'lda to'lov qo'shish"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "ichida"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "Email"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "Administratorni yangilab bo'lmadi"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "Ushbu jadval uchun shaxsiy ko'rinishlaringizni boshqaring"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "Teglar bo'yicha filtrlash"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "Admin dashboard'ga kirish uchun tizimga kiring"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "Yolg'on"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "Yorug'"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "Tiklash"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "ga teng"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "Parol yangilandi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "o'z ichiga olmaydi"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "Optsiya guruhi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "Quyida manzil tafsilotlarini tahrirlang."
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "Soliq toifasi yaratildi"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "To'plamlarni ko'chirib bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "To'lov holatini yangilab bo'lmadi"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "Buyurtmalaringiz xulosasi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "Yuklash"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "Variantli mahsulot"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "Barcha {0} ta natija ko'rsatilmoqda"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "Qidiruv ID'si"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ yana {0} ta"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "Optsiya guruhlari"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "Maxsus maydonlar"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "Barcha mumkin bo'lgan buyurtma holatlari va ularning o'tishlari. Joriy holat ajratilgan."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "Buyurtmalar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "Buyurtmalar xulosasi vidjeti"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "Elementlar qo'shilmoqda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "Qo'shimcha to'lovni tayyorlash"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "To'lovni tayyorlash"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "Bekor qilingan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "Yaratilgan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "Yetkazilgan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "Qoralama"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "O'zgartirilmoqda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "Qisman yetkazilgan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "Qisman jo'natilgan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "To'lov tasdiqlangan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "To'lov yakunlangan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "Jo'natilgan"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "Obyekt ma'lumotlari"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "Buyurtma jami"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "Faqat adminlarga ko'rinadi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "Miqdor"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "Teglar"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "Super Admin"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "Mavjud amallar"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr "Buyurtma qatorini yangilab bo'lmadi: {0}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "Havola qo'shish"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "Yoqilgan bo'lsa, filtrlar asosiy to'plamdan meros qilinadi va ushbu to'plamdagi filtrlar bilan birlashtiriladi."
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "Hududni tanlang"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "Yetkazib berish usullarini sinash"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "To'lov yakunlandi"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "Hududdan {0} {1} olib tashlandi"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "Yoqish"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "To'lov usullari"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "Tasdiqlangan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "Bekor qilingan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "Yaratilgan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "Rad etilgan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "Xatolik"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "Muvaffaqiyatsiz"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "Kutilmoqda"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "Yakunlangan"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "O'rtacha buyurtma qiymati"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "Hududni yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "Zaxira darajalari"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "API kalitini yangilab bo'lmadi"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "Buyurtma qatorlari"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "Global ko'rinish nomini o'zgartirib bo'lmadi"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "URL va maqsad parametrlari bilan yangi havola qo'shish"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "Balandlik"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "{formattedDiff} miqdorida pul qaytarish talab qilinadi. To'lov summalarini tanlang va davom etish uchun eslatma kiriting."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "Birlik narxi"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "Reja andozasi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "To'lov muvaffaqiyatsiz tugadi"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "Kanal qo'shish"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "Kanallarni qidirish..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "Mijozlar guruhlarini qo'shish"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "Mavjud tillar"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "Tanlovni tiklash"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "Manzil yo'q"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "To'lov usuli yaratildi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "Mijoz ma'lumotlari yangilandi"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr "Qoralama buyurtmani o'chirib bo'lmadi: {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "Ko'rinishni globalga o'tkazib bo'lmadi"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "Mahsulot variantlari"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "Mahsulotlar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "Aksiyalar"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "Mahsulot opsiyasini yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "Eski email:"
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "Ko'rinishni barcha foydalanuvchilarga ochish uchun uni \"Global\" qilib saqlang."
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "Variantlarni yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "Variant zaxirasi tugagan deb hisoblanadigan darajani belgilaydi. Manfiy qiymat oldindan buyurtma imkonini yoqadi. Mahsulot variantlari buni bekor qilishi mumkin."
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "Kalitni almashtirish"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "Parolni yashirish"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "Yangi sotuvchi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "masalan, Qizil, Katta, Paxta"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "Profilni yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "Kupon kodlari olib tashlandi"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "Filtrni tozalash"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "Hududlar"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "Yuklash uchun fayllarni shu yerga tashlang"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "Barcha ko'rinadigan variantlarni almashtirish"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "Tasdiqlangan"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "Yangi optsiya guruhi"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "Hali birorta global ko'rinish yaratilmagan."
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "Rolni yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "To'liq API kaliti faqat hozir ko'rsatiladi. Hozir nusxalang yoki yuklab oling — keyin uni qayta olib bo'lmaydi."
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "To'plam yangilandi"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "To'lov usuli yangilandi"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "Ko'rinish o'chirildi"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "YOKI"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "Teglarni boshqarish"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "Buyurtmadan kupon kodi olib tashlandi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "Hech qachon"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "Faset qiymatini yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "Buyurtma bajarildi"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr "Buyurtma uchun hisob-kitob manzilini o'rnatib bo'lmadi: {0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "Yetkazib berish manzili yo'q"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "So'rov kengaytmasi yaroqsiz GraphQL sintaksisini o'z ichiga oladi"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "So'rov kengaytmasi xatosi"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "So'rov kengaytmasi xatosi:"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "So'rov kengaytmasi yaroqsiz: kamida bitta yuqori darajadagi maydon bo'lishi kerak"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "So'rov kengaytmasi mos kelmadi:"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "public"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "Soliq toifasi yangilandi"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "Ko'chirish"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "Mavjud teglarni tahrirlash yoki o'chirish"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "Bu yetkazib berish usulining muvofiqlik shartlari joriy buyurtma va manzil uchun bajarilmagan."
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "Kupon kodini qo'shish"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "Buyurtma uchun kupon kodi o'rnatildi"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "Maxsus maydonlar"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "Yangi yetkazib berish usuli"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "Ombor joylashuvlarini o'chirish"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "katta yoki teng"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "Oldindan ko'rish"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{1} dan {0} ta bajarish uchun mavjud"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "Oy boshidan hozirgacha"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "Mijoz so'rovi"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "Yetkazishda shikastlangan"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "Mavjud emas"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "Boshqa"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "Noto'g'ri mahsulot"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "O'zgartirishlar xulosasi"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "Pul qaytarishlar ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "Oxirgi bajarilgan"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "To'lov tafsilotlari"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "Qidiruv indeksini qayta qurish"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "Ishlamoqda"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "Har 60 soniyada"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "Mijozlar guruhini yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "To'lov metama'lumotlari"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "O'zgartirishni bekor qilish"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "Xuddi shu oyna"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "Boshlash uchun jadvalga filtrlarni qo'llang va \"Ko'rinishni saqlash\" tugmasini bosing."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "Rollar"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "Qo'shimcha to'lov talab qilinadi"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "Buyurtmani yangilab bo'lmadi"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "Tanlangan bilan..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "Zaxira joyini yaratib bo'lmadi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "kichik yoki teng"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "{customerGroupName} uchun mijozlar guruhi a'zolari"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "Holat"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "Kuzatmaslik"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "Bajarish #{0} yaratildi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "Kutilayotgan qidiruv indeksi yangilanishlari ishga tushirilmoqda"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "Bu standart Rol va uni o'zgartirib bo'lmaydi"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "Mening saqlangan ko'rinishlarim"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "Shtat / Viloyat"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "Yoqilgan"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "Sahifaga elementlar"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "A'zolarni tahrirlash"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "Mavjud zaxira"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "{columnId} bo'yicha filtrlash"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "Ogohlantirishlar"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "Optsiya qiymatlari"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "O'zgartirishlarni oldindan ko'rish"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "{entityType} kanaldan olib tashlab bo'lmadi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "Variant o'chirildi"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "Tanlangan havola xususiyatlarini tahrirlash"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "Sotuvlar"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "Manzil to'plamini tanlang"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "So'nggi buyurtmalaringiz"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "Rejalashtirilgan vazifalar"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "Bu elementni o'chirmoqchimisiz? Bu amalni bekor qilib bo'lmaydi."
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "Variantlar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "Sotuvchilar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "Sozlamalar"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "Sozlamalar do'koni"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "3-sarlavha"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "Vendure'ga xush kelibsiz"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "Yetkazib berish usullari"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} qaytarilishi mumkin)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "Identifikator"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "To'plamni yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "Narx va soliq"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "Buyurtma topilmadi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "Xato"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "Buyurtma o'zgartirildi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "Parolni tiklash so'raldi"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "Ajratilgan to'lov summasi pul qaytarish jamiga teng bo'lishi kerak"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "Joriy kanaldan {0} {entityType} olib tashlamoqchimisiz?"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "Teglar qo'shish..."
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "{0} ta element tanlandi"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "Tillarni qidirish..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "Zaxira joylashuvlari"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "Oldingi sahifaga o'tish"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "Tarkib"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr "{rejected} ta vazifani bekor qilib bo'lmadi"
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "Global ko'rinishni shaxsiyga aylantirib bo'lmadi"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "Vazifa natijasi"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "To'lov qo'shish ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "Tizim"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "Variant nomi"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "Olib tashlash"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "Mijozni yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "Optsiya guruhlari olib tashlansinmi?"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "Bu joriy filtr sozlamalariga asoslangan to'plam tarkibi. To'plamni saqlagach, tarkib yangi sozlamalar bo'yicha yangilanadi."
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, one {{count} ta mijoz guruhdan olib tashlandi} other {{count} ta mijoz guruhdan olib tashlandi}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "Soliq toifalari"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "Soliq stavkalari"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "Mijozlarni guruhdan olib tashlab bolmadi"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "Global sozlamalarni yuklab bo'lmadi"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "Pul qaytarish va zaxiraga qaytarish uchun elementlarni tanlang"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "Saqlash"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "Buyurtma o'zgartirishlarini oldindan ko'rish"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "Sahifa standart so'rov bilan davom etadi."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "Ko'cha manzili"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "Boshqa fasetlar yo'q"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "Qidiruv indeksini qayta qurish boshlandi"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "To'plam pozitsiyasi yangilandi"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "\"{newOptionInput}\" qo'shish"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "Yangi mahsulot varianti"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "Pul qaytarish o'tkazildi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "Mahalliy autentifikatsiya strategiyasidan foydalanilmoqda"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} ta {entityType} kanalga biriktirib bo'lmadi"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "Standart til"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "Token"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "Bajarilmoqda..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "Mahsulotga optsiya guruhi qo'shish"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "Sotuvchi muvaffaqiyatli yangilandi"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "Buyurtmani holatga o'tkazib bo'lmadi"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "Hammasini ko'rsatish ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "Soliq stavkasini yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "Men bu API kalitini saqladim"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "Do'kon va kanallaringiz uchun mavjud tillarni sozlang"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "Mahsulot muvaffaqiyatli yaratildi"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "Mahsulot varianti qo'shish"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "Yozing va qo'shish uchun Enter yoki vergul bosing..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "Eslatmani tahrirlash"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "Asset topilmadi. Filtrlarni o'zgartirib ko'ring."
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "Variant qo'shish"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "Optsiya guruhini saqlash"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "Bu yetkazib berish usulini sinash uchun \"Testni ishga tushirish\" tugmasini bosing."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "Administrator muvaffaqiyatli yangilandi"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "Filtrlarni tozalash"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "{1} dan {2} ga bajarish #{0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "Global ko'rinishni o'chirib bo'lmadi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "Standart til"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "Holat"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "Variantlar topilmadi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "Ikkilik"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "Optsiya guruhi muvaffaqiyatli yangilandi"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "Yangi yetkazib berish usuli"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "Har 10 soniyada"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "soliqsiz:"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "Optsiya qiymati muvaffaqiyatli qo'shildi"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "To'plam yangi ota-elementga ko'chirildi"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "Optsiya guruhi olib tashlandi"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "Tanlangan holatga o'tkazish"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "{formattedDiff} miqdorida qo'shimcha to'lov talab qilinadi."
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "Standart bo'yicha omborni kuzatish"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "{total} tadan {selected} tasi tanlandi"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "Yetkazib berish usuli muvaffaqiyatli yaratildi"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "Yangi mijozlar guruhi"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "Mijozga ko'rinadigan"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "Optsiya guruhi muvaffaqiyatli yaratildi"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "Soliq stavkalari"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug avtomatik yaratiladi..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "Mijoz topilmadi"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "{0} larni tanlang"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "Qo'shish uchun yangi faset qiymatlari:"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "Pul qaytarishni qayta ishlab bo'lmadi"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "Ismi"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "o'z ichiga oladi"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "Optsiya guruhi topilmadi"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "Element topilmadi"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "Oraliq jami"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "Bajarilgan elementlar ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "Qiymat yangilandi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "Tasdiqlanmagan"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "Miqdor"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "Filtr qo'shish"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "Soliq toifasi"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "Profil"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "Test ma'lumotlari yangilandi. Yangilangan natijalarni ko'rish uchun \"Testni ishga tushirish\" tugmasini bosing."
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "ichida emas"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "Buyurtma satri yangilandi"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "Yangi to'lov usuli"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "\"{trimmed}\" takroriy qiymati allaqachon mavjud"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "Sabab"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "Mijozlar guruhlari"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "{entityType} kanaldan muvaffaqiyatli olib tashlandi"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "Optsiya guruhlari"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "Qo'shimcha to'lov qo'shish"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "Joriy faset qiymatlari"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "{totalPages} dan {page}-sahifa"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr "{rejected} ta vazifani bekor qilib bo'lmadi"
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "O'tgan oy"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "Mamlakat qo'shish"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "Elementni olib tashlash"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "Video"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "dan kichik"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "Variantni qo'shib bo'lmadi. Ota-mahsulot yoqilganiga ishonch hosil qiling."
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "Metrikalar"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "Til"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "Yangi to'plam"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "Pul qaytarish va buyurtmani bekor qilish"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "Elektron pochta yangilanishi tasdiqlandi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "oralig'ida"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "Pul qaytarish va bekor qilish"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "Yetkazib berish usullari sinovdan o'tkazilmoqda..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "Yetkazib berish usulini yaratib bo'lmadi"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "{entityIdsLength} ta {entityType} kanalga muvaffaqiyatli biriktirildi"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "Global tillar"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "Yangi administrator"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "Qoralamani o'chirish"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "Manba"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "Mavjud amallar yo'q"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "Kanalni yangilab bo'lmadi"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "Umumiy"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "Yangi manzil qo'shish"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "Faset muvaffaqiyatli yangilandi"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "Hudud muvaffaqiyatli yaratildi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "Qiymat"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "Mijoz yangilandi"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "Narx konversiya koeffitsienti"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "Sotuvchi buyurtmasi"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "Yangi faset"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "Ushbu optsiya guruhini mahsulotdan olib tashlamoqchimisiz?"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "Tavsif (muqobil)"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "Teglar topilmadi"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "Standart valyuta"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "Bu o'zgartirishlar uchun to'lov yoki pul qaytarish talab qilinmaydi."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr "{cancellableCount, plural, one {{cancellableCount} ta vazifani bekor qilmoqchimisiz? Bu amalni qaytarib bo'lmaydi.} other {{cancellableCount} ta vazifani bekor qilmoqchimisiz? Bu amalni qaytarib bo'lmaydi.}}"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "Jami daromad"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "Keyingi bajarilish"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "Eslatma maxfiy"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "O'rta sana"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "Noto'g'ri raqam"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "Hali hech qanday ko'rinishni saqlamadingiz."
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "Ushbu ko'rinishni o'chirmoqchimisiz? Bu amalni qaytarib bo'lmaydi."
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "Buyurtma jarayonini ko'rish"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "Ko'rinishni nusxalash amalga oshmadi"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "Standart yetkazib berish manzili sifatida ishlatish"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "Slug'ni qo'lda tahrirlash"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "To'plam tarkibini ko'rish uchun filtrlar qo'shing."
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "Oraliq jami"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "dan kichik"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "Pul qaytarish ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "Buyurtmaning maxsus maydonlari yangilandi"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "Kalkulyator"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "Optsiya guruhini kanaldan olib tashlash amalga oshmadi: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "Vazifa ma'lumotlarini ko'rish"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "Eng yuqori darajaga ko'chirish"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "Tozalash"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "Buyurtmalar xulosasi"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "Assetlarni qidirish..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "Yangi faset"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "{entityType} ni kanalga biriktirish"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "Davom etish"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "Aksiyalar"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "Xatolik xabari"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "Boshqa joy uchun zaxira darajasini qo'shish"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "Manzilni o'chirish"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "Fasetni yangilash amalga oshmadi"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters WidgetFiltersProvider ichida ishlatilishi kerak"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "Manzilni tahrirlash"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "Fasetni kanaldan olib tashlash amalga oshmadi: {message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "Havolani o'rnatish"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "Yangi sotuvchi"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "Rasmni tahrirlash"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "Variantlarni boshqarish"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "Zaxira ajratildi"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "dan katta yoki teng"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "Ushbu variant zaxirada tugagan deb hisoblanadigan zaxira darajasini belgilaydi. Manfiy qiymat oldindan buyurtmani yoqadi."
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "Saqlanmoqda..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "Natijani ko'rish"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "Sahifadagi qatorlar"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "To'plamlar yuklanmoqda..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "Faset qiymati muvaffaqiyatli yangilandi"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "Asset qo'shish"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "Mijoz guruhga qo'shildi"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "Sotuvchi buyurtmalari"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "Optsiya qiymatini qo'shish amalga oshmadi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "{groupName} ga optsiya qiymatini qo'shish"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr "Buyurtma uchun yetkazib berish manzilini bekor qilish amalga oshmadi: {0}"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity} ta mahsulot uchun pul qaytarildi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "Hali optsiya guruhi belgilanmagan. Mahsulotingizning turli variantlarini yaratish uchun optsiya guruhlarini qo'shing (masalan, O'lcham, Rang, Material)"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "Yangi email:"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "To'lov usulini yangilash amalga oshmadi"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "Mavjud:"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "Yaratilgan sana"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "Mahsulot variantini yaratish amalga oshmadi"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "Til: {0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "Sizda global til sozlamalarini ko'rish ruxsati yo'q"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "Soliq stavkasi muvaffaqiyatli yaratildi"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "Sarlavha 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "Kupon kodlari qo'shildi"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "Faol"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "Soliq asosi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "Ko'proq yuklash"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "Pul qaytarish hisoblashildi"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API kaliti"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "{count} ta {entityName} muvaffaqiyatli nusxalandi"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "Yangi optsiya guruhi"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "Hali natija yo'q"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "To'lov hisoblashildi"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "Mavjud shartlar"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "Faol filtrlar"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "Hammasini tozalash"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "dan katta"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "Yopish"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "Buyurtmaga to'lov qo'shish"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "Yuklanmoqda..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "Token API so'rovlarini yuborishda kanalni belgilash uchun ishlatiladi."
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "Manzillar topilmadi"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "Bajarish ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "Pul qaytarish uchun to'lovlarni tanlang"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "{failed} ta {entityName} ni o'chirish amalga oshmadi"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "Zaxira tugash chegarasi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "Qiymatni yangilash amalga oshmadi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "API kalitini yaratish amalga oshmadi"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "Pul qaytarishni hisoblash"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "To'lov usuli talab qilinadi"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "Mijozni guruhga qo'shish amalga oshmadi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "Variantlarni boshqarish"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "\"{viewName}\" global ko'rinishi qo'llanildi"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "Mijoz ro'yxatdan o'tdi"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "Hududlar"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "Sotuvchilarni qidirish..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "Aksiya muvaffaqiyatli yaratildi"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "Optsiya"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "Buyurtma jarayoni"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "Telefon raqami"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "Maxfiy"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "Variant"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "Global sozlamalar muvaffaqiyatli yangilandi"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API kaliti muvaffaqiyatli yangilandi"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "Bu tillar barcha kanallar uchun mavjud bo'ladi"

--- a/packages/dashboard/src/i18n/locales/zh_Hans.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hans.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "全名"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "选择项目"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "查看更改"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "跟踪代码"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "所选权限将应用于这些渠道。"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "商品选项"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "新税率"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "分配现有选项组或创建新的选项组"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "新角色"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "公寓、套房等"
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "没有更多项目"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "编辑链接"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "请至少添加一件商品到订单"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "添加商品以创建测试订单"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "创建地址失败"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "全部切换"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "编辑 JSON 值"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "使用外部身份验证策略：{strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "选择原因..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "标题 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "添加支付失败"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "已更新"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "更新全局设置失败"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "已成功履行订单"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "确定要删除 {0} {entityName} 吗？"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "全局缺货阈值"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "管理语言"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "正在复制... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "成功删除"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "从当前渠道中删除"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "已删除 {selectionLength} 个资源"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "已成功更新税率"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "输入自定义原因..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "类型"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "选择 {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "查看值"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "删除行"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "条件"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "当前"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "无履行"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, other {无法删除 {2} 个库存地点：{messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "启用后，商品目录中输入的价格将包含默认税务区域的税费。"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "为您的商品创建变体"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "草稿订单已完成"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "自动刷新：{0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "健康检查"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "已删除 {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "健康检查"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "卖家"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "选项"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, other {成功取消 {fulfilled} 个任务}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "卖家"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "添加付款"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "通过模拟订单测试此配送方式，以查看其是否适用以及配送成本是多少。"
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "探索企业版"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "库存位置"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "履行处理器"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "订单"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "选择角色"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "已成功创建角色"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "确定要删除此变体吗？"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "所有资源正在运行"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "创建管理员失败"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "否"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "已成功更新商品变体"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "删除 {failed} {entityName} 失败：{allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "已成功更新商品"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "更新国家失败"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "至少输入 2 个字符进行搜索..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "姓"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "链接标题"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "已成功更新客户组"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "自定义字段已更改"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "已成功创建库存位置"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "未知错误"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "退款总额不能为负数"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "查看详情"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "选择要将 {0} {entityType} 分配到的渠道"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "已成功创建客户"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "过去7天"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "创建渠道失败"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "开发者模式"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "新角色"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "删除资源失败：{message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "退回库存"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "可见性"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "产品变体"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "新客户组"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "创建\"{0}\""
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "重命名"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "选择您偏好的显示语言和区域设置"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "已成功从渠道中移除 {successCount} 个选项组"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "配送方式不适用于此订单"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "更新地址失败"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "地址已成功删除"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "税率"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "订单草稿尚未准备就绪"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "新集合"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "洞察"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "运行"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "更新税率失败"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "这是 <0>{collectionName}</0> 集合的内容。"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "私有"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "成功创建产品选项"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "父级产品"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "城市"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "管理员"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "总价：<0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "转到下一页"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "删除链接"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "此字段为只读"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "订单数量"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "已成功更新订单"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "继承筛选器"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "管理对所有用户可见的全局保存视图"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "搜索支付方式..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "订单已取消配送地址"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "创建 {enabledCount} 个变体"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "支付 #{0} 已转换到 {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "加载客户历史出错：{0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "已成功从渠道中删除 {selectionLength} {entityType}"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "添加选项值"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "全局设置"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "在之后"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "成功更新产品选项"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "编辑属性值"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "正在添加..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "移动集合"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "角色"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "网格视图"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "删除地址失败"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "无可用配送方式"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "全局视图已成功转换为个人视图"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "履行已转换"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "确定要删除 {selectionLength} 个资源吗？"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "登录"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "列表视图"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "测试订单"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "选择客户以继续"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "选项组分配成功"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "运行测试"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "税率：{taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "请添加商品并填写配送地址以运行测试。"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "切换标题行"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "选择地址"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "支付资格检查器"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "默认税务区域"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "订单草稿已准备就绪可以完成"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "元数据"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "筛选..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "新属性值"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "已成功更新渠道"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "显示更少"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "短日期"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "可用货币"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "选择 {0} 个项目"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "下单时间"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "轮换此密钥将立即使当前密钥失效。所有使用该密钥的集成将停止工作，直到更新为新密钥。"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "传递给作业的数据"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "确认导航"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "链接目标"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "完成草稿"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "名称"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "履行订单失败"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "总计"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "输入此退款结算的交易 ID"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "您的 API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "确定要删除此草稿订单吗？"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "履行已创建"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "找到 {0} 个符合条件的配送方式"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "尺寸"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "显示密码"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(最大: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "公司"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "在后面添加列"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "操作"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "折扣"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "输入退款备注"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "订单行已删除"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "内容:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "密钥"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "确认"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "创建集合失败"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "转到首页"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "创建商品失败"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "客户"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "加载订单历史出错：{0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "订单已设置配送地址"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "焦点"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "单一变体，无选项"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "选择订单的下一个状态"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "区域设置"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "计划任务"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "输入交易 ID"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "刷新数据"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "为 {0} {entityType} 添加或删除属性值"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "这些是 <0>{facetName}</0> 属性的属性值。"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "已成功向订单添加支付"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "已为订单设置账单地址"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "更新区域失败"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "密码"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "删除失败"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "将执行计划任务"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "新库存位置"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "权限"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "配送地址已更改"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "未找到产品"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "在前面添加行"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "转换到 {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "本月"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "创建属性失败"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "取消订单商品失败"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "交易 ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "已分配"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "添加另一个选项组"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "请选择如何处理剩余库存"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "探索 Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "每 5 秒"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "已成功创建集合"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "价格"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "草稿订单"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "范围"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "添加条件"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "配送方式适用于此订单"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "管理员"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "已从组中删除"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "宽度"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "不需要支付或退款"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "下载为 .env 文件"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "启用后，促销在商店中可用"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "跟踪后，商品变体库存水平将在售出时自动调整。此设置可由各个商品变体覆盖。"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "订单已设置配送方式"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "更新促销失败"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "图片"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "搜索 {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "编辑资源"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "取消付款"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "作业队列"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "资源"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "电子邮件地址"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "从源字段重新生成 slug"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "从全局设置继承"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "未找到结果"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "当前状态"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "设置收货地址并选择配送方式"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "关"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "设置商店"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "队列"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "新税率"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "支付已转换"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "剩余："
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "未找到代码为\"{duplicatorCode}\"的 {entityName} 复制器"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "价格包含默认税务区域的税费"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "退款总计："
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "查看作业结果"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "通过模拟新订单来测试您的配送方式。"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "未选择项目"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr "，已选择 {0} 项"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "未找到国家"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "变体创建成功"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "自动生成 slug"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "附加费"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "支付方式"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "库存"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "未找到客户"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "使用全局缺货阈值"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "新商品选项组"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "支付状态已成功更新"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "新建"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "退款总额"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "地址已删除"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "仅您账户已分配的角色可用。"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "项目已添加到订单"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "编辑焦点"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "未找到卖家"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "资源"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {此选项组被另一个产品使用。更改也会影响该产品。} other {此选项组在 # 个产品中共享。更改将影响所有产品。}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "我的保存视图"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "新渠道"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "创建卖家失败"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "配置{0}的复制设置"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "没有与当前筛选条件匹配的变体。"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "地址"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "向 {groupName} 选项组添加新的选项值"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "订单修改 #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "在前面添加列"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "渠道语言"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "创建选项组失败"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "是"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "选择客户"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "订单已转换"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "此商品有现有变体，但未定义选项组。您需要在创建新变体之前添加选项组。"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "在之前"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "删除草稿订单"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "目录"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "新支付方式"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "已成功更新促销"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, other {取消 {rejected} 个任务失败}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "选择一个渠道"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "显示语言"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "履行详情"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "丢弃剩余库存"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "现在"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "渠道"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "视图已成功转换为全局"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "之前"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "大小"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "未找到 {0} 的翻译"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "新客户"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "最新订单"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} 个更多"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "用作默认账单地址"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "删除"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "禁用"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "集合"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "添加变体"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "创建国家失败"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "国家"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "创建商品选项失败"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "重命名视图失败"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "可用"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "正常"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "筛选器"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "客户组"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "客户"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "示例格式"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "新选项"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "使用限制"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "正在加载全局设置..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "地址已成功更新"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "已创建"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "正在加载地址..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "选择要将 {0} 移动到的目标集合。"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "客户详情已更新"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "不在"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "应用"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "新商品选项"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "转到末页"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "取消"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "已成功创建商品变体"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "从此方式退款"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "邮政编码"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "请先添加商品选项"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "新税务类别"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "添加选项"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "部分退款已完成"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "设置自定义字段"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "集合"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "删除变体"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "未进行修改"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "默认配送区域"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "原因:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "配送地址"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "转换到 {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "税务类别"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "私有集合在商店中不可见"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "启用后，商品在商店中可用"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "无法执行计划任务"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "客户组"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "已禁用"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "新促销"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "默认配送地址"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "需要退款"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "履行订单"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "您没有查看渠道设置的权限"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "过去30天"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "无属性值"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "需要提供退款原因"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "无法移除选项组"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "更新税务类别失败"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "退款已成功完成"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "更新"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "标题 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "订单已下单"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "已成功更新个人资料"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "结束"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "支付方式"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "编辑"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "变体已成功更新"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "按集合名称筛选"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "备注已添加"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "选择要履行的数量并配置履行处理器"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "已从订单移除账单地址"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "开始于"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "复制"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "无结果"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "列设置"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, other {无法删除 {count} 个库存地点}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "代码"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "移除选项组失败"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "订单已送达"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "转移到 {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "剩余库存"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "从区域移除"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "从此渠道的全局可用语言中选择"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "确定要删除此地址吗？"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "分配选项组失败"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "更新资源失败"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "已成功更新库存位置"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "确认操作"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "已成功更新国家"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "属性"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "添加备注失败"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "删除备注失败"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "扩展查询文档失败"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "更新备注失败"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "退还运费"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "只读"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "复制全局视图失败"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "显示 {total} 个中的 {shown} 个 • 已选择 {selected} 个"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "测试配送方式"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "属性值"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "已成功更新资源"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "主题"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} 位客户"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "选择一种语言"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "退出"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "尝试次数"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "可用货币代码"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "可用语言代码"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "面包屑导航"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "类别"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "渠道"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "子项"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "代码"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "优惠券代码"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "创建时间"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "货币代码"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "客户"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "客户组"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "客户"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "自定义字段"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "数据"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "默认货币代码"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "默认语言代码"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "默认配送区域"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "默认税务区域"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "描述"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "时长"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "电子邮件地址"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "已启用"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "结束时间"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "错误"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "特色资源"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "名"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "履行处理器代码"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "默认"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "私有"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "已完成"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "姓"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "名称"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "订单下单时间"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "父级 ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "每位客户使用限制"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "权限"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "位置"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "价格"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "价格含税"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "含税价格"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "商品变体"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "进度"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "队列名称"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "结果"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "重试次数"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "卖家"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "结算时间"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "配送行"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "开始时间"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "开始时间"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "状态"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "库存水平"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "令牌"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "总计"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "含税总计"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "类型"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "更新时间"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "使用限制"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "用户"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "值"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "值列表"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "区域"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "方法"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "税费摘要"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "设置所有渠道可用的语言。然后，各个渠道可以支持这些语言的子集。"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "集合移动成功"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "已注册"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "取消作业"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "结束于"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "第 {0} 页，共 {1} 页"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "费率"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "大小、颜色等"
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "浏览分面"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "区域"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "已取消"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "已创建"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "已送达"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "待处理"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "已发货"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "保存视图"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "已选择 {0} 个"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "搜索选项组..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "修改订单"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "已选项目"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "值"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "订单已设置客户"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "属性"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, other {您确定要从此组中移除{count}位客户吗？}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "现有库存"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "无法开始重建搜索索引"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "配送地址"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "新区域"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "新建 API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "删除列"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "分配现有"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "为空"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "这些是 <0>{customerGroupName}</0> 客户组中的客户。"
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "管理全局视图"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "默认渠道"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "插入带有来源、标题和尺寸的新图片"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "创建属性值失败"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "更新产品选项失败"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>忘记密码？</0><1>请求重置</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "优惠券代码"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "客户已验证"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "全局设置"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "时间表"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "无法将集合移动到其自身的子集"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "新税务类别"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "当前渠道无可用库存位置"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "已成功创建渠道"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "已成功更新客户"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "查看数据"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "删除视图"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "为客户添加新地址。"
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "更多视图"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "编辑所选图片的属性"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "已应用视图\"{viewName}\""
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "已成功从渠道中删除 {successCount} 个属性"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "新商品"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "新资源"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "重新计算运费"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "选择应用于现有变体\"{0}\"的选项"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "资源"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "这将移除此产品的所有选项组并返回变体设置选择。"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "账单地址"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "添加属性值"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "请选择目标集合"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "在将更改应用到订单之前，请先查看更改。"
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "选择一个角色"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "订单已取消"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "折扣"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "所有类型"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "只有草稿订单可以完成"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "更新商品失败"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "正在调整 {0} 行"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "添加属性值"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "之后"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "渠道"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "健康检查"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "金额"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "电话号码"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "新客户"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "图片"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "成功创建管理员"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "商品选项"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "选择国家"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "正在创建..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "确定要删除此全局视图吗？此操作无法撤销，将影响所有用户。"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "强制移除选项组"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "已添加"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "客户历史"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "已成功为 {entityIdsLength} {entityType} 更新属性值"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "从组中删除客户失败"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "系统"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "每位客户使用限制"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "账单地址已更改"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "选择一个选项"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "复制到个人"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "退款总额超过最大可退款金额 {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "删除全局视图"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "创建"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "每 30 秒"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "新国家"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "从 {0} 到 {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "创建客户失败"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "焦点已更新"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "选项值"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "默认账单地址"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "无客户"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "从区域移除国家/地区失败"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "创建促销失败"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "今天"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "昨天"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "选项名称"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "确定要从此区域移除 {0} {1} 吗？"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "正在添加 {0} 项附加费"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "链接 href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "回退值: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "订单历史"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "覆盖"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "交易 ID 为必填项"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "匹配正则表达式"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "全局视图已成功重命名"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "未选择标签"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "返回"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "视图已成功重命名"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "应用筛选器"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "上次结果"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "已添加到组"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "洞察"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "创建变体"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "正在测试配送方式..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "深色"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "测试结果"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "添加客户"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "保存更改"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "地址已更新"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "退款处理成功"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "新区域"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "更新集合位置失败"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "退款"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "修改"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "未配置全局语言"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "正在删除 {0} 个项目"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "跟踪"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "创建变体"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "{facetName} 的属性值"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "保存布局"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "密码重置已验证"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "删除视图失败"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "确定要离开此页面吗？任何未保存的更改都将丢失。"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "切换标题列"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "新促销"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "选项值名称"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "最后使用时间"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "默认税务类别"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug 已设置"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "更新焦点失败"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "已成功更新区域"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "州/省"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "更新选项组失败"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "渠道默认值"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "创建税务类别失败"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "设置 {columnId} 列的筛选条件"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "国家"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "简单产品"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "作业队列"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "请在关闭前确认您已保存 API Key。"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "确认删除"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "修改订单失败"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "含 {taxRate}% 税"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "订单指标"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "选择显示语言"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "认证方式"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "开始"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "轮换 API Key 失败"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "在"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "搜索角色..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "商品变体"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "管理全局视图"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "处理中..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "找到 {totalItems} 个{0}"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "选择日期范围"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "商品"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "轮换 API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "类别"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "正在移动..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "分配"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "已成功创建卖家"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "成功更新配送方式"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "更新商品变体失败"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "拖动以重新排序"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "区域"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "请选择如何处理您要删除的 {count, plural, other {# 个库存地点}} 中剩余的库存。所有选中的地点会将其剩余库存转移到您选择的那个地点，或将其丢弃。"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "搜索分面值..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "备注"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "可用语言"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "加载更多{0}个 (剩余{remaining}个)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "属性值"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "重新排序商品失败"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "订单总数"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "未找到此订单的符合条件的配送方式。"
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "添加商品选项"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "配送"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions 必须在 DashboardBaseWidget 中使用"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "此选项组正被现有变体使用。强制移除可能会影响这些变体。您确定吗？"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "已请求电子邮件更新"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "转换到状态时出错"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "已成功创建客户组"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "新窗口"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "支付已授权"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "已成功更新角色"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "选择一个国家"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "更新配送方式失败"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, other {已删除 {deleted} 个库存地点}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "配送方式"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "选择一个地址"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "是"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "设置焦点"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "结束"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "选择一种货币"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "更新备注内容或可见性"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "最新订单小部件"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "{collectionName} 的集合内容"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "配送方式已更改"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "税项描述"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "小于或等于"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "不等于"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "刷新"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "例如：尺寸"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "完成支付"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "渠道"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "运费已退款"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "资源类型"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "新库存位置"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "失败前已退还 {successfulRefundCount} 笔付款。请查看订单历史了解详情。"
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "选择项目"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "新商品"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "管理标签"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "已退款商品"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "添加操作"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "将选项分配给现有变体"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "复制 {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "从组中移除"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "更新履行状态失败"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "创建包含选项、定价和库存的新产品变体"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "私有属性在商店中不可见"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "选择一个税务类别"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "已创建"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "未运行"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "已分配"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "标题 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "选择可用语言"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "正在添加 {0} 个项目"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "在后面添加行"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "税费总计"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "草稿订单状态"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "已成功创建商品选项"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "正在加载地点…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "创建支付方式失败"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "已成功创建属性值"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "营销"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "草稿订单已删除"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "大于"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "指标小部件"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "搜索货币..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "从渠道中移除"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "标题"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "插入图片"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "更新卖家失败"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "已成功创建国家"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "选择卖家"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "正在加载标签..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "已成功创建属性"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} 个变体"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "完成支付失败"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "无账单地址"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, other {无法删除 {2} 个库存地点}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "属性"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "无法从活动渠道中移除"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "未设置"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "强制移除"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "新渠道"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "选项组名称"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "与"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "创建客户组失败"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "创建角色失败"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "商品名称"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "履行状态已成功更新"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "商品"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "地址已创建"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key 轮换成功"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "添加选项组"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "退款 {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "手动输入 slug"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "无可用小组件"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "取消支付失败"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "支付已成功取消"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "全局视图已成功复制"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "创建者"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "筛选变体..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "添加另一种货币的价格"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "电子邮件地址或标识符"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "退款 #{0} 已转换到 {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "客户"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "标题 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "更新库存位置失败"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "订单已发货"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "保存地址"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "设为全局"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "选择下一个状态"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "无提醒"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "正在将 {0} 个集合移动到 {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "测试"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "之间"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "备注已成功添加"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "备注已成功删除"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "备注已成功更新"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "完成退款失败"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "库存水平"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "添加项目"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key 创建成功"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "正在加载预览..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "返回搜索"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "视图已成功复制"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "移除选项组"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "描述"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "国家"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "街道地址 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "全局视图已成功删除"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "编辑布局"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "分配给渠道"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "本周"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "成功创建商品选项组"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "添加 {0} 的手动付款"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "在"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "电子邮件"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "更新管理员失败"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "管理此表格的个人保存视图"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "按标签筛选"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "登录以访问管理仪表板"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "向订单添加支付 ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "否"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "浅色"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "重置"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "等于"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "创建选项"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "密码已更新"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "不包含"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "选项组"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "编辑下面的地址详情。"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "已成功创建税务类别"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "移动集合失败"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "更新支付状态失败"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "您的订单摘要"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "上传"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "带选项的产品"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "显示所有 {0} 个结果"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "查找 ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} 个更多"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "选项组"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "自定义字段"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "所有可能的订单状态及其转换。当前状态已高亮显示。"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "订单"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "订单摘要小部件"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "添加商品中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "安排额外付款"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "安排支付中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "已取消"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "已创建"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "已送达"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "草稿"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "修改中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "部分已送达"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "部分已发货"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "支付已授权"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "支付已完成"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "已发货"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "监控资源"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "实体信息"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "订单总额"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "仅管理员可见"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "数量"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "标签"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "超级管理员"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "某些资源已关闭"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "可用操作"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "插入链接"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "如果启用，筛选器将从父集合继承，并与此集合上设置的筛选器组合。"
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "选择一个区域"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "测试配送方式"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "支付已成功完成"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "已从区域移除 {0} {1}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "启用"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "支付方式"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "已授权"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "已取消"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "已创建"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "已拒绝"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "错误"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "失败"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "待处理"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "已结算"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "平均订单价值"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "创建区域失败"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "库存水平"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "更新 API Key 失败"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "订单行"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "重命名全局视图失败"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "插入带有 URL 和目标选项的新超链接"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "高度"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "需要退款 {formattedDiff}。选择付款金额并输入备注以继续。"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "单价"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "时间表模式"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "支付失败"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "添加渠道"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "更新商品选项组失败"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "搜索渠道..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "添加客户组"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "可用语言"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "重置选择"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "无地址"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "已成功创建支付方式"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "客户信息已更新"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "将视图转换为全局失败"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "商品变体"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "商品"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "促销"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "创建产品选项失败"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "旧电子邮件："
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "将视图保存为\"全局\"以使其对所有用户可用。"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "创建变体失败"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "设置将此变体视为缺货的库存水平。使用负值可启用延期交货支持。可由商品变体覆盖。"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "轮换密钥"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "创建产品变体失败"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "隐藏密码"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "新卖家"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "例如：红色、大号、棉质"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "更新个人资料失败"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "已删除优惠券代码"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "清除筛选器"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "地区"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "将文件拖放到此处上传"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "切换所有可见变体"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "已验证"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "新建选项组"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "上次更新 {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "尚未创建全局视图。"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "更新角色失败"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "完整的 API Key 仅此一次显示。请立即复制或下载，之后将无法再次获取。"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "已成功更新集合"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "已成功更新支付方式"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "视图已成功删除"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "选项组 {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "或"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "管理标签"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "优惠券代码已从订单中移除"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "从不"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "更新属性值失败"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "删除组"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "订单已履行"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "无配送地址"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "查询扩展包含无效的 GraphQL 语法"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "查询扩展错误"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "查询扩展错误："
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "查询扩展无效：必须至少有一个顶级字段"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "查询扩展不匹配："
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "公开"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "已成功更新税务类别"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "移动"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "编辑或删除现有标签"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "此配送方式的资格检查器条件不符合当前订单和配送地址。"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "添加优惠券代码"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "已为订单设置优惠券代码"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "自定义字段"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "新配送方式"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "删除库存地点"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "大于或等于"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "预览"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{1} 个中有 {0} 个可履行"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "本月至今"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "客户要求"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "运输中损坏"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "无库存"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "其他"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "发错商品"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "修改摘要"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "退款 ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "上次执行"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "支付详情"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "重建搜索索引"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "正在运行"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "每 60 秒"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "更新客户组失败"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "支付元数据"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "取消修改"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "相同窗口"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "对表格应用筛选器，然后点击\"保存视图\"开始。"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "角色"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "需要额外支付"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "更新订单失败"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "对所选..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "创建库存位置失败"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "小于或等于"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "{customerGroupName} 的客户组成员"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "州/省"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "不跟踪"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "已创建履行 #{0}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "正在运行待处理的搜索索引更新"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "这是默认角色，无法修改"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "我的保存视图"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "州/省"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "已启用"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "每页条数"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "编辑成员"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "现有库存"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "按 {columnId} 筛选"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "警报"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "选项值"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "预览更改"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "从渠道中移除 {entityType} 失败"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "变体已成功删除"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "编辑所选链接的属性"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "销售"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "选择目标集合"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "您的最新订单"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "计划任务"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "确定要删除此项目吗？此操作无法撤销。"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "变体"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "卖家"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "设置"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "设置商店"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "标题 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "欢迎使用 Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "配送方式"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} 可退款)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "标识符"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "更新集合失败"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "价格和税费"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "未找到订单"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "错误"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "订单已修改"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "已请求重置密码"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "分配的付款金额必须等于退款总额"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "例如：小号"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "确定要从当前渠道中删除 {0} {entityType} 吗？"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "添加标签..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "创建商品选项组失败"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "已选择 {0} 个项目"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "搜索语言..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "库存位置"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "转到上一页"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "内容"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "将全局视图转换为个人视图失败"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "作业的结果"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "添加支付 ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "系统"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "变体名称"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "删除"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "更新客户失败"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "移除选项组？"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "这是基于当前筛选器设置的集合内容预览。保存集合后,内容将更新以反映新的筛选器设置。"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, other {已从组中移除{count}位客户}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "税务类别"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "税率"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "从组中移除客户失败"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "加载全局设置失败"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "选择要退款的商品，可选择退回库存"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "保存"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "已选择 {0} 行中的 {selectedRowCount} 行。"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "预览订单修改"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "成功更新商品选项组"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "页面将继续使用默认查询。"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "街道地址"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "没有更多分面"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "已开始重建搜索索引"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "集合位置已更新"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "选项组名称"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "添加「{newOptionInput}」"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "新商品变体"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "退款已转换"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "使用本地身份验证策略"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "无法将 {entityIdsLength} 个 {entityType} 分配到渠道"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "默认语言"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "令牌"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "正在履行..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "将选项组添加到商品"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "{0} 的预览"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "已成功更新卖家"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "将订单转换到状态失败"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "显示全部 ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "创建税率失败"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "我已保存此 API Key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "为您的商店和渠道配置可用语言"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "已成功创建商品"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "添加商品变体"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "输入后按 Enter 或逗号添加..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "编辑备注"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "未找到资源。请尝试调整筛选条件。"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "添加选项"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "保存选项组"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "创建 {createCount} 个变体"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "点击\"运行测试\"以测试此配送方式。"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "成功更新管理员"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "清除筛选器"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "履行 #{0}，从 {1} 到 {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "删除全局视图失败"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "默认语言"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "状态"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "未找到选项"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "二进制"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "选项组更新成功"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "新配送方式"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "每 10 秒"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "不含税："
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "向位置添加库存"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "已成功添加选项值"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "集合已移至新的父级"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "选项组已删除"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "转换到选定状态"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "需要额外支付 {formattedDiff}。"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "默认跟踪库存"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "已选择 {total} 个中的 {selected} 个"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "成功创建配送方式"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "新客户组"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "客户可见"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "已成功创建选项组"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "税率"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug 将自动生成..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "未找到客户"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "选择 {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "要添加的新属性值："
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "处理退款失败"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "名"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "包含"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "未找到选项组"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "未找到项目"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "小计"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "已履行的项目 ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "值已更新"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "未验证"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "数量"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "添加筛选器"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "税务类别"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "个人资料"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "测试数据已更新。点击\"运行测试\"以查看更新的结果。"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "不在"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "订单行已更新"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "新支付方式"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "重复值\"{trimmed}\"已存在"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "原因"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "客户组"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "已成功从渠道中移除 {entityType}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "选项组"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "添加附加费"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "当前属性值"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "第 {page} 页，共 {totalPages} 页"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "上个月"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "添加国家"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "删除项目"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "视频"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "小于"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "无法添加变体。请确保父产品已启用。"
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "发生未知错误"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "指标"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "语言"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "新集合"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "退款并取消订单"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "电子邮件更新已验证"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "在之间"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "退款并取消"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "正在测试配送方式..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "创建配送方式失败"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "已成功将 {entityIdsLength} {entityType} 分配给渠道"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "全局语言"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "新管理员"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "删除草稿"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "来源"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "无可用操作"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "更新渠道失败"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "常规"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "从渠道移除产品失败"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "添加新地址"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "已成功更新属性"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "已成功创建区域"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "值"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "客户已更新"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "价格转换系数"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "卖家订单"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "新属性"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "您确定要从产品中移除此选项组吗？"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "描述（替代文本）"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "未找到标签"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "默认货币"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "这些更改不需要支付或退款。"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "总收入"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "下次执行"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "备注为私有"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "中等日期"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "无效数字"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "您尚未保存任何视图。"
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "确定要删除此视图吗？此操作无法撤销。"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "查看订单流程"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "复制视图失败"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "用作默认配送地址"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "手动编辑 slug"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "添加筛选器以预览集合内容。"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "商品选项组"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "小计"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "小于"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "退款 ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "订单自定义字段已更新"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "计算器"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "从渠道中移除选项组失败: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "查看作业数据"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "移动到顶层"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "清除"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "订单摘要"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "搜索资源..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "新属性"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "将 {entityType} 分配给渠道"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "继续"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "促销"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "错误消息"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "为另一个位置添加库存水平"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "删除地址"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "更新属性失败"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters 必须在 WidgetFiltersProvider 中使用"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "编辑地址"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "从渠道中删除属性失败：{message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "设置链接"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "新卖家"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "编辑图片"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "管理变体"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "库存已分配"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "大于或等于"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "设置将此变体视为缺货的库存水平。使用负值可启用延期交货支持。"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "创建商品选项"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "正在保存..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "查看结果"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "每页行数"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "正在加载集合..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "已成功更新属性值"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "添加资源"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "保存更改"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "客户已添加到组"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "卖家订单"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "添加选项值失败"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "向 {groupName} 添加选项值"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity}件商品已退款"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "尚未定义选项组。添加选项组以创建商品的不同变体（例如：尺寸、颜色、材质）"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "新电子邮件："
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "更新支付方式失败"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "可用："
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "创建于"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "创建商品变体失败"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "语言：{0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "您没有查看全局语言设置的权限"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "已成功创建税率"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "标题 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "已添加优惠券代码"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "活跃"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "税基"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "加载更多"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "退款已完成"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "已成功复制 {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "新建选项组"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "尚无结果"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "支付已完成"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "可用条件"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "活动筛选条件"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "全部清除"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "大于"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "关闭"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "向订单添加支付"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "正在加载..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "在进行 API 请求时使用令牌来指定渠道。"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "未找到地址"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "履行 ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "选择要退款的付款"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "删除 {failed} {entityName} 失败"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "缺货阈值"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "已成功从渠道移除产品"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "更新值失败"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "创建 API Key 失败"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "完成退款"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "支付方式为必填项"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "将客户添加到组失败"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "管理变体"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "已应用全局视图\"{viewName}\""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "客户已注册"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "区域"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "搜索卖家..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "已成功创建促销"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "选项"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "订单流程"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "电话号码"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "私有"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "变体"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "已成功更新全局设置"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key 更新成功"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "这些语言将可供所有渠道使用"

--- a/packages/dashboard/src/i18n/locales/zh_Hant.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hant.po
@@ -13,6186 +13,6186 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
-#: src/lib/components/shared/customer-address-form.tsx:103
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Full Name"
 msgstr "全名"
 
-#: src/lib/components/data-input/relation-selector.tsx:409
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select items"
 msgstr "選取項目"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View changes"
 msgstr "檢視變更"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Tracking code"
 msgstr "追蹤代碼"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "The selected permissions will be applied to the these channels."
 msgstr "所選權限將套用至這些通路。"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Product options"
 msgstr "商品選項"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "New Tax Rate"
 msgstr "新增稅率"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign an existing option group or create a new one"
 msgstr "指派現有選項群組或建立新的選項群組"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "New role"
 msgstr "新增角色"
 
-#: src/lib/components/shared/customer-address-form.tsx:131
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Apartment, suite, etc."
 msgstr "公寓、套房等"
 
-#: src/lib/components/data-input/relation-selector.tsx:458
-#: src/lib/components/shared/facet-value-selector.tsx:214
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more items"
 msgstr "沒有更多項目"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit link"
 msgstr "編輯連結"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Add at least one item to the order"
 msgstr "請至少新增一件商品到訂單"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Add products to create a test order"
 msgstr "新增商品以建立測試訂單"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create address"
 msgstr "建立地址失敗"
 
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
-#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx
 msgid "Toggle all"
 msgstr "全部切換"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Edit JSON value"
 msgstr "編輯 JSON 值"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using external authentication strategy: {strategy}"
 msgstr "使用外部驗證策略：{strategy}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:230
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select a reason..."
 msgstr "選擇原因..."
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 5"
 msgstr "標題 5"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Failed to add payment"
 msgstr "新增付款失敗"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:746
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Updated"
 msgstr "已更新"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Failed to update global settings"
 msgstr "更新全域設定失敗"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Successfully fulfilled order"
 msgstr "已成功履行訂單"
 
 #. placeholder {0}: selection.length
-#: src/app/common/delete-bulk-action.tsx:141
+#: src/app/common/delete-bulk-action.tsx
 msgid "Are you sure you want to delete {0} {entityName}?"
 msgstr "確定要刪除 {0} {entityName} 嗎？"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global out of stock threshold"
 msgstr "全域缺貨臨界值"
 
-#: src/lib/components/layout/channel-switcher.tsx:194
-#: src/lib/components/layout/manage-languages-dialog.tsx:241
+#: src/lib/components/layout/channel-switcher.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Manage Languages"
 msgstr "管理語言"
 
 #. placeholder {0}: progress.completed
 #. placeholder {1}: progress.total
-#: src/app/common/duplicate-bulk-action.tsx:127
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Duplicating... ({0}/{1})"
 msgstr "正在複製... ({0}/{1})"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Deleted successfully"
 msgstr "成功刪除"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 #~ msgid "Remove from current channel"
 #~ msgstr "從目前通路中移除"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Deleted {selectionLength} assets"
 msgstr "已刪除 {selectionLength} 個資源"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully updated tax rate"
 msgstr "已成功更新稅率"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Enter custom reason..."
 msgstr "輸入自訂原因..."
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:751
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Type"
 msgstr "類型"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:266
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The default currency is chosen from this list."
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:679
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}"
 msgstr "選取 {0}"
 
 #. placeholder {0}: selectedItems.length
-#: src/lib/components/data-input/relation-selector.tsx:408
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Add more ({0} selected)"
 msgstr ""
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:67
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "View values"
 msgstr "檢視值"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete row"
 msgstr "刪除列"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Conditions"
 msgstr "條件"
 
-#: src/lib/components/layout/channel-switcher.tsx:99
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "current channel"
 msgid "Current"
 msgstr "目前"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "No fulfillments"
 msgstr "無履行"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:116
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location: {messages}} other {Failed to delete {2} stock locations: {messages}}}"
 msgstr "{0, plural, other {無法刪除 {2} 個庫存地點：{messages}}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:339
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
 msgstr "啟用後，商品目錄中輸入的價格將包含預設稅務區域的稅金。"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create variants for your product"
 #~ msgstr "為您的商品建立變體"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:331
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order completed"
 msgstr "草稿訂單已完成"
 
 #. placeholder {0}: currentInterval?.label
-#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Auto refresh: {0}"
 msgstr "自動重新整理：{0}"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} job"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:43
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Health checks"
 #~ msgstr "健康檢查"
 
-#: src/app/common/delete-bulk-action.tsx:108
+#: src/app/common/delete-bulk-action.tsx
 msgid "Deleted {deleted} {entityName}"
 msgstr "已刪除 {deleted} {entityName}"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:32
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "File Size"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:13
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Healthchecks"
 #~ msgstr "健康檢查"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "Sellers"
 msgstr "賣家"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Options"
 msgstr "選項"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{fulfilled, plural, one {Successfully cancelled {fulfilled} job} other {Successfully cancelled {fulfilled} jobs}}"
 msgstr "{fulfilled, plural, other {已成功取消 {fulfilled} 個任務}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:244
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Seller"
 msgstr "賣家"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "SKU:"
 msgstr "SKU:"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment"
 msgstr "新增付款"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
 msgstr "透過模擬訂單測試此配送方式，以查看其是否適用以及配送成本是多少。"
 
-#: src/lib/components/layout/nav-user.tsx:100
+#: src/lib/components/layout/nav-user.tsx
 #~ msgid "Explore Enterprise Edition"
 #~ msgstr "探索企業版"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "Stock Locations"
 msgstr "庫存位置"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Fulfillment handler"
 msgstr "履行處理器"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:251
-#: src/app/routes/_authenticated/_orders/orders.tsx:21
-#: src/app/routes/_authenticated/_orders/orders.tsx:37
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Orders"
 msgstr "訂單"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Select roles"
 msgstr "選擇角色"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully created role"
 msgstr "已成功建立角色"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:434
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to delete this variant?"
 msgstr "確定要刪除此變體嗎？"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:67
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "All resources are up and running"
 #~ msgstr "所有資源正在執行"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to create administrator"
 msgstr "建立管理員失敗"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "No"
 msgstr "否"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Successfully updated product variant"
 msgstr "已成功更新商品變體"
 
-#: src/app/common/delete-bulk-action.tsx:114
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}: {allErrors}"
 msgstr "刪除 {failed} {entityName} 失敗：{allErrors}"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully updated product"
 msgstr "已成功更新商品"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to update country"
 msgstr "更新國家失敗"
 
-#: src/lib/components/shared/facet-value-selector.tsx:147
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Type at least 2 characters to search..."
 msgstr "至少輸入 2 個字元進行搜尋..."
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:122
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:186
-#: src/app/routes/_authenticated/_profile/profile.tsx:109
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Last name"
 msgstr "姓氏"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link title"
 msgstr "連結標題"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully updated customer group"
 msgstr "已成功更新客戶群組"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Custom fields changed"
 msgstr "自訂欄位已變更"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully created stock location"
 msgstr "已成功建立庫存位置"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:55
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:73
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:197
-#: src/lib/components/shared/asset/asset-preview.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Unknown error"
 msgstr "未知錯誤"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total cannot be negative"
 msgstr "退款總額不能為負數"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "View details"
 msgstr "檢視詳細資料"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Select a channel to assign {0} {entityType} to"
 #~ msgstr "選取要將 {0} {entityType} 指派到的通路"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully created customer"
 msgstr "已成功建立客戶"
 
-#: src/lib/components/date-range-picker.tsx:39
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 7 days"
 msgstr "過去7天"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to create channel"
 msgstr "建立通路失敗"
 
-#: src/lib/components/layout/dev-mode-indicator.tsx:14
-#: src/lib/components/layout/nav-user.tsx:144
+#: src/lib/components/layout/dev-mode-indicator.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Dev Mode"
 msgstr "開發人員模式"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:88
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "New Role"
 msgstr "新增角色"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Failed to delete assets: {message}"
 msgstr "刪除資源失敗：{message}"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Return to stock"
 msgstr "退回庫存"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:39
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Visibility"
 msgstr "可見性"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:281
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product variants"
 msgstr "產品變體"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "New customer group"
 msgstr "新增客戶群組"
 
 #. placeholder {0}: searchValue.trim()
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Create \"{0}\""
 msgstr "建立「{0}」"
 
-#: src/lib/components/data-table/views-sheet.tsx:238
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Rename"
 msgstr "重新命名"
 
-#: src/lib/components/layout/language-dialog.tsx:52
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Choose your preferred display language and locale settings"
 msgstr "選擇您偏好的顯示語言和地區設定"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:89
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "← Back"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Successfully removed {successCount} option groups from channel"
 msgstr "已成功從頻道中移除 {successCount} 個選項群組"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is not eligible for this order"
 msgstr "配送方式不適用於此訂單"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to update address"
 msgstr "更新地址失敗"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address deleted successfully"
 msgstr "地址已成功刪除"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax rate"
 msgstr "稅率"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{fulfilled, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft isn't ready to be completed"
 msgstr "訂單草稿尚未準備就緒"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "New collection"
 msgstr "新增集合"
 
-#: src/app/routes/_authenticated/index.tsx:184
+#: src/app/routes/_authenticated/index.tsx
 msgid "Insights"
 msgstr "洞察"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Run"
 msgstr "執行"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to update tax rate"
 msgstr "更新稅率失敗"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "This is the contents of the <0>{collectionName}</0> collection."
 msgstr "這是 <0>{collectionName}</0> 集合的內容。"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "private"
 msgstr "私人"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully created product option"
 msgstr "成功建立產品選項"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Parent product"
 msgstr "父級產品"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
-#: src/lib/components/shared/customer-address-form.tsx:141
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "City"
 msgstr "城市"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Administrators"
 msgstr "管理員"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Gross price: <0/>"
 msgstr "總價：<0/>"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:82
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to next page"
 msgstr "前往下一頁"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Remove link"
 msgstr "移除連結"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "This field is readonly"
 msgstr "此欄位為唯讀"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
 msgstr "訂單數量"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:159
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must first select an available currency to set a default currency"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Successfully updated order"
 msgstr "已成功更新訂單"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Inherit filters"
 msgstr "繼承篩選器"
 
-#: src/lib/components/data-table/views-sheet.tsx:130
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage global saved views that are visible to all users"
 msgstr "管理對所有使用者可見的全域儲存檢視"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Search payment methods..."
 msgstr "搜尋付款方式..."
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:257
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address unset for order"
 msgstr "訂單已取消配送地址"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create {enabledCount} variants"
 msgstr "建立 {enabledCount} 個變體"
 
 #. placeholder {0}: entry.data.paymentId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Payment #{0} transitioned to {1}"
 msgstr "付款 #{0} 已轉換到 {1}"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Error loading customer history: {0}"
 msgstr "載入客戶歷程時發生錯誤：{0}"
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Successfully removed {selectionLength} {entityType} from channel"
 msgstr "已成功從通路中移除 {selectionLength} {entityType}"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value"
 msgstr "新增選項值"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Global Settings"
 msgstr "全域設定"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is after"
 msgstr "在之後"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Successfully updated product option"
 msgstr "成功更新產品選項"
 
-#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
-#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx
 msgid "Edit facet values"
 msgstr "編輯屬性值"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Adding..."
 msgstr "正在新增..."
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move Collections"
 msgstr "移動集合"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:140
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
-#: src/app/routes/_authenticated/_roles/roles.tsx:18
-#: src/app/routes/_authenticated/_roles/roles.tsx:27
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "Roles"
 msgstr "角色"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:395
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Grid view"
 msgstr "網格檢視"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Failed to delete address"
 msgstr "刪除地址失敗"
 
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
 msgid "No shipping methods available"
 msgstr "無可用配送方式"
 
-#: src/lib/components/data-table/views-sheet.tsx:108
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view converted to personal view successfully"
 msgstr "全域檢視已成功轉換為個人檢視"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment transitioned"
 msgstr "履行已轉換"
 
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
 msgid "Are you sure you want to delete {selectionLength} assets?"
 msgstr "確定要刪除 {selectionLength} 個資源嗎？"
 
-#: src/lib/components/login/login-form.tsx:105
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in"
 msgstr "登入"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:398
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "List view"
 msgstr "清單檢視"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Test Order"
 msgstr "測試訂單"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Select a customer to continue"
 msgstr "選擇客戶以繼續"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully assigned option group"
 msgstr "選項群組指派成功"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Run Test"
 msgstr "執行測試"
 
-#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx
 msgid "Tax rate: {taxRate}%"
 msgstr "稅率：{taxRate}%"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Please add products and complete the shipping address to run the test."
 msgstr "請新增商品並填寫配送地址以執行測試。"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header row"
 msgstr "切換標題列"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:52
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select address"
 msgstr "選取地址"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Payment eligibility checker"
 msgstr "付款資格檢查器"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:321
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default tax zone"
 msgstr "預設稅務區域"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Order draft is ready to be completed"
 msgstr "訂單草稿已準備就緒可以完成"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Metadata"
 msgstr "中繼資料"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping method for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
-#: src/lib/components/data-table/data-table.tsx:378
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Filter..."
 msgstr "篩選..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "New facet value"
 msgstr "新增屬性值"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully updated channel"
 msgstr "已成功更新通路"
 
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show less"
 msgstr "顯示較少"
 
-#: src/lib/components/layout/language-dialog.tsx:130
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Short date"
 msgstr "短日期"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:265
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Available currencies"
 msgstr "可用貨幣"
 
 #. placeholder {0}: selectedIds.size
-#: src/lib/components/data-input/product-multi-selector-input.tsx:473
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Select {0} Items"
 msgstr "選取 {0} 個項目"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Placed At"
 msgstr "下單時間"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
 msgstr "輪換此金鑰將立即使目前的金鑰失效。所有使用該金鑰的整合將停止運作，直到更新為新金鑰。"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "The data that has been passed to the job"
 msgstr "傳遞給工作的資料"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:44
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm navigation"
 msgstr "確認導覽"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link target"
 msgstr "連結目標"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:405
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Complete draft"
 msgstr "完成草稿"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
-#: src/app/routes/_authenticated/_customers/customers.tsx:70
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:328
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
-#: src/lib/components/shared/asset/asset-gallery.tsx:750
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Name"
 msgstr "名稱"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Failed to fulfill order"
 msgstr "履行訂單失敗"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:193
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Total"
 msgstr "總計"
 
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Enter the transaction ID for this refund settlement"
 msgstr "輸入此退款結算的交易 ID"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Your API Key"
 msgstr "您的 API Key"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:389
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Are you sure you want to delete this draft order?"
 msgstr "確定要刪除此草稿訂單嗎？"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Fulfillment created"
 msgstr "履行已建立"
 
 #. placeholder {0}: testResult.length
 #. placeholder {1}: testResult.length !== 1 ? 's' : ''
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Found {0} eligible shipping method{1}"
 msgstr "找到 {0} 個符合條件的配送方式"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:753
-#: src/lib/components/shared/asset/asset-properties.tsx:39
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Dimensions"
 msgstr "尺寸"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Show password"
 msgstr "顯示密碼"
 
 #. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:287
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "(max: {0})"
 msgstr "(最大: {0})"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
-#: src/lib/components/shared/customer-address-form.tsx:111
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Company"
 msgstr "公司"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column after"
 msgstr "在後面新增欄"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
-#: src/lib/components/data-table/use-generated-columns.tsx:253
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Actions"
 msgstr "動作"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Discounts"
 msgstr "折扣"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Enter refund note"
 msgstr "輸入退款備註"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:153
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line removed"
 msgstr "訂單行已移除"
 
-#: src/lib/components/layout/channel-switcher.tsx:158
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Content:"
 msgstr "內容:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Key"
 msgstr "金鑰"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
-#: src/lib/components/shared/navigation-confirmation.tsx:58
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Confirm"
 msgstr "確認"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to complete draft order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to create collection"
 msgstr "建立集合失敗"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:57
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to first page"
 msgstr "前往第一頁"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:220
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Defaults to the default currency."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to create product"
 msgstr "建立商品失敗"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:497
-#: src/lib/components/shared/role-code-label.tsx:8
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Customer"
 msgstr "客戶"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Error loading order history: {0}"
 msgstr "載入訂單歷程時發生錯誤：{0}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:235
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address set for order"
 msgstr "訂單已設定配送地址"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
-#: src/lib/components/shared/asset/asset-preview.tsx:153
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal Point"
 msgstr "焦點"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Single variant, no options"
 msgstr "單一變體，無選項"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select the next state for the order"
 msgstr "選取訂單的下一個狀態"
 
-#: src/lib/components/layout/language-dialog.tsx:80
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Locale"
 msgstr "地區設定"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled Tasks"
 msgstr "排程任務"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Enter transaction ID"
 msgstr "輸入交易 ID"
 
-#: src/lib/components/data-table/refresh-button.tsx:43
+#: src/lib/components/data-table/refresh-button.tsx
 msgid "Refresh data"
 msgstr "重新整理資料"
 
 #. placeholder {0}: entityIds.length
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add or remove facet values for {0} {entityType}"
 msgstr "為 {0} {entityType} 新增或刪除屬性值"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "These are the facet values for the <0>{facetName}</0> facet."
 msgstr "這些是 <0>{facetName}</0> 屬性的屬性值。"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Successfully added payment to order"
 msgstr "已成功向訂單新增付款"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:246
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address set for order"
 msgstr "已為訂單設定帳單地址"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to update zone"
 msgstr "更新區域失敗"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:134
-#: src/app/routes/_authenticated/_profile/profile.tsx:121
-#: src/app/routes/_authenticated/_profile/profile.tsx:138
-#: src/lib/components/login/login-form.tsx:93
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/login/login-form.tsx
 msgid "Password"
 msgstr "密碼"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:391
-#: src/lib/components/data-table/use-generated-columns.tsx:397
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Failed to delete"
 msgstr "刪除失敗"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task will be executed"
 msgstr "將執行排程任務"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "New stock location"
 msgstr "新增庫存位置"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Permissions"
 msgstr "權限"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping address changed"
 msgstr "配送地址已變更"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "No products found"
 msgstr "找不到產品"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row before"
 msgstr "在前面新增列"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Transition to {suggestedState}"
 msgstr "轉換到 {suggestedState}"
 
-#: src/lib/components/date-range-picker.tsx:71
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This month"
 msgstr "本月"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to create facet"
 msgstr "建立屬性失敗"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to cancel order items"
 msgstr "取消訂單商品失敗"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Transaction ID"
 msgstr "交易 ID"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Allocated"
 msgstr "已配置"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:318
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add another option group"
 #~ msgstr "新增另一個選項群組"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:310
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set coupon code for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:191
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Select what to do with remaining stock"
 msgstr "請選擇如何處理剩餘庫存"
 
-#: src/lib/components/layout/nav-user.tsx:102
+#: src/lib/components/layout/nav-user.tsx
 msgid "Explore Platform & Cloud"
 msgstr "探索 Platform & Cloud"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 5 seconds"
 msgstr "每 5 秒"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully created collection"
 msgstr "已成功建立集合"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
-#: src/lib/components/layout/language-dialog.tsx:136
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Price"
 msgstr "價格"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:383
-#: src/app/routes/_authenticated/_orders/orders.tsx:115
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Draft order"
 msgstr "草稿訂單"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:281
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Scope"
 msgstr "範圍"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Add condition"
 msgstr "新增條件"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Shipping method is eligible for this order"
 msgstr "配送方式適用於此訂單"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:195
+#: src/lib/framework/defaults.ts
 msgid "Administrators"
 msgstr "管理員"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Removed from group"
 msgstr "已從群組中移除"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Width"
 msgstr "寬度"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund required"
 msgstr "不需要付款或退款"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Download as .env file"
 msgstr "下載為 .env 檔案"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "When enabled, a promotion is available in the shop"
 msgstr "啟用後，促銷在商店中可用"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
 msgstr "追蹤後，商品變體庫存水準將在售出時自動調整。此設定可由各個商品變體覆寫。"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:282
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping method set for order"
 msgstr "訂單已設定配送方式"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to update promotion"
 msgstr "更新促銷失敗"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:368
-#: src/lib/components/shared/asset/asset-gallery.tsx:380
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Images"
 msgstr "圖片"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:158
+#: src/lib/framework/defaults.ts
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Search {name}..."
 msgstr "搜尋 {name}..."
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Edit asset"
 msgstr "編輯資源"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Cancel payment"
 msgstr "取消付款"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:77
-#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Job Queue"
 msgstr "工作佇列"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:66
+#: src/lib/framework/defaults.ts
 msgid "Assets"
 msgstr "資源"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:192
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Email address"
 msgstr "電子郵件地址"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:321
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove coupon code from order: {0}"
 msgstr ""
 
-#: src/lib/components/data-input/slug-input.tsx:266
-#: src/lib/components/data-input/slug-input.tsx:267
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Regenerate slug from source field"
 msgstr "從來源欄位重新產生 slug"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Inherit from global settings"
 msgstr "從全域設定繼承"
 
-#: src/lib/components/data-input/relation-selector.tsx:430
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
-#: src/lib/components/shared/facet-value-selector.tsx:163
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No results found"
 msgstr "找不到結果"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:55
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Current status"
 #~ msgstr "目前狀態"
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Set a shipping address and select a shipping method"
 msgstr "設定收貨地址並選擇配送方式"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Off"
 msgstr "關閉"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Settings Store"
 msgstr "設定商店"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Queue"
 msgstr "佇列"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "New tax rate"
 msgstr "新增稅率"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment transitioned"
 msgstr "付款已轉換"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Remaining:"
 msgstr "剩餘："
 
-#: src/app/common/duplicate-entity-dialog.tsx:104
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
 msgstr "找不到代碼為「{duplicatorCode}」的 {entityName} 複製器"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:337
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Prices include tax for default tax zone"
 msgstr "價格包含預設稅務區域的稅金"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:130
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:131
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:134
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:135
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "This field is required"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Total refund:"
 msgstr "退款總計："
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:180
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View job result"
 msgstr "檢視工作結果"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test your shipping methods by simulating a new order."
 msgstr "透過模擬新訂單來測試您的配送方式。"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:433
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items selected"
 msgstr "未選取項目"
 
 #. placeholder {0}: selected.length
-#: src/lib/components/shared/asset/asset-gallery.tsx:476
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid ", {0} selected"
 msgstr "，已選取 {0} 項"
 
-#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/country-selector.tsx
 msgid "No countries found"
 msgstr "找不到國家"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Successfully created variants"
 msgstr "變體建立成功"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Generate slug automatically"
 msgstr "自動產生 slug"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Surcharge"
 msgstr "附加費用"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "Payment Methods"
 msgstr "付款方式"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock"
 msgstr "庫存"
 
-#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/customer-selector.tsx
 msgid "No customers found"
 msgstr "找不到客戶"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Use global out-of-stock threshold"
 msgstr "使用全域缺貨臨界值"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:129
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "New product option group"
 #~ msgstr "新增商品選項群組"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment state updated successfully"
 msgstr "付款狀態已成功更新"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Create new"
 msgstr "新建"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:254
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund total"
 msgstr "退款總額"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address deleted"
 msgstr "地址已刪除"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Only roles assigned to your account are available."
 msgstr "僅您帳戶已指派的角色可用。"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:65
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
 msgstr ""
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:499
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{buttonText}"
 msgstr "{buttonText}"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:113
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Item added to order"
 msgstr "項目已新增至訂單"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:146
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Edit focal point"
 msgstr "編輯焦點"
 
-#: src/lib/components/shared/seller-selector.tsx:92
+#: src/lib/components/shared/seller-selector.tsx
 #~ msgid "No sellers found"
 #~ msgstr "找不到賣家"
 
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:34
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Asset"
 msgstr "資源"
 
-#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx
 msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
 msgstr "{productCount, plural, one {此選項群組被另一個產品使用。變更也會影響該產品。} other {此選項群組在 # 個產品中共用。變更將影響所有產品。}}"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "My Saved Views"
 msgstr "我的儲存檢視"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:66
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "New channel"
 msgstr "新增通路"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to create seller"
 msgstr "建立賣家失敗"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:88
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Configure duplication settings for {0}s"
 msgstr "設定{0}的複製設定"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "No variants match the current filter."
 msgstr "沒有符合目前篩選條件的變體。"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:207
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Addresses"
 msgstr "地址"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:136
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add a new option value to the {groupName} option group"
 msgstr "向 {groupName} 選項群組新增選項值"
 
 #. placeholder {0}: entry.data.modificationId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Order modification #{0}"
 msgstr "訂單修改 #{0}"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add column before"
 msgstr "在前面新增欄"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:306
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Channel Languages"
 msgstr "通路語言"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to create option group"
 msgstr "建立選項群組失敗"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "True"
 msgstr "是"
 
-#: src/lib/components/shared/customer-selector.tsx:77
+#: src/lib/components/shared/customer-selector.tsx
 msgid "Select customer"
 msgstr "選取客戶"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order transitioned"
 msgstr "訂單已轉換"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:254
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "This product has existing variants but no option groups defined. You need to add option groups before creating new variants."
 #~ msgstr "此商品有現有變體，但未定義選項群組。您需要在建立新變體之前新增選項群組。"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is before"
 msgstr "在之前"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:388
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft order"
 msgstr "刪除草稿訂單"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:24
+#: src/lib/framework/defaults.ts
 msgid "Catalog"
 msgstr "目錄"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "New payment method"
 msgstr "新增付款方式"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully updated promotion"
 msgstr "已成功更新促銷"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{rejected, plural, one {Failed to cancel {rejected} job} other {Failed to cancel {rejected} jobs}}"
 msgstr "{rejected, plural, other {取消 {rejected} 個任務失敗}}"
 
-#: src/lib/components/shared/channel-selector.tsx:47
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Select a channel"
 msgstr "選取一個通路"
 
-#: src/lib/components/layout/language-dialog.tsx:58
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Display language"
 msgstr "顯示語言"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Fulfillment details"
 msgstr "履行詳細資料"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:89
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:202
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Discard remaining stock"
 msgstr "捨棄剩餘庫存"
 
-#: src/lib/components/data-input/datetime-input.tsx:181
+#: src/lib/components/data-input/datetime-input.tsx
 msgid "Now"
 msgstr "現在"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:181
+#: src/lib/framework/defaults.ts
 msgid "Channels"
 msgstr "通路"
 
-#: src/lib/components/data-table/views-sheet.tsx:118
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View converted to global successfully"
 msgstr "檢視已成功轉換為全域"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:30
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "before"
 msgstr "之前"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set customer for order: {0}"
 msgstr ""
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:752
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Size"
 msgstr "大小"
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/shared/translatable-form-field.tsx:68
+#: src/lib/components/shared/translatable-form-field.tsx
 msgid "No translation found for {0}"
 msgstr "找不到 {0} 的翻譯"
 
-#: src/app/routes/_authenticated/_customers/customers.tsx:92
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "New Customer"
 msgstr "新增客戶"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Latest Orders"
 msgstr "最新訂單"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:427
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "+ {leftOver} more"
 msgstr "+ {leftOver} 個更多"
 
-#: src/lib/components/shared/customer-address-form.tsx:241
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default billing address"
 msgstr "用作預設帳單地址"
 
-#: src/app/common/delete-bulk-action.tsx:139
-#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:337
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:217
-#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx:28
-#: src/lib/components/data-table/use-generated-columns.tsx:407
-#: src/lib/components/data-table/use-generated-columns.tsx:437
-#: src/lib/components/data-table/views-sheet.tsx:270
-#: src/lib/components/data-table/views-sheet.tsx:296
+#: src/app/common/delete-bulk-action.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/stock-location-bulk-actions.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete"
 msgstr "刪除"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Disable"
 msgstr "停用"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:59
+#: src/lib/framework/defaults.ts
 msgid "Collections"
 msgstr "集合"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add variant"
 msgstr "新增變體"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Failed to create country"
 msgstr "建立國家失敗"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:237
+#: src/lib/framework/defaults.ts
 msgid "Countries"
 msgstr "國家"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:124
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:209
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Failed to create product options"
 #~ msgstr "建立商品選項失敗"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename view"
 msgstr "重新命名檢視失敗"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Available"
 msgstr "可用"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Normal"
 msgstr "正常"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Filters"
 msgstr "篩選器"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:105
+#: src/lib/framework/defaults.ts
 msgid "Customer Groups"
 msgstr "客戶群組"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:91
-#: src/lib/framework/defaults.ts:98
+#: src/lib/framework/defaults.ts
+#: src/lib/framework/defaults.ts
 msgid "Customers"
 msgstr "客戶"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-calculator-selector.tsx
 msgid "Select Shipping Calculator"
 msgstr ""
 
-#: src/lib/components/layout/language-dialog.tsx:103
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Sample Formatting"
 msgstr "範例格式"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New option"
 msgstr "新增選項"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Usage limit"
 msgstr "使用限制"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:267
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Loading global settings..."
 msgstr "正在載入全域設定..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Address updated successfully"
 msgstr "地址已成功更新"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
-#: src/lib/components/shared/asset/asset-gallery.tsx:754
-#: src/lib/framework/layout-engine/page-layout.tsx:733
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Created"
 msgstr "已建立"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:63
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Loading addresses..."
 msgstr "正在載入地址..."
 
 #. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a target collection to move {0} to."
 msgstr "選取要將 {0} 移動到的目標集合。"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:272
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer details updated"
 msgstr "客戶詳細資料已更新"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "not in"
 msgstr "不在"
 
-#: src/lib/components/data-table/views-sheet.tsx:227
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply"
 msgstr "套用"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "New product option"
 msgstr "新增商品選項"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:94
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to last page"
 msgstr "前往最後一頁"
 
-#: src/app/common/duplicate-entity-dialog.tsx:113
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:363
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:48
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:210
-#: src/app/routes/_authenticated/_system/settings-store.tsx:140
-#: src/lib/components/data-input/product-multi-selector-input.tsx:470
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
-#: src/lib/components/data-table/use-generated-columns.tsx:423
-#: src/lib/components/data-table/views-sheet.tsx:217
-#: src/lib/components/data-table/views-sheet.tsx:293
-#: src/lib/components/layout/manage-languages-dialog.tsx:379
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:145
-#: src/lib/components/shared/confirmation-dialog.tsx:42
-#: src/lib/components/shared/customer-address-form.tsx:253
-#: src/lib/components/shared/navigation-confirmation.tsx:55
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/use-generated-columns.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
+#: src/lib/components/shared/customer-address-form.tsx
+#: src/lib/components/shared/navigation-confirmation.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Cancel"
 msgstr "取消"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:97
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order custom fields: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Successfully created product variant"
 msgstr "已成功建立商品變體"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund from this method"
 msgstr "從此方式退款"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
-#: src/lib/components/shared/customer-address-form.tsx:163
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Postal Code"
 msgstr "郵遞區號"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:249
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 #~ msgid "Add product options first"
 #~ msgstr "請先新增商品選項"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "New tax category"
 msgstr "新增稅務類別"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:311
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Add option"
 #~ msgstr "新增選項"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Partial refund completed"
 msgstr "部分退款已完成"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:492
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Set custom fields"
 msgstr "設定自訂欄位"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
-#: src/app/routes/_authenticated/_collections/collections.tsx:51
-#: src/app/routes/_authenticated/_collections/collections.tsx:339
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collections"
 msgstr "集合"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-eligibility-checker-selector.tsx
 msgid "Select Shipping Eligibility Checker"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:433
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Delete variant"
 msgstr "刪除變體"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "No modifications made"
 msgstr "未進行修改"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:329
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default shipping zone"
 msgstr "預設配送區域"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Reason:"
 msgstr "原因:"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:510
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Shipping address"
 msgstr "配送地址"
 
 #. placeholder {0}: getTranslatedFulfillmentState(state)
 #. placeholder {0}: getTranslatedOrderState(state)
 #. placeholder {0}: getTranslatedPaymentState(state)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Transition to {0}"
 msgstr "轉換到 {0}"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "Tax Categories"
 msgstr "稅務類別"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Private collections are not visible in the shop"
 msgstr "私人集合在商店中不可見"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:222
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "When enabled, a product is available in the shop"
 msgstr "啟用後，商品在商店中可用"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Scheduled task could not be executed"
 msgstr "無法執行排程任務"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "Customer Groups"
 msgstr "客戶群組"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:155
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Disabled"
 msgstr "已停用"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "New promotion"
 msgstr "新增促銷"
 
-#: src/lib/components/shared/customer-address-form.tsx:220
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Shipping Address"
 msgstr "預設配送地址"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:65
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "{operator}"
 msgstr "{operator}"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Refund required"
 msgstr "需要退款"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfill order"
 msgstr "履行訂單"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:316
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view channel settings"
 msgstr "您沒有檢視通路設定的權限"
 
-#: src/lib/components/date-range-picker.tsx:55
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last 30 days"
 msgstr "過去30天"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "No facet values"
 msgstr "無屬性值"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "A reason for the refund is required"
 msgstr "需要提供退款原因"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:187
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Could not remove option group"
 msgstr "無法移除選項群組"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to update tax category"
 msgstr "更新稅務類別失敗"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund settled successfully"
 msgstr "退款已成功完成"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_profile/profile.tsx:93
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
-#: src/lib/framework/page/detail-page.tsx:185
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/lib/framework/page/detail-page.tsx
 msgid "Update"
 msgstr "更新"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 2"
 msgstr "標題 2"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order placed"
 msgstr "訂單已下單"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:72
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Successfully updated profile"
 msgstr "已成功更新個人資料"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
-#: src/lib/components/data-table/data-table-filter-badge.tsx:111
+#: src/i18n/common-strings.ts
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 #~ msgid "end"
 #~ msgstr "結束"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment method"
 msgstr "付款方式"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
-#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx
 msgid "Edit"
 msgstr "編輯"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:180
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant updated successfully"
 msgstr "變體已成功更新"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Filter by collection name"
 msgstr "按集合名稱篩選"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Note added"
 msgstr "備註已新增"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Select quantities to fulfill and configure the fulfillment handler"
 msgstr "選取要履行的數量並設定履行處理器"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:268
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address unset for order"
 msgstr "已從訂單移除帳單地址"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Starts at"
 msgstr "開始於"
 
-#: src/app/common/duplicate-bulk-action.tsx:131
-#: src/app/common/duplicate-entity-dialog.tsx:116
-#: src/lib/components/data-table/views-sheet.tsx:244
+#: src/app/common/duplicate-bulk-action.tsx
+#: src/app/common/duplicate-entity-dialog.tsx
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Duplicate"
 msgstr "複製"
 
-#: src/lib/components/data-table/data-table.tsx:588
-#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/data-table/data-table.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "No results"
 msgstr "無結果"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:95
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Column settings"
 msgstr "欄設定"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:137
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{count, plural, one {Failed to delete {count} stock location} other {Failed to delete {count} stock locations}}"
 msgstr "{count, plural, other {無法刪除 {count} 個庫存地點}}"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:224
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Code"
 msgstr "代碼"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to remove option groups"
 msgstr "移除選項群組失敗"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order delivered"
 msgstr "訂單已送達"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:47
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Transfer to {name}"
 msgstr "轉移至 {name}"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:174
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Remaining stock"
 msgstr "剩餘庫存"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Remove from zone"
 msgstr "從區域移除"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:341
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select from globally available languages for this channel"
 msgstr "從此通路的全域可用語言中選取"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Are you sure you want to delete this address?"
 msgstr "確定要刪除此地址嗎？"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Failed to assign option group"
 msgstr "指派選項群組失敗"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Failed to update asset"
 msgstr "更新資源失敗"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Successfully updated stock location"
 msgstr "已成功更新庫存位置"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "Confirm Action"
 msgstr "確認動作"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully updated country"
 msgstr "已成功更新國家"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:52
+#: src/lib/framework/defaults.ts
 msgid "Facets"
 msgstr "屬性"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:107
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to add note"
 msgstr "新增備註失敗"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:148
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to delete note"
 msgstr "刪除備註失敗"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:41
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Failed to extend query document"
 msgstr "擴充查詢文件失敗"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:128
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Failed to update note"
 msgstr "更新備註失敗"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:206
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund shipping"
 msgstr "退還運費"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:289
-#: src/app/routes/_authenticated/_system/settings-store.tsx:293
-#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Readonly"
 msgstr "唯讀"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate global view"
 msgstr "複製全域檢視失敗"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Showing {shown} of {total} • {selected} selected"
 msgstr "顯示 {total} 個中的 {shown} 個 • 已選取 {selected} 個"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test Shipping Method"
 msgstr "測試配送方式"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:327
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Facet Values"
 msgstr "屬性值"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "Successfully updated asset"
 msgstr "已成功更新資源"
 
-#: src/lib/components/layout/nav-user.tsx:118
+#: src/lib/components/layout/nav-user.tsx
 msgid "Theme"
 msgstr "佈景主題"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:156
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select at least one available currency"
 msgstr ""
 
 #. placeholder {0}: value.totalItems
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "{0} customers"
 msgstr "{0} 位客戶"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/lib/components/shared/language-selector.tsx:52
+#: src/lib/components/shared/language-selector.tsx
 msgid "Select a language"
 msgstr "選取一種語言"
 
-#: src/lib/components/layout/nav-user.tsx:164
+#: src/lib/components/layout/nav-user.tsx
 msgid "Log out"
 msgstr "登出"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:50
+#: src/i18n/common-strings.ts
 msgid "fieldName.attempts"
 msgstr "嘗試次數"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:51
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableCurrencyCodes"
 msgstr "可用貨幣代碼"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:52
+#: src/i18n/common-strings.ts
 msgid "fieldName.availableLanguageCodes"
 msgstr "可用語言代碼"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:53
+#: src/i18n/common-strings.ts
 msgid "fieldName.breadcrumbs"
 msgstr "麵包屑導覽"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:54
+#: src/i18n/common-strings.ts
 msgid "fieldName.category"
 msgstr "類別"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:55
+#: src/i18n/common-strings.ts
 msgid "fieldName.channels"
 msgstr "通路"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:56
+#: src/i18n/common-strings.ts
 msgid "fieldName.children"
 msgstr "子項目"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:57
+#: src/i18n/common-strings.ts
 msgid "fieldName.code"
 msgstr "代碼"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:58
+#: src/i18n/common-strings.ts
 msgid "fieldName.couponCode"
 msgstr "優惠券代碼"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:59
+#: src/i18n/common-strings.ts
 msgid "fieldName.createdAt"
 msgstr "建立時間"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:60
+#: src/i18n/common-strings.ts
 msgid "fieldName.currencyCode"
 msgstr "貨幣代碼"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:61
+#: src/i18n/common-strings.ts
 msgid "fieldName.customer"
 msgstr "客戶"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:62
+#: src/i18n/common-strings.ts
 msgid "fieldName.customerGroup"
 msgstr "客戶群組"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:63
+#: src/i18n/common-strings.ts
 msgid "fieldName.customers"
 msgstr "客戶"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:64
+#: src/i18n/common-strings.ts
 msgid "fieldName.customFields"
 msgstr "自訂欄位"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:65
+#: src/i18n/common-strings.ts
 msgid "fieldName.data"
 msgstr "資料"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:66
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultCurrencyCode"
 msgstr "預設貨幣代碼"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:67
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultLanguageCode"
 msgstr "預設語言代碼"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:68
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultShippingZone"
 msgstr "預設配送區域"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:69
+#: src/i18n/common-strings.ts
 msgid "fieldName.defaultTaxZone"
 msgstr "預設稅務區域"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:70
+#: src/i18n/common-strings.ts
 msgid "fieldName.description"
 msgstr "描述"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:71
+#: src/i18n/common-strings.ts
 msgid "fieldName.duration"
 msgstr "持續時間"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:72
+#: src/i18n/common-strings.ts
 msgid "fieldName.emailAddress"
 msgstr "電子郵件地址"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:73
+#: src/i18n/common-strings.ts
 msgid "fieldName.enabled"
 msgstr "已啟用"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:74
+#: src/i18n/common-strings.ts
 msgid "fieldName.endsAt"
 msgstr "結束時間"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:75
+#: src/i18n/common-strings.ts
 msgid "fieldName.error"
 msgstr "錯誤"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:76
+#: src/i18n/common-strings.ts
 msgid "fieldName.featuredAsset"
 msgstr "精選資源"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:77
+#: src/i18n/common-strings.ts
 msgid "fieldName.firstName"
 msgstr "名字"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:78
+#: src/i18n/common-strings.ts
 msgid "fieldName.fulfillmentHandlerCode"
 msgstr "履行處理器代碼"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:79
+#: src/i18n/common-strings.ts
 msgid "fieldName.id"
 msgstr "ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:80
+#: src/i18n/common-strings.ts
 msgid "fieldName.isDefault"
 msgstr "預設"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:81
+#: src/i18n/common-strings.ts
 msgid "fieldName.isPrivate"
 msgstr "私人"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:82
+#: src/i18n/common-strings.ts
 msgid "fieldName.isSettled"
 msgstr "已完成"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:83
+#: src/i18n/common-strings.ts
 msgid "fieldName.lastName"
 msgstr "姓氏"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:84
+#: src/i18n/common-strings.ts
 msgid "fieldName.name"
 msgstr "名稱"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:85
+#: src/i18n/common-strings.ts
 msgid "fieldName.orderPlacedAt"
 msgstr "訂單下單時間"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:86
+#: src/i18n/common-strings.ts
 msgid "fieldName.parentId"
 msgstr "父項 ID"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:87
+#: src/i18n/common-strings.ts
 msgid "fieldName.perCustomerUsageLimit"
 msgstr "每位客戶使用限制"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:88
+#: src/i18n/common-strings.ts
 msgid "fieldName.permissions"
 msgstr "權限"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:89
+#: src/i18n/common-strings.ts
 msgid "fieldName.position"
 msgstr "位置"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:90
+#: src/i18n/common-strings.ts
 msgid "fieldName.price"
 msgstr "價格"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:92
+#: src/i18n/common-strings.ts
 msgid "fieldName.pricesIncludeTax"
 msgstr "價格含稅"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:91
+#: src/i18n/common-strings.ts
 msgid "fieldName.priceWithTax"
 msgstr "含稅價格"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:93
+#: src/i18n/common-strings.ts
 msgid "fieldName.productVariants"
 msgstr "商品變體"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:94
+#: src/i18n/common-strings.ts
 msgid "fieldName.progress"
 msgstr "進度"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:95
+#: src/i18n/common-strings.ts
 msgid "fieldName.queueName"
 msgstr "佇列名稱"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:96
+#: src/i18n/common-strings.ts
 msgid "fieldName.result"
 msgstr "結果"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:97
+#: src/i18n/common-strings.ts
 msgid "fieldName.retries"
 msgstr "重試次數"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:98
+#: src/i18n/common-strings.ts
 msgid "fieldName.seller"
 msgstr "賣家"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:99
+#: src/i18n/common-strings.ts
 msgid "fieldName.settledAt"
 msgstr "結算時間"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:100
+#: src/i18n/common-strings.ts
 msgid "fieldName.shippingLines"
 msgstr "配送行"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:101
+#: src/i18n/common-strings.ts
 msgid "fieldName.sku"
 msgstr "SKU"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:102
+#: src/i18n/common-strings.ts
 msgid "fieldName.slug"
 msgstr "Slug"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:103
+#: src/i18n/common-strings.ts
 msgid "fieldName.startedAt"
 msgstr "開始時間"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:104
+#: src/i18n/common-strings.ts
 msgid "fieldName.startsAt"
 msgstr "開始時間"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:105
+#: src/i18n/common-strings.ts
 msgid "fieldName.state"
 msgstr "狀態"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:106
+#: src/i18n/common-strings.ts
 msgid "fieldName.stockLevels"
 msgstr "庫存水準"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:107
+#: src/i18n/common-strings.ts
 msgid "fieldName.token"
 msgstr "權杖"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:108
+#: src/i18n/common-strings.ts
 msgid "fieldName.total"
 msgstr "總計"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:109
+#: src/i18n/common-strings.ts
 msgid "fieldName.totalWithTax"
 msgstr "含稅總計"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:110
+#: src/i18n/common-strings.ts
 msgid "fieldName.type"
 msgstr "類型"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:111
+#: src/i18n/common-strings.ts
 msgid "fieldName.updatedAt"
 msgstr "更新時間"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:112
+#: src/i18n/common-strings.ts
 msgid "fieldName.usageLimit"
 msgstr "使用限制"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:113
+#: src/i18n/common-strings.ts
 msgid "fieldName.user"
 msgstr "使用者"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:114
+#: src/i18n/common-strings.ts
 msgid "fieldName.value"
 msgstr "值"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:115
+#: src/i18n/common-strings.ts
 msgid "fieldName.valueList"
 msgstr "值清單"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:116
+#: src/i18n/common-strings.ts
 msgid "fieldName.zone"
 msgstr "區域"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Method"
 msgstr "方法"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Tax summary"
 msgstr "稅金摘要"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
 msgstr "設定所有通路可用的語言。然後，各個通路可以支援這些語言的子集。"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Collections moved successfully"
 msgstr "集合移動成功"
 
-#: src/lib/components/data-input/relation-selector.tsx:411
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Change selection"
 msgstr ""
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Registered"
 msgstr "已註冊"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:239
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Cancel Job"
 msgstr "取消工作"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Ends at"
 msgstr "結束於"
 
 #. placeholder {0}: table.getState().pagination.pageIndex + 1
 #. placeholder {1}: table.getPageCount() || 1
-#: src/lib/components/data-table/data-table-pagination.tsx:43
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Page {0} of {1}"
 msgstr "第 {0} 頁，共 {1} 頁"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Rate"
 msgstr "費率"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:113
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Size, colour, etc."
 msgstr "大小、顏色等"
 
-#: src/lib/components/shared/facet-value-selector.tsx:155
-#: src/lib/components/shared/facet-value-selector.tsx:172
+#: src/lib/components/shared/facet-value-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Browse facets"
 msgstr "瀏覽分面"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Zone"
 msgstr "區域"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:9
-#: src/i18n/common-strings.ts:12
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Cancelled"
 msgstr "已取消"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:7
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Created"
 msgstr "已建立"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:11
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Delivered"
 msgstr "已送達"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:8
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Pending"
 msgstr "待處理"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:10
+#: src/i18n/common-strings.ts
 msgid "fulfillmentState.Shipped"
 msgstr "已出貨"
 
-#: src/lib/components/data-table/save-view-button.tsx:35
+#: src/lib/components/data-table/save-view-button.tsx
 msgid "Save View"
 msgstr "儲存檢視"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "{0} selected"
 msgstr "已選取 {0} 個"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Search option groups..."
 msgstr "搜尋選項群組..."
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Modify order"
 msgstr "修改訂單"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:418
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Selected Items"
 msgstr "已選取項目"
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:50
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "Values"
 msgstr "值"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:172
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Customer set for order"
 msgstr "訂單已設定客戶"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
-#: src/app/routes/_authenticated/_facets/facets.tsx:21
-#: src/app/routes/_authenticated/_facets/facets.tsx:28
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
-#: src/lib/components/shared/facet-value-selector.tsx:222
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/app/routes/_authenticated/_facets/facets.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Facets"
 msgstr "屬性"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:58
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Are you sure you want to remove {count} customer from this group?} other {Are you sure you want to remove {count} customers from this group?}}"
 msgstr "{count, plural, other {您確定要從此群組中移除{count}位客戶嗎？}}"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Stock on Hand"
 msgstr "現有庫存"
 
-#: src/app/routes/_authenticated/_products/products.tsx:35
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild could not be started"
 msgstr "無法開始重建搜尋索引"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Shipping Address"
 msgstr "配送地址"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "New zone"
 msgstr "新增區域"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "New API Key"
 msgstr "新建 API Key"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Delete column"
 msgstr "刪除欄"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assign existing"
 msgstr "指派現有"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:19
-#: src/lib/components/data-table/human-readable-operator.tsx:36
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is null"
 msgstr "為空"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
 msgstr "這些是 <0>{customerGroupName}</0> 客戶群組中的客戶。"
 
-#: src/lib/components/data-table/manage-global-views-button.tsx:18
+#: src/lib/components/data-table/manage-global-views-button.tsx
 msgid "Manage global views"
 msgstr "管理全域檢視"
 
-#: src/lib/components/shared/channel-code-label.tsx:5
+#: src/lib/components/shared/channel-code-label.tsx
 msgid "Default channel"
 msgstr "預設通路"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert a new image with source, title, and dimensions"
 msgstr "插入帶有來源、標題和尺寸的新圖片"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to create facet value"
 msgstr "建立屬性值失敗"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "="
 msgstr "="
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to update product option"
 msgstr "更新產品選項失敗"
 
-#: src/lib/components/login/login-form.tsx:111
+#: src/lib/components/login/login-form.tsx
 #~ msgid "<0>Forgot password?</0><1>Request reset</1>"
 #~ msgstr "<0>忘記密碼？</0><1>請求重設</1>"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Coupon code"
 msgstr "優惠券代碼"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer verified"
 msgstr "客戶已驗證"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:251
+#: src/lib/framework/defaults.ts
 msgid "Global Settings"
 msgstr "全域設定"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule"
 msgstr "排程"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:288
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Cannot move a collection into its own descendant"
 msgstr "無法將集合移動到其自身的子集"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
 msgid "New Tax Category"
 msgstr "新增稅務類別"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:174
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "No stock locations available on current channel"
 #~ msgstr "目前通路無可用庫存位置"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:173
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Successfully created channel"
 msgstr "已成功建立通路"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:100
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Successfully updated customer"
 msgstr "已成功更新客戶"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View data"
 msgstr "檢視資料"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete View"
 msgstr "刪除檢視"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:235
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "為客戶新增地址。"
 
-#: src/lib/components/data-table/global-views-bar.tsx:75
+#: src/lib/components/data-table/global-views-bar.tsx
 msgid "More views"
 msgstr "更多檢視"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit the selected image properties"
 msgstr "編輯所選圖片的屬性"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied view \"{viewName}\""
 msgstr "已套用檢視「{viewName}」"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Successfully removed {successCount} facets from channel"
 msgstr "已成功從通路中移除 {successCount} 個屬性"
 
-#: src/app/routes/_authenticated/_products/products.tsx:117
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "New Product"
 msgstr "新增商品"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
 msgid "New asset"
 msgstr "新增資源"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Recalculate shipping"
 msgstr "重新計算運費"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:328
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Select which options should apply to the existing variant \"{0}\""
 #~ msgstr "選取應套用至現有變體「{0}」的選項"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
-#: src/app/routes/_authenticated/_assets/assets.tsx:17
-#: src/app/routes/_authenticated/_assets/assets.tsx:40
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:360
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_assets/assets.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Assets"
 msgstr "資源"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:300
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "這將移除此產品的所有選項群組並返回變體設定選擇。"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:532
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Billing address"
 msgstr "帳單地址"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Add facet value"
 msgstr "新增屬性值"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Please select a target collection"
 msgstr "請選取目標集合"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Review the changes before applying them to the order."
 msgstr "在將變更套用到訂單之前，請先檢閱變更。"
 
-#: src/lib/components/shared/role-selector.tsx:52
+#: src/lib/components/shared/role-selector.tsx
 msgid "Select a role"
 msgstr "選取一個角色"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order cancelled"
 msgstr "訂單已取消"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Discount"
 msgstr "折扣"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:367
-#: src/lib/components/shared/asset/asset-gallery.tsx:379
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "All types"
 msgstr "所有類型"
 
 #. placeholder {0}: entityIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:121
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select channels to assign {0} {entityType} to"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx
 msgid "Only draft orders can be completed"
 msgstr "只有草稿訂單可以完成"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:167
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Failed to update product"
 msgstr "更新商品失敗"
 
-#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx:26
+#: src/app/routes/_authenticated/_collections/components/collection-filters-selector.tsx
 msgid "Add collection filter"
 msgstr ""
 
 #. placeholder {0}: adjustedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adjusting {0} lines"
 msgstr "正在調整 {0} 行"
 
-#: src/lib/components/shared/facet-value-selector.tsx:118
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Add facet values"
 msgstr "新增屬性值"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:32
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "after"
 msgstr "之後"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Channel"
 msgstr "通路"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 #~ msgid "Healthchecks"
 #~ msgstr "健康檢查"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Amount"
 msgstr "金額"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
-#: src/lib/components/shared/customer-address-form.tsx:201
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Phone Number"
 msgstr "電話號碼"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:63
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:156
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "New customer"
 msgstr "新增客戶"
 
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Image"
 msgstr "圖片"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully created administrator"
 msgstr "成功建立管理員"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:308
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product Options"
 msgstr "商品選項"
 
-#: src/lib/components/shared/country-selector.tsx:72
+#: src/lib/components/shared/country-selector.tsx
 msgid "Select country"
 msgstr "選取國家"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Creating..."
 msgstr "正在建立..."
 
-#: src/lib/components/data-table/views-sheet.tsx:168
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
 msgstr "確定要刪除此全域檢視嗎？此動作無法復原，將影響所有使用者。"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:37
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove option group"
 msgstr "強制移除選項群組"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:141
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Added"
 msgstr "已新增"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:254
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer history"
 msgstr "客戶歷程"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
 msgstr "已成功為 {entityIdsLength} {entityType} 更新屬性值"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to remove customer from group"
 msgstr "從群組中移除客戶失敗"
 
-#: src/lib/components/layout/nav-user.tsx:135
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "System"
 msgstr "系統"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Per customer usage limit"
 msgstr "每位客戶使用限制"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Billing address changed"
 msgstr "帳單地址已變更"
 
-#: src/lib/components/data-input/select-with-options.tsx:107
+#: src/lib/components/data-input/select-with-options.tsx
 msgid "Select an option"
 msgstr "選取一個選項"
 
-#: src/lib/components/data-table/views-sheet.tsx:251
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Copy to Personal"
 msgstr "複製到個人"
 
 #. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund total exceeds maximum refundable amount of {0}"
 msgstr "退款總額超過最大可退款金額 {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:163
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Delete Global View"
 msgstr "刪除全域檢視"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:106
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:163
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Create"
 msgstr "建立"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 30 seconds"
 msgstr "每 30 秒"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "New country"
 msgstr "新增國家"
 
 #. placeholder {0}: entry.data.from
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "From {0} to {1}"
 msgstr "從 {0} 到 {1}"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to create customer"
 msgstr "建立客戶失敗"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:123
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Focal point updated"
 msgstr "焦點已更新"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option values"
 msgstr "選項值"
 
-#: src/lib/components/shared/customer-address-form.tsx:238
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Default Billing Address"
 msgstr "預設帳單地址"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No customer"
 msgstr "無客戶"
 
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Failed to remove countries from zone"
 msgstr "從區域移除國家/地區失敗"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Failed to create promotion"
 msgstr "建立促銷失敗"
 
-#: src/lib/components/date-range-picker.tsx:23
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Today"
 msgstr "今天"
 
-#: src/lib/components/date-range-picker.tsx:31
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Yesterday"
 msgstr "昨天"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:288
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option name"
 #~ msgstr "選項名稱"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Are you sure you want to remove {0} {1} from this zone?"
 msgstr "確定要從此區域移除 {0} {1} 嗎？"
 
 #. placeholder {0}: addedSurcharges.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} surcharge(s)"
 msgstr "正在新增 {0} 項附加費"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Link href"
 msgstr "連結 href"
 
-#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+#: src/lib/utils/get-locale-fallback-placeholder.ts
 msgid "Fallback: {value}"
 msgstr "備援值: {value}"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order history"
 msgstr "訂單歷程"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Override"
 msgstr "覆蓋"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Transaction ID is required"
 msgstr "交易 ID 為必填欄位"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:62
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "matches regex"
 msgstr "符合正規表示式"
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view renamed successfully"
 msgstr "全域檢視已成功重新命名"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "No tags selected"
 msgstr "未選取標籤"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
 msgid "Back"
 msgstr "返回"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 #~ msgid "Select at least one currency"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:63
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View renamed successfully"
 msgstr "檢視已成功重新命名"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:94
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Apply filter"
 msgstr "套用篩選器"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Result"
 msgstr "上次結果"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Added to group"
 msgstr "已新增至群組"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:16
+#: src/lib/framework/defaults.ts
 msgid "Insights"
 msgstr "洞察"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:158
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create Variants"
 #~ msgstr "建立變體"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Testing shipping method..."
 msgstr "正在測試配送方式..."
 
-#: src/lib/components/layout/nav-user.tsx:131
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Dark"
 msgstr "深色"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test Results"
 msgstr "測試結果"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:137
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Add customer"
 msgstr "新增客戶"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Save Changes"
 msgstr "儲存變更"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address updated"
 msgstr "地址已更新"
 
 #. placeholder {0}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
 msgstr "退款處理成功"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:72
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select value"
 msgstr ""
 
 #. placeholder {0}: action.label
 #. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
 #. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
-#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
-#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
-#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
-#: src/lib/components/data-input/product-multi-selector-input.tsx:377
-#: src/lib/components/data-input/product-multi-selector-input.tsx:380
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "{0}"
 msgstr "{0}"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:53
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "New Zone"
 msgstr "新增區域"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:330
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Failed to update collection position"
 msgstr "更新集合位置失敗"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:106
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund"
 msgstr "退款"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
-#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx
 msgid "Modify"
 msgstr "修改"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:337
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "No global languages configured"
 msgstr "未設定全域語言"
 
 #. placeholder {0}: removedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removing {0} item(s)"
 msgstr "正在移除 {0} 個項目"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Track"
 msgstr "追蹤"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Create variant"
 msgstr "建立變體"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx
 msgid "Facet values for {facetName}"
 msgstr "{facetName} 的屬性值"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Save Layout"
 msgstr "儲存佈局"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset verified"
 msgstr "密碼重設已驗證"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete view"
 msgstr "刪除檢視失敗"
 
-#: src/lib/components/shared/navigation-confirmation.tsx:47
+#: src/lib/components/shared/navigation-confirmation.tsx
 msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
 msgstr "確定要離開此頁面嗎？任何未儲存的變更都將遺失。"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Toggle header column"
 msgstr "切換標題欄"
 
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "New Promotion"
 msgstr "新增促銷"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:144
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option value name"
 msgstr "選項值名稱"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Last used"
 msgstr "最後使用時間"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Is default tax category"
 msgstr "預設稅務類別"
 
-#: src/lib/components/data-input/slug-input.tsx:238
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug is set"
 msgstr "Slug 已設定"
 
-#: src/lib/components/shared/asset/asset-preview.tsx:126
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Failed to update focal point"
 msgstr "更新焦點失敗"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully updated zone"
 msgstr "已成功更新區域"
 
-#: src/lib/components/shared/customer-address-form.tsx:149
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "State/Province"
 msgstr "州/省"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Failed to update option group"
 msgstr "更新選項群組失敗"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:277
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Channel defaults"
 msgstr "通路預設值"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Failed to create tax category"
 msgstr "建立稅務類別失敗"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:58
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Set filter criteria for the {columnId} column"
 msgstr "設定 {columnId} 欄的篩選條件"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
-#: src/lib/components/shared/customer-address-form.tsx:173
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Country"
 msgstr "國家"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:96
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Simple product"
 msgstr "簡單產品"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:137
+#: src/lib/framework/defaults.ts
 msgid "Job Queue"
 msgstr "工作佇列"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Please confirm you have saved the API key before closing."
 msgstr "請在關閉前確認您已儲存 API Key。"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:413
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Confirm deletion"
 msgstr "確認刪除"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to modify order"
 msgstr "修改訂單失敗"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Includes tax at {taxRate}%"
 msgstr "含 {taxRate}% 稅"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order metrics"
 msgstr "訂單指標"
 
-#: src/lib/components/layout/language-dialog.tsx:49
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Select display language"
 msgstr "選取顯示語言"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-handler-selector.tsx
 msgid "Select Payment Handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:129
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Authentication methods"
 msgstr "驗證方式"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "start"
 msgstr "開始"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Failed to rotate API key"
 msgstr "輪換 API Key 失敗"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "in"
 msgstr "在"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
-#: src/lib/components/shared/role-selector.tsx:53
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/lib/components/shared/role-selector.tsx
 msgid "Search roles..."
 msgstr "搜尋角色..."
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Successfully cancelled {fulfilled} jobs"
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
 msgid "Product Variants"
 msgstr "商品變體"
 
-#: src/lib/components/data-table/views-sheet.tsx:125
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage Global Views"
 msgstr "管理全域檢視"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:370
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Processing..."
 msgstr "處理中..."
 
 #. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
-#: src/lib/components/shared/asset/asset-gallery.tsx:472
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "{totalItems} {0} found"
 msgstr "找到 {totalItems} 個{0}"
 
-#: src/lib/components/date-range-picker.tsx:126
+#: src/lib/components/date-range-picker.tsx
 msgid "Select date range"
 msgstr "選擇日期範圍"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:97
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Product"
 msgstr "商品"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate API Key"
 msgstr "輪換 API Key"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Category"
 msgstr "類別"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving..."
 msgstr "正在移動..."
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:148
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign"
 msgstr "指派"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully created seller"
 msgstr "已成功建立賣家"
 
 #. placeholder {0}: failedChannelIds.length
 #. placeholder {1}: selectedChannelIds.length
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:104
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
 msgstr "成功更新配送方式"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Failed to update product variant"
 msgstr "更新商品變體失敗"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:72
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Drag to reorder"
 msgstr "拖曳以重新排序"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
-#: src/app/routes/_authenticated/_zones/zones.tsx:14
-#: src/app/routes/_authenticated/_zones/zones.tsx:24
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Zones"
 msgstr "區域"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:163
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Choose what to do with any stock remaining in the {count, plural, one {# stock location} other {# stock locations}} you are deleting. All selected locations transfer their remaining stock into the single location you choose, or discard it."
 msgstr "請選擇如何處理您要刪除的 {count, plural, other {# 個庫存地點}} 中剩餘的庫存。所有選取的地點會將其剩餘庫存轉移到您選擇的那個地點，或將其捨棄。"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
-#: src/lib/components/shared/facet-value-selector.tsx:123
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Search facet values..."
 msgstr "搜尋分面值..."
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Note"
 msgstr "備註"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:252
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Available languages"
 msgstr "可用語言"
 
 #. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
-#: src/app/routes/_authenticated/_collections/collections.tsx:478
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Load {0} more ({remaining} remaining)"
 msgstr "載入更多{0}個 (剩餘{remaining}個)"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
-#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
-#: src/app/routes/_authenticated/_products/products.tsx:76
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Facet values"
 msgstr "屬性值"
 
-#: src/lib/components/data-table/data-table.tsx:237
+#: src/lib/components/data-table/data-table.tsx
 msgid "Failed to reorder items"
 msgstr "重新排序商品失敗"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Orders"
 msgstr "訂單總數"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "No eligible shipping methods found for this order."
 msgstr "找不到此訂單的符合條件的配送方式。"
 
-#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:126
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx
 msgid "Add product option"
 msgstr "新增商品選項"
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:194
-#: src/app/routes/_authenticated/_orders/orders.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
 msgid "Shipping"
 msgstr "配送"
 
-#: src/lib/hooks/use-widget-dimensions.ts:9
+#: src/lib/hooks/use-widget-dimensions.ts
 msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
 msgstr "useWidgetDimensions 必須在 DashboardBaseWidget 中使用"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:40
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
 msgstr "此選項群組正被現有變體使用。強制移除可能會影響這些變體。您確定嗎？"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update requested"
 msgstr "已要求電子郵件更新"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Error transitioning to state"
 msgstr "轉換到狀態時發生錯誤"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Successfully created customer group"
 msgstr "已成功建立客戶群組"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "New window"
 msgstr "新視窗"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment authorized"
 msgstr "付款已授權"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Successfully updated role"
 msgstr "已成功更新角色"
 
-#: src/lib/components/shared/customer-address-form.tsx:184
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Select a country"
 msgstr "選取一個國家"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to update shipping method"
 msgstr "更新配送方式失敗"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:103
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{deleted, plural, one {Deleted {deleted} stock location} other {Deleted {deleted} stock locations}}"
 msgstr "{deleted, plural, other {已刪除 {deleted} 個庫存地點}}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "Shipping Methods"
 msgstr "配送方式"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:58
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "Select an address"
 msgstr "選取一個地址"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Yes"
 msgstr "是"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:239
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Slug"
 msgstr "Slug"
 
-#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:98
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx
 msgid "Set Focal Point"
 msgstr "設定焦點"
 
-#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+#: src/lib/components/data-table/data-table-filter-badge.tsx
 msgid "end"
 msgstr "結束"
 
-#: src/lib/components/shared/currency-selector.tsx:29
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Select a currency"
 msgstr "選取一種貨幣"
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Update the note content or visibility"
 msgstr "更新備註內容或可見性"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:272
+#: src/lib/framework/defaults.ts
 msgid "Latest Orders Widget"
 msgstr "最新訂單小工具"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx
 msgid "Collection contents for {collectionName}"
 msgstr "{collectionName} 的集合內容"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Shipping method changed"
 msgstr "配送方式已變更"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
 msgid "Tax description"
 msgstr "稅項描述"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:55
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than or equal to"
 msgstr "小於或等於"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:18
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not equal to"
 msgstr "不等於"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:47
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Refresh"
 #~ msgstr "重新整理"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:269
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Size"
 #~ msgstr "例如：尺寸"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:38
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "No checkers found"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Settle payment"
 msgstr "完成付款"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:65
-#: src/app/routes/_authenticated/_channels/channels.tsx:15
-#: src/app/routes/_authenticated/_channels/channels.tsx:23
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:337
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
-#: src/lib/components/layout/channel-switcher.tsx:146
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_channels/channels.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Channels"
 msgstr "通路"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Shipping refunded"
 msgstr "運費已退款"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:376
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Asset type"
 msgstr "資源類型"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx
 msgid "New Stock Location"
 msgstr "新增庫存位置"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
 msgstr "失敗前已退還 {successfulRefundCount} 筆付款。請查看訂單歷史了解詳情。"
 
-#: src/lib/components/data-input/relation-selector.tsx:412
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Select item"
 msgstr "選取項目"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:205
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "New product"
 msgstr "新增商品"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "管理標籤"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Items refunded"
 msgstr "已退款商品"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:37
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Add action"
 msgstr "新增動作"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:325
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Assign options to existing variant"
 #~ msgstr "將選項指派給現有變體"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/app/common/duplicate-entity-dialog.tsx:85
+#: src/app/common/duplicate-entity-dialog.tsx
 msgid "Duplicate {0}s"
 msgstr "複製 {0}"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:56
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Remove from group"
 msgstr "從群組中移除"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Failed to update fulfillment state"
 msgstr "更新履行狀態失敗"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Create a new product variant with options, pricing, and stock"
 msgstr "建立包含選項、定價和庫存的新產品變體"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private facets are not visible in the shop"
 msgstr "私人屬性在商店中不可見"
 
-#: src/lib/components/shared/tax-category-selector.tsx:50
+#: src/lib/components/shared/tax-category-selector.tsx
 msgid "Select a tax category"
 msgstr "選取一個稅務類別"
 
 #~ msgid "fulfillmentState.Created"
 #~ msgstr "已建立"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Not Running"
 msgstr "未執行"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Assigned"
 msgstr "已指派"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 1"
 msgstr "標題 1"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:279
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Select Available Languages"
 msgstr "選取可用語言"
 
 #. placeholder {0}: addedLines.length
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Adding {0} item(s)"
 msgstr "正在新增 {0} 個項目"
 
-#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx
 msgid "Add row after"
 msgstr "在後面新增列"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax total"
 msgstr "稅金總計"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:414
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order status"
 msgstr "草稿訂單狀態"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:119
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Successfully created product options"
 #~ msgstr "已成功建立商品選項"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:190
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Loading locations…"
 msgstr "正在載入地點…"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to create payment method"
 msgstr "建立付款方式失敗"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully created facet value"
 msgstr "已成功建立屬性值"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:114
+#: src/lib/framework/defaults.ts
 msgid "Marketing"
 msgstr "行銷"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:351
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Draft order deleted"
 msgstr "草稿訂單已刪除"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than"
 msgstr "大於"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:263
+#: src/lib/framework/defaults.ts
 msgid "Metrics Widget"
 msgstr "指標小工具"
 
-#: src/lib/components/shared/currency-selector.tsx:30
+#: src/lib/components/shared/currency-selector.tsx
 msgid "Search currencies..."
 msgstr "搜尋貨幣..."
 
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Remove from channel"
 msgstr "從頻道中移除"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:173
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Title"
 msgstr "標題"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Insert image"
 msgstr "插入圖片"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Failed to update seller"
 msgstr "更新賣家失敗"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
 msgid "Successfully created country"
 msgstr "已成功建立國家"
 
-#: src/lib/components/shared/seller-selector.tsx:39
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Select seller"
 msgstr "選取賣家"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Loading tags..."
 msgstr "正在載入標籤..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully created facet"
 msgstr "已成功建立屬性"
 
 #. placeholder {0}: row.original.productVariantCount
-#: src/app/routes/_authenticated/_collections/collections.tsx:409
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "{0} variants"
 msgstr "{0} 個變體"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "完成付款失敗"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"
 msgstr "無帳單地址"
 
 #. placeholder {0}: failed.length
 #. placeholder {1}: failed.length
 #. placeholder {2}: failed.length
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:120
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "{0, plural, one {Failed to delete {1} stock location} other {Failed to delete {2} stock locations}}"
 msgstr "{0, plural, other {無法刪除 {2} 個庫存地點}}"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Facet"
 msgstr "屬性"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "{rejected, plural, one {{0}} other {{1}}}"
 #~ msgstr ""
 
-#: src/lib/components/shared/assigned-channels.tsx:58
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Cannot remove from active channel"
 msgstr "無法從活動頻道中移除"
 
-#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
-#: src/lib/components/shared/asset/asset-preview.tsx:162
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx
+#: src/lib/components/shared/asset/asset-preview.tsx
 msgid "Not set"
 msgstr "未設定"
 
-#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx:60
+#: src/app/routes/_authenticated/_products/components/force-remove-option-group-dialog.tsx
 msgid "Force remove"
 msgstr "強制移除"
 
-#: src/app/routes/_authenticated/_channels/channels.tsx:70
+#: src/app/routes/_authenticated/_channels/channels.tsx
 msgid "New Channel"
 msgstr "新增通路"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Group Name"
 msgstr "選項群組名稱"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:46
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "AND"
 msgstr "與"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to create customer group"
 msgstr "建立客戶群組失敗"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to create role"
 msgstr "建立角色失敗"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:233
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product name"
 msgstr "商品名稱"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment state updated successfully"
 msgstr "履行狀態已成功更新"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:59
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:55
-#: src/app/routes/_authenticated/_products/products.tsx:24
-#: src/app/routes/_authenticated/_products/products.tsx:47
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Products"
 msgstr "商品"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Address created"
 msgstr "地址已建立"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:196
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 #~ msgid "Add an option group to get started with variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "API key rotated successfully"
 msgstr "API Key 輪換成功"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group"
 msgstr "新增選項群組"
 
 #. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:372
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund {0}"
 msgstr "退款 {0}"
 
-#: src/lib/components/data-input/slug-input.tsx:240
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Enter slug manually"
 msgstr "手動輸入 slug"
 
-#: src/app/routes/_authenticated/index.tsx:230
+#: src/app/routes/_authenticated/index.tsx
 msgid "No widgets available"
 msgstr "無可用小工具"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to cancel payment"
 msgstr "取消付款失敗"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment cancelled successfully"
 msgstr "付款已成功取消"
 
-#: src/lib/components/data-table/views-sheet.tsx:96
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view duplicated successfully"
 msgstr "全域檢視已成功複製"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
 msgid "Created by"
 msgstr "建立者"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Filter variants..."
 msgstr "篩選變體..."
 
-#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx
 msgid "Add a price in another currency"
 msgstr "新增另一種貨幣的價格"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:128
-#: src/app/routes/_authenticated/_profile/profile.tsx:115
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Email Address or identifier"
 msgstr "電子郵件地址或識別碼"
 
 #. placeholder {0}: entry.data.refundId
 #. placeholder {1}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Refund #{0} transitioned to {1}"
 msgstr "退款 #{0} 已轉換到 {1}"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
-#: src/app/routes/_authenticated/_customers/customers.tsx:15
-#: src/app/routes/_authenticated/_customers/customers.tsx:21
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Customers"
 msgstr "客戶"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 4"
 msgstr "標題 4"
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to update stock location"
 msgstr "更新庫存位置失敗"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order shipped"
 msgstr "訂單已出貨"
 
-#: src/lib/components/shared/customer-address-form.tsx:257
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Save Address"
 msgstr "儲存地址"
 
-#: src/lib/components/data-table/views-sheet.tsx:261
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Make Global"
 msgstr "設為全域"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Select next state"
 msgstr "選取下一個狀態"
 
-#: src/lib/components/shared/alerts.tsx:46
+#: src/lib/components/shared/alerts.tsx
 msgid "No alerts"
 msgstr "無提醒"
 
 #. placeholder {0}: collectionsToMove.length
 #. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
 #. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Moving {0} collection{1} into {2}"
 msgstr "正在將 {0} 個集合移動到 {2}"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx
 msgid "Test"
 msgstr "測試"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "between"
 msgstr "之間"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note added successfully"
 msgstr "備註已成功新增"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note deleted successfully"
 msgstr "備註已成功刪除"
 
 #. js-lingui-explicit-id
-#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
-#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts
 msgid "Note updated successfully"
 msgstr "備註已成功更新"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle refund"
 msgstr "完成退款失敗"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Stock level"
 msgstr "庫存水準"
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:289
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Add item"
 msgstr "新增項目"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully created API key"
 msgstr "API Key 建立成功"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Loading preview…"
 msgstr "正在載入預覽..."
 
-#: src/lib/components/shared/facet-value-selector.tsx:189
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Back to search"
 msgstr "返回搜尋"
 
-#: src/lib/components/data-table/views-sheet.tsx:97
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View duplicated successfully"
 msgstr "檢視已成功複製"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:50
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:56
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:297
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Remove option group"
 msgstr "移除選項群組"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:255
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Description"
 msgstr "描述"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
-#: src/app/routes/_authenticated/_countries/countries.tsx:13
-#: src/app/routes/_authenticated/_countries/countries.tsx:22
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_countries/countries.tsx
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Countries"
 msgstr "國家"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:162
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to remove order line: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "Street Address 2"
 msgstr "街道地址 2"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Global view deleted successfully"
 msgstr "全域檢視已成功刪除"
 
-#: src/app/routes/_authenticated/index.tsx:199
+#: src/app/routes/_authenticated/index.tsx
 msgid "Edit Layout"
 msgstr "編輯佈局"
 
-#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
-#: src/lib/components/shared/assigned-channels.tsx:98
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Assign to channel"
 msgstr "指派給通路"
 
-#: src/lib/components/date-range-picker.tsx:47
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "This week"
 msgstr "本週"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:106
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully created product option group"
 #~ msgstr "成功建立商品選項群組"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add a manual payment of {0}"
 msgstr "新增 {0} 的手動付款"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:38
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is in"
 msgstr "在"
 
-#: src/lib/components/login/login-form.tsx:83
+#: src/lib/components/login/login-form.tsx
 msgid "Email"
 msgstr "電子郵件"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:87
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Failed to update administrator"
 msgstr "更新管理員失敗"
 
-#: src/lib/components/data-table/views-sheet.tsx:132
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Manage your personal saved views for this table"
 msgstr "管理此表格的個人儲存檢視"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Filter by tags"
 msgstr "按標籤篩選"
 
-#: src/lib/components/login/login-form.tsx:73
+#: src/lib/components/login/login-form.tsx
 msgid "Sign in to access the admin dashboard"
 msgstr "登入以存取管理儀表板"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 #~ msgid "Add payment to order ({0})"
 #~ msgstr "向訂單新增付款 ({0})"
 
-#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx
 msgid "False"
 msgstr "否"
 
-#: src/lib/components/layout/nav-user.tsx:127
+#: src/lib/components/layout/nav-user.tsx
 msgctxt "theme"
 msgid "Light"
 msgstr "淺色"
 
-#: src/lib/components/data-table/data-table-view-options.tsx:130
+#: src/lib/components/data-table/data-table-view-options.tsx
 msgid "Reset"
 msgstr "重設"
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:17
-#: src/lib/components/data-table/human-readable-operator.tsx:26
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is equal to"
 msgstr "等於"
 
-#: src/lib/components/shared/asset/asset-properties.tsx:17
+#: src/lib/components/shared/asset/asset-properties.tsx
 msgid "Source File"
 msgstr ""
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:249
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:408
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create options"
 #~ msgstr "建立選項"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password updated"
 msgstr "密碼已更新"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:60
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "does not contain"
 msgstr "不包含"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Option Group"
 msgstr "選項群組"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit the address details below."
 msgstr "編輯下方的地址詳細資料。"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully created tax category"
 msgstr "已成功建立稅務類別"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Failed to move collections"
 msgstr "移動集合失敗"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to update payment state"
 msgstr "更新付款狀態失敗"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Your orders summary"
 msgstr "您的訂單摘要"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:406
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Upload"
 msgstr "上傳"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:111
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Product with options"
 msgstr "帶選項的產品"
 
 #. placeholder {0}: filteredTags.length
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
 msgid "Showing all {0} results"
 msgstr "顯示所有 {0} 個結果"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Lookup ID"
 msgstr "查詢 ID"
 
 #. placeholder {0}: list.totalItems - 3
-#: src/app/routes/_authenticated/_facets/facets.tsx:65
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "+ {0} more"
 msgstr "+ {0} 個更多"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:45
+#: src/lib/framework/defaults.ts
 msgid "Option Groups"
 msgstr "選項群組"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:471
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Custom fields"
 msgstr "自訂欄位"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "All possible order states and their transitions. The current state is highlighted."
 msgstr "所有可能的訂單狀態及其轉換。目前狀態已醒目標示。"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:82
+#: src/lib/framework/defaults.ts
 msgid "Orders"
 msgstr "訂單"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:280
+#: src/lib/framework/defaults.ts
 msgid "Orders Summary Widget"
 msgstr "訂單摘要小工具"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:30
+#: src/i18n/common-strings.ts
 msgid "orderState.AddingItems"
 msgstr "新增商品中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:40
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingAdditionalPayment"
 msgstr "安排額外付款"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:32
+#: src/i18n/common-strings.ts
 msgid "orderState.ArrangingPayment"
 msgstr "安排付款中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:31
+#: src/i18n/common-strings.ts
 msgid "orderState.Cancelled"
 msgstr "已取消"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:28
+#: src/i18n/common-strings.ts
 msgid "orderState.Created"
 msgstr "已建立"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:38
+#: src/i18n/common-strings.ts
 msgid "orderState.Delivered"
 msgstr "已送達"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:29
+#: src/i18n/common-strings.ts
 msgid "orderState.Draft"
 msgstr "草稿"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:39
+#: src/i18n/common-strings.ts
 msgid "orderState.Modifying"
 msgstr "修改中"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:37
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyDelivered"
 msgstr "部分已送達"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:35
+#: src/i18n/common-strings.ts
 msgid "orderState.PartiallyShipped"
 msgstr "部分已出貨"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:33
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentAuthorized"
 msgstr "付款已授權"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:34
+#: src/i18n/common-strings.ts
 msgid "orderState.PaymentSettled"
 msgstr "付款已完成"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:36
+#: src/i18n/common-strings.ts
 msgid "orderState.Shipped"
 msgstr "已出貨"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:83
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Monitored Resources"
 #~ msgstr "監控資源"
 
-#: src/lib/framework/layout-engine/page-layout.tsx:705
+#: src/lib/framework/layout-engine/page-layout.tsx
 msgid "Entity Information"
 msgstr "實體資訊"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Total"
 msgstr "訂單總額"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to admins only"
 msgstr "僅管理員可見"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:103
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Qty"
 msgstr "數量"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Tags"
 msgstr "標籤"
 
-#: src/lib/components/shared/role-code-label.tsx:6
+#: src/lib/components/shared/role-code-label.tsx
 msgid "Super Admin"
 msgstr "超級管理員"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:74
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Some resources are down"
 #~ msgstr "部分資源已關閉"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-actions-selector.tsx
 msgid "Available Actions"
 msgstr "可用動作"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:143
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to update order line: {0}"
 msgstr ""
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert link"
 msgstr "插入連結"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
 msgstr "如果啟用，篩選器將從父集合繼承，並與此集合上設定的篩選器組合。"
 
-#: src/lib/components/shared/zone-selector.tsx:50
+#: src/lib/components/shared/zone-selector.tsx
 msgid "Select a zone"
 msgstr "選取一個區域"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx
 msgid "Test shipping methods"
 msgstr "測試配送方式"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment settled successfully"
 msgstr "付款已成功完成"
 
 #. placeholder {0}: selection.length
 #. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
-#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx
 msgid "Removed {0} {1} from zone"
 msgstr "已從區域移除 {0} {1}"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Enable"
 msgstr "啟用"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:216
+#: src/lib/framework/defaults.ts
 msgid "Payment Methods"
 msgstr "付款方式"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:16
+#: src/i18n/common-strings.ts
 msgid "paymentState.Authorized"
 msgstr "已授權"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:20
+#: src/i18n/common-strings.ts
 msgid "paymentState.Cancelled"
 msgstr "已取消"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:15
+#: src/i18n/common-strings.ts
 msgid "paymentState.Created"
 msgstr "已建立"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:18
+#: src/i18n/common-strings.ts
 msgid "paymentState.Declined"
 msgstr "已拒絕"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:19
+#: src/i18n/common-strings.ts
 msgid "paymentState.Error"
 msgstr "錯誤"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:25
+#: src/i18n/common-strings.ts
 msgid "paymentState.Failed"
 msgstr "失敗"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:23
+#: src/i18n/common-strings.ts
 msgid "paymentState.Pending"
 msgstr "待處理"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:17
-#: src/i18n/common-strings.ts:24
+#: src/i18n/common-strings.ts
+#: src/i18n/common-strings.ts
 msgid "paymentState.Settled"
 msgstr "已結算"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Average Order Value"
 msgstr "平均訂單價值"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Failed to create zone"
 msgstr "建立區域失敗"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Stock levels"
 msgstr "庫存水準"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to update API key"
 msgstr "更新 API Key 失敗"
 
-#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+#: src/lib/framework/dashboard-widget/base-widget.tsx
 msgid "{title}"
 msgstr "{title}"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:87
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Order lines"
 msgstr "訂單行"
 
-#: src/lib/components/data-table/views-sheet.tsx:68
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to rename global view"
 msgstr "重新命名全域檢視失敗"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Insert a new hyperlink with URL and target options"
 msgstr "插入帶有 URL 和目標選項的新超連結"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Height"
 msgstr "高度"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:118
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Assign {entityType} to channels"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
 msgstr "需要退款 {formattedDiff}。選取付款金額並輸入備註以繼續。"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:171
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:100
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Unit price"
 msgstr "單價"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Schedule Pattern"
 msgstr "排程模式"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment failed"
 msgstr "付款失敗"
 
-#: src/lib/components/layout/channel-switcher.tsx:212
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Add channel"
 msgstr "新增頻道"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:118
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to update product option group"
 #~ msgstr "更新商品選項群組失敗"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:137
-#: src/lib/components/shared/channel-selector.tsx:48
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/channel-selector.tsx
 msgid "Search channels..."
 msgstr "搜尋通路..."
 
-#: src/lib/components/shared/customer-group-selector.tsx:45
+#: src/lib/components/shared/customer-group-selector.tsx
 msgid "Add customer groups"
 msgstr "新增客戶群組"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:323
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Available Languages"
 msgstr "可用語言"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
 msgid "Reset selection"
 msgstr "重設選取"
 
-#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx
 msgid "No address"
 msgstr "無地址"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully created payment method"
 msgstr "已成功建立付款方式"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Customer information updated"
 msgstr "客戶資訊已更新"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:358
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to delete draft order: {0}"
 msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:120
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert view to global"
 msgstr "將檢視轉換為全域失敗"
 
-#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx:37
+#: src/app/routes/_authenticated/_payment-methods/components/payment-eligibility-checker-selector.tsx
 msgid "Select Payment Eligibility Checker"
 msgstr ""
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:136
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Select one or more channels"
 msgstr ""
 
-#: src/lib/components/data-table/filters/data-table-enum-filter.tsx:53
+#: src/lib/components/data-table/filters/data-table-enum-filter.tsx
 msgid "Select operator"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:38
+#: src/lib/framework/defaults.ts
 msgid "Product Variants"
 msgstr "商品變體"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:31
+#: src/lib/framework/defaults.ts
 msgid "Products"
 msgstr "商品"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:121
+#: src/lib/framework/defaults.ts
 msgid "Promotions"
 msgstr "促銷"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
 msgid "Failed to create product option"
 msgstr "建立產品選項失敗"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Old email:"
 msgstr "舊電子郵件："
 
-#: src/lib/components/data-table/views-sheet.tsx:144
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Save a view as \"Global\" to make it available to all users."
 msgstr "將檢視儲存為「全域」以使其對所有使用者可用。"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Failed to create variants"
 msgstr "建立變體失敗"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
 msgstr "設定將此變體視為缺貨的庫存水準。使用負值可啟用延期交貨支援。可由商品變體覆寫。"
 
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
-#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx
 msgid "Rotate Key"
 msgstr "輪換金鑰"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:132
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Failed to create product variants"
 #~ msgstr "建立產品變體失敗"
 
-#: src/lib/components/ui/password-input.tsx:20
+#: src/lib/components/ui/password-input.tsx
 msgid "Hide password"
 msgstr "隱藏密碼"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "New seller"
 msgstr "新增賣家"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:146
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "e.g., Red, Large, Cotton"
 msgstr "例如：紅色、大號、棉質"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:76
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "Failed to update profile"
 msgstr "更新個人資料失敗"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Removed coupon codes"
 msgstr "已移除優惠券代碼"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:83
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Clear filter"
 msgstr "清除篩選器"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:36
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Regions"
 msgstr "地區"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:445
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Drop files here to upload"
 msgstr "將檔案拖放到此處上傳"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Toggle all visible variants"
 msgstr "切換所有可見變體"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Verified"
 msgstr "已驗證"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "New option group"
 msgstr "新建選項群組"
 
-#: src/app/routes/_authenticated/_system/healthchecks.tsx:58
+#: src/app/routes/_authenticated/_system/healthchecks.tsx
 #~ msgid "Last updated {0}"
 #~ msgstr "上次更新 {0}"
 
-#: src/lib/components/data-table/views-sheet.tsx:141
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "No global views have been created yet."
 msgstr "尚未建立全域檢視。"
 
-#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx
 msgid "Failed to update role"
 msgstr "更新角色失敗"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
 msgstr "完整的 API Key 僅此一次顯示。請立即複製或下載，之後將無法再次取得。"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Successfully updated collection"
 msgstr "已成功更新集合"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Successfully updated payment method"
 msgstr "已成功更新付款方式"
 
-#: src/lib/components/data-table/views-sheet.tsx:83
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "View deleted successfully"
 msgstr "檢視已成功刪除"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:368
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group {0}"
 #~ msgstr "選項群組 {0}"
 
-#: src/lib/components/data-input/combination-mode-input.tsx:59
+#: src/lib/components/data-input/combination-mode-input.tsx
 msgid "OR"
 msgstr "或"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:166
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "You must select a default currency from the list of available currencies"
 msgstr ""
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Manage tags"
 msgstr "管理標籤"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:317
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code removed from order"
 msgstr "優惠券代碼已從訂單中移除"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
-#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Never"
 msgstr "永不"
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Failed to update facet value"
 msgstr "更新屬性值失敗"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:278
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Remove group"
 #~ msgstr "移除群組"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order fulfilled"
 msgstr "訂單已履行"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:437
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Loading selected items..."
 msgstr ""
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:250
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set billing address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No shipping address"
 msgstr "無配送地址"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:49
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension contains invalid GraphQL syntax"
 msgstr "查詢擴充包含無效的 GraphQL 語法"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:23
-#: src/lib/hooks/use-extended-list-query.ts:64
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error"
 msgstr "查詢擴充錯誤"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:51
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension error: "
 msgstr "查詢擴充錯誤："
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:43
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension is invalid: must have at least one top-level field"
 msgstr "查詢擴充無效：必須至少有一個頂層欄位"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-list-query.ts:47
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "Query extension mismatch: "
 msgstr "查詢擴充不符："
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:44
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "public"
 msgstr "公開"
 
-#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
 msgid "Successfully updated tax category"
 msgstr "已成功更新稅務類別"
 
-#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx
 msgid "Move"
 msgstr "移動"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Edit or delete existing tags"
 msgstr "編輯或刪除現有標籤"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
 msgstr "此配送方式的資格檢查器條件不符合目前訂單和配送地址。"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:308
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
 msgid "Add coupon code"
 msgstr "新增優惠券代碼"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:301
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Coupon code set for order"
 msgstr "已為訂單設定優惠券代碼"
 
-#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx
 msgid "Custom Fields"
 msgstr "自訂欄位"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx
 msgid "New Shipping Method"
 msgstr "新增配送方式"
 
-#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx:160
+#: src/app/routes/_authenticated/_stock-locations/components/delete-stock-locations-dialog.tsx
 msgid "Delete stock locations"
 msgstr "刪除庫存地點"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:47
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than or equal to"
 msgstr "大於或等於"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
-#: src/lib/components/shared/entity-assets.tsx:151
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+#: src/lib/components/shared/entity-assets.tsx
 msgid "Preview"
 msgstr "預覽"
 
 #. placeholder {0}: quantity.max
 #. placeholder {1}: line.quantity
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "{0} of {1} available to fulfill"
 msgstr "{1} 個中有 {0} 個可履行"
 
-#: src/lib/components/date-range-picker.tsx:63
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Month to date"
 msgstr "本月至今"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:43
+#: src/i18n/common-strings.ts
 msgid "refundReason.CustomerRequest"
 msgstr "客戶要求"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:45
+#: src/i18n/common-strings.ts
 msgid "refundReason.DamagedInShipping"
 msgstr "運輸中損壞"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:44
+#: src/i18n/common-strings.ts
 msgid "refundReason.NotAvailable"
 msgstr "無庫存"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:47
+#: src/i18n/common-strings.ts
 msgid "refundReason.Other"
 msgstr "其他"
 
 #. js-lingui-explicit-id
-#: src/i18n/common-strings.ts:46
+#: src/i18n/common-strings.ts
 msgid "refundReason.WrongItem"
 msgstr "發錯商品"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Summary of modifications"
 msgstr "修改摘要"
 
 #. placeholder {0}: payment.refunds.length
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refunds ({0})"
 msgstr "退款 ({0})"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Last Executed"
 msgstr "上次執行"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Payment details"
 msgstr "付款詳細資料"
 
-#: src/app/routes/_authenticated/_products/products.tsx:111
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Rebuild search index"
 msgstr "重建搜尋索引"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Running"
 msgstr "正在執行"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 60 seconds"
 msgstr "每 60 秒"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
 msgid "Failed to update customer group"
 msgstr "更新客戶群組失敗"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Payment metadata"
 msgstr "付款中繼資料"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Cancel modification"
 msgstr "取消修改"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Same window"
 msgstr "相同視窗"
 
-#: src/lib/components/data-table/views-sheet.tsx:155
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Apply filters to the table and click \"Save View\" to get started."
 msgstr "對表格套用篩選器，然後按一下「儲存檢視」開始。"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:202
+#: src/lib/framework/defaults.ts
 msgid "Roles"
 msgstr "角色"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Additional payment required"
 msgstr "需要額外付款"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Failed to update order"
 msgstr "更新訂單失敗"
 
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "With selected..."
 msgstr "對所選..."
 
-#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
 msgid "Failed to create stock location"
 msgstr "建立庫存位置失敗"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:53
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than or equal"
 msgstr "小於或等於"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx
 msgid "Customer group members for {customerGroupName}"
 msgstr "{customerGroupName} 的客戶群組成員"
 
 #. placeholder {0}: e instanceof Error ? e.message : String(e)
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to set address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
-#: src/app/routes/_authenticated/_orders/orders.tsx:101
-#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/orders.tsx
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "State"
 msgstr "州/省"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Do not track"
 msgstr "不追蹤"
 
 #. placeholder {0}: entry.data.fulfillmentId
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} created"
 msgstr "已建立履行 #{0}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts
 msgid "Running pending search index updates"
 msgstr "正在執行待處理的搜尋索引更新"
 
-#: src/app/routes/_authenticated/_roles/roles.tsx:53
+#: src/app/routes/_authenticated/_roles/roles.tsx
 msgid "This is a default Role and cannot be modified"
 msgstr "這是預設角色，無法修改"
 
-#: src/lib/components/data-table/my-views-button.tsx:37
+#: src/lib/components/data-table/my-views-button.tsx
 msgid "My saved views"
 msgstr "我的儲存檢視"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
 msgid "State / Province"
 msgstr "州/省"
 
-#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:221
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
-#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
-#: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/layout/nav-user.tsx:152
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx
+#: src/lib/components/data-display/boolean.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Enabled"
 msgstr "已啟用"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:483
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Items per page"
 msgstr "每頁筆數"
 
-#: src/app/routes/_authenticated/_zones/zones.tsx:39
+#: src/app/routes/_authenticated/_zones/zones.tsx
 msgid "Edit members"
 msgstr "編輯成員"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock on hand"
 msgstr "現有庫存"
 
-#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+#: src/lib/components/data-table/data-table-filter-dialog.tsx
 msgid "Filter by {columnId}"
 msgstr "按 {columnId} 篩選"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "ID"
 msgstr "ID"
 
-#: src/lib/components/shared/alerts.tsx:33
+#: src/lib/components/shared/alerts.tsx
 msgid "Alerts"
 msgstr "警示"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Option Values"
 msgstr "選項值"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Preview changes"
 msgstr "預覽變更"
 
-#: src/lib/components/shared/assigned-channels.tsx:52
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Failed to remove {entityType} from channel"
 msgstr "從頻道中移除 {entityType} 失敗"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:188
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variant deleted successfully"
 msgstr "變體已成功刪除"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Edit the selected link properties"
 msgstr "編輯所選連結的屬性"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:75
+#: src/lib/framework/defaults.ts
 msgid "Sales"
 msgstr "銷售"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Select a destination collection"
 msgstr "選取目標集合"
 
-#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
 msgid "Your latest orders"
 msgstr "您的最新訂單"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:144
+#: src/lib/framework/defaults.ts
 msgid "Scheduled Tasks"
 msgstr "排程任務"
 
-#: src/lib/components/data-table/use-generated-columns.tsx:416
+#: src/lib/components/data-table/use-generated-columns.tsx
 msgid "Are you sure you want to delete this item? This action cannot be undone."
 msgstr "確定要刪除此項目嗎？此動作無法復原。"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:322
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Variants"
 msgstr "變體"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:174
+#: src/lib/framework/defaults.ts
 msgid "Sellers"
 msgstr "賣家"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:167
+#: src/lib/framework/defaults.ts
 msgid "Settings"
 msgstr "設定"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:151
+#: src/lib/framework/defaults.ts
 msgid "Settings Store"
 msgstr "設定商店"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 3"
 msgstr "標題 3"
 
-#: src/lib/components/login/login-form.tsx:70
+#: src/lib/components/login/login-form.tsx
 msgid "Welcome to Vendure"
 msgstr "歡迎使用 Vendure"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:209
+#: src/lib/framework/defaults.ts
 msgid "Shipping Methods"
 msgstr "配送方式"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:149
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "({maxRefundable} refundable)"
 msgstr "({maxRefundable} 可退款)"
 
-#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+#: src/app/routes/_authenticated/_administrators/administrators.tsx
 msgid "Identifier"
 msgstr "識別碼"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx:51
+#: src/app/routes/_authenticated/_shipping-methods/components/fulfillment-handler-selector.tsx
 msgid "Select a fulfillment handler"
 msgstr ""
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
 msgid "Failed to update collection"
 msgstr "更新集合失敗"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Price and tax"
 msgstr "價格和稅金"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Order not found"
 msgstr "找不到訂單"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:28
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "!="
 msgstr "!="
 
-#: src/lib/components/shared/error-page.tsx:18
+#: src/lib/components/shared/error-page.tsx
 msgid "Error"
 msgstr "錯誤"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Order modified"
 msgstr "訂單已修改"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Password reset requested"
 msgstr "已要求重設密碼"
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Allocated payment amount must equal refund total"
 msgstr "分配的付款金額必須等於退款總額"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:290
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "e.g. Small"
 #~ msgstr "例如：小號"
 
 #. placeholder {0}: selection.length
-#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx
 msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
 msgstr "確定要從目前通路中移除 {0} {entityType} 嗎？"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
 msgid "Add tags..."
 msgstr "新增標籤..."
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:117
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Failed to create product option group"
 #~ msgstr "建立商品選項群組失敗"
 
 #. placeholder {0}: selectedIds.length
-#: src/lib/components/data-input/product-multi-selector-input.tsx:504
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "{0} items selected"
 msgstr "已選取 {0} 個項目"
 
-#: src/lib/components/shared/language-selector.tsx:53
+#: src/lib/components/shared/language-selector.tsx
 msgid "Search languages..."
 msgstr "搜尋語言..."
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:188
+#: src/lib/framework/defaults.ts
 msgid "Stock Locations"
 msgstr "庫存位置"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:69
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Go to previous page"
 msgstr "前往上一頁"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
-#: src/app/routes/_authenticated/_collections/collections.tsx:402
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Contents"
 msgstr "內容"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} jobs"
 #~ msgstr ""
 
-#: src/lib/components/data-table/views-sheet.tsx:110
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to convert global view to personal view"
 msgstr "將全域檢視轉換為個人檢視失敗"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 #~ msgid "The assigned option groups have no options yet. Add options to your option groups before generating variants."
 #~ msgstr ""
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:182
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "The result of the job"
 msgstr "工作的結果"
 
 #. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment ({0})"
 msgstr "新增付款 ({0})"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:130
+#: src/lib/framework/defaults.ts
 msgid "System"
 msgstr "系統"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:81
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx
 msgid "Variant name"
 msgstr "變體名稱"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:579
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Remove"
 msgstr "移除"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:109
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to update customer"
 msgstr "更新客戶失敗"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:299
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Remove option groups?"
 msgstr "移除選項群組？"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
 msgstr "這是基於目前篩選器設定的集合內容預覽。儲存集合後,內容將更新以反映新的篩選器設定。"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:31
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "{count, plural, one {Removed {count} customer from group} other {Removed {count} customers from group}}"
 msgstr "{count, plural, other {已從群組中移除{count}位客戶}}"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:223
+#: src/lib/framework/defaults.ts
 msgid "Tax Categories"
 msgstr "稅務類別"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:230
+#: src/lib/framework/defaults.ts
 msgid "Tax Rates"
 msgstr "稅率"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx:40
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-bulk-actions.tsx
 msgid "Failed to remove customers from group"
 msgstr "從群組中移除客戶失敗"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:273
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Failed to load global settings"
 msgstr "載入全域設定失敗"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:79
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select items to refund and optionally return to stock"
 msgstr "選擇要退款的商品，可選擇退回庫存"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
-#: src/app/routes/_authenticated/_system/settings-store.tsx:143
-#: src/lib/components/data-table/views-sheet.tsx:210
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
+#: src/app/routes/_authenticated/_system/settings-store.tsx
+#: src/lib/components/data-table/views-sheet.tsx
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Save"
 msgstr "儲存"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:17
+#: src/lib/components/data-table/data-table-pagination.tsx
 #~ msgid "{selectedRowCount} of {0} row(s) selected."
 #~ msgstr "已選取 {0} 列中的 {selectedRowCount} 列。"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Preview order modifications"
 msgstr "預覽訂單修改"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx:107
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$id.tsx
 #~ msgid "Successfully updated product option group"
 #~ msgstr "成功更新商品選項群組"
 
 #. js-lingui-explicit-id
-#: src/lib/hooks/use-extended-detail-query.ts:25
-#: src/lib/hooks/use-extended-list-query.ts:66
+#: src/lib/hooks/use-extended-detail-query.ts
+#: src/lib/hooks/use-extended-list-query.ts
 msgid "The page will continue with the default query."
 msgstr "頁面將繼續使用預設查詢。"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
-#: src/lib/components/shared/customer-address-form.tsx:121
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Street Address"
 msgstr "街道地址"
 
-#: src/lib/components/shared/facet-value-selector.tsx:242
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "No more facets"
 msgstr "沒有更多分面"
 
-#: src/app/routes/_authenticated/_products/products.tsx:32
+#: src/app/routes/_authenticated/_products/products.tsx
 msgid "Search index rebuild started"
 msgstr "已開始重建搜尋索引"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:323
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection position updated"
 msgstr "集合位置已更新"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:267
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Option group name"
 #~ msgstr "選項群組名稱"
 
-#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx
 msgid "Add \"{newOptionInput}\""
 msgstr "添加「{newOptionInput}」"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "New product variant"
 msgstr "新增商品變體"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund transitioned"
 msgstr "退款已轉換"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "Using native authentication strategy"
 msgstr "使用原生驗證策略"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Failed to assign {entityIdsLength} {entityType} to channel"
 #~ msgstr "無法將 {entityIdsLength} 個 {entityType} 分配到頻道"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:351
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Default Language"
 msgstr "預設語言"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:233
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Token"
 msgstr "權杖"
 
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
 msgid "Fulfilling..."
 msgstr "正在履行..."
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Add option group to product"
 msgstr "將選項群組新增至商品"
 
 #. placeholder {0}: asset.name
-#: src/lib/components/shared/asset/asset-preview-dialog.tsx:37
+#: src/lib/components/shared/asset/asset-preview-dialog.tsx
 msgid "Preview of {0}"
 msgstr "{0} 的預覽"
 
-#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
 msgid "Successfully updated seller"
 msgstr "已成功更新賣家"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Failed to transition order to state"
 msgstr "將訂單轉換到狀態失敗"
 
 #. placeholder {0}: group.entries.length - 2
-#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx
 msgid "Show all ({0})"
 msgstr "顯示全部 ({0})"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Failed to create tax rate"
 msgstr "建立稅率失敗"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "I have saved this API key"
 msgstr "我已儲存此 API Key"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:244
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Configure available languages for your store and channels"
 msgstr "為您的商店和通路設定可用語言"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:159
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Successfully created product"
 msgstr "已成功建立商品"
 
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Add product variant"
 msgstr "新增商品變體"
 
 #. js-lingui-explicit-id
-#: src/lib/components/data-input/string-list-input.tsx:237
+#: src/lib/components/data-input/string-list-input.tsx
 msgid "Type and press Enter or comma to add..."
 msgstr "輸入後按 Enter 或逗號新增..."
 
-#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx
 msgid "Edit Note"
 msgstr "編輯備註"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:635
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "No assets found. Try adjusting your filters."
 msgstr "找不到資源。請嘗試調整篩選條件。"
 
-#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx
 msgid "Add Option"
 msgstr "新增選項"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Save option group"
 msgstr "儲存選項群組"
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx:188
+#: src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
 #~ msgid "Create {createCount} variants"
 #~ msgstr "建立 {createCount} 個變體"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx
 msgid "Click \"Run Test\" to test this shipping method."
 msgstr "按一下「執行測試」以測試此配送方式。"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:79
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "Successfully updated administrator"
 msgstr "成功更新管理員"
 
-#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
-#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
-#: src/lib/components/shared/asset/asset-gallery.tsx:361
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx
+#: src/lib/components/data-table/data-table-faceted-filter.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Clear filters"
 msgstr "清除篩選器"
 
 #. placeholder {0}: entry.data.fulfillmentId
 #. placeholder {1}: entry.data.from
 #. placeholder {2}: entry.data.to
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "Fulfillment #{0} from {1} to {2}"
 msgstr "履行 #{0}，從 {1} 到 {2}"
 
-#: src/lib/components/data-table/views-sheet.tsx:87
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to delete global view"
 msgstr "刪除全域檢視失敗"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:282
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default language"
 msgstr "預設語言"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:257
-#: src/app/routes/_authenticated/_customers/customers.tsx:44
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers.tsx
 msgid "Status"
 msgstr "狀態"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:298
-#: src/lib/components/shared/configurable-operation-selector.tsx:155
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx
+#: src/lib/components/shared/configurable-operation-selector.tsx
 msgid "No options found"
 msgstr "找不到選項"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:370
-#: src/lib/components/shared/asset/asset-gallery.tsx:382
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Binary"
 msgstr "二進位"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
 msgid "Successfully updated option group"
 msgstr "選項群組更新成功"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "New shipping method"
 msgstr "新增配送方式"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "Every 10 seconds"
 msgstr "每 10 秒"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx
 msgid "ex. tax:"
 msgstr "不含稅："
 
-#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx:182
+#: src/app/routes/_authenticated/_products/components/create-product-variants.tsx
 #~ msgid "Add Stock to Location"
 #~ msgstr "向位置新增庫存"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:98
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Successfully added option value"
 msgstr "已成功新增選項值"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:325
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "Collection moved to new parent"
 msgstr "集合已移至新的父級"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:51
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:67
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Option group removed"
 msgstr "選項群組已移除"
 
-#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx
 msgid "Transition to selected state"
 msgstr "轉換到選定狀態"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "An additional payment of {formattedDiff} will be required."
 msgstr "需要額外付款 {formattedDiff}。"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Track inventory by default"
 msgstr "預設追蹤庫存"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "{selected} of {total} selected"
 msgstr "已選取 {total} 個中的 {selected} 個"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully created shipping method"
 msgstr "成功建立配送方式"
 
-#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx
 msgid "New Customer Group"
 msgstr "新增客戶群組"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Visible to customer"
 msgstr "客戶可見"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "Successfully created option group"
 msgstr "已成功建立選項群組"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
-#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx
 msgid "Tax Rates"
 msgstr "稅率"
 
-#: src/lib/components/data-input/slug-input.tsx:239
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Slug will be generated automatically..."
 msgstr "Slug 將自動產生..."
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
 msgid "Customer not found"
 msgstr "找不到客戶"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:666
+#: src/lib/components/data-input/default-relation-input.tsx
 msgid "Select {0}s"
 msgstr "選取 {0}"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "New facet values to add:"
 msgstr "要新增的屬性值："
 
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
-#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Failed to process refund"
 msgstr "處理退款失敗"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:116
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:180
-#: src/app/routes/_authenticated/_profile/profile.tsx:103
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
 msgid "First name"
 msgstr "名字"
 
-#: src/lib/components/shared/product-variant-selector.tsx:83
+#: src/lib/components/shared/product-variant-selector.tsx
 msgid "Add item to order"
 msgstr ""
 
-#: src/lib/components/data-table/human-readable-operator.tsx:58
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "contains"
 msgstr "包含"
 
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
 msgid "No option groups found"
 msgstr "找不到選項群組"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:162
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "No items found"
 msgstr "找不到項目"
 
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:54
-#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts:72
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
+#: src/app/routes/_authenticated/_products/hooks/use-remove-option-group.ts
 msgid "Failed to remove option group"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
 msgid "Sub total"
 msgstr "小計"
 
 #. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfilled items ({0})"
 msgstr "已履行的項目 ({0})"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value updated"
 msgstr "值已更新"
 
-#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx
 msgid "Unverified"
 msgstr "未驗證"
 
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:182
-#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
-#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx
 msgid "Quantity"
 msgstr "數量"
 
-#: src/lib/components/data-table/add-filter-menu.tsx:35
+#: src/lib/components/data-table/add-filter-menu.tsx
 msgid "Add filter"
 msgstr "新增篩選器"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Tax category"
 msgstr "稅務類別"
 
-#: src/app/routes/_authenticated/_profile/profile.tsx:39
-#: src/app/routes/_authenticated/_profile/profile.tsx:85
-#: src/lib/components/layout/nav-user.tsx:108
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/app/routes/_authenticated/_profile/profile.tsx
+#: src/lib/components/layout/nav-user.tsx
 msgid "Profile"
 msgstr "個人資料"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx
 msgid "Test data has been updated. Click \"Run Test\" to see updated results."
 msgstr "測試資料已更新。按一下「執行測試」以查看更新的結果。"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:40
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is not in"
 msgstr "不在"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:134
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order line updated"
 msgstr "訂單行已更新"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx
 msgid "New Payment Method"
 msgstr "新增付款方式"
 
-#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx
 msgid "Duplicate value \"{trimmed}\" already exists"
 msgstr "重複值「{trimmed}」已存在"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Reason"
 msgstr "原因"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:260
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Customer groups"
 msgstr "客戶群組"
 
-#: src/lib/components/shared/assigned-channels.tsx:48
+#: src/lib/components/shared/assigned-channels.tsx
 msgid "Successfully removed {entityType} from channel"
 msgstr "已成功從頻道中移除 {entityType}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
-#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:259
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option Groups"
 msgstr "選項群組"
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
-#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "Add surcharge"
 msgstr "新增附加費"
 
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
 msgid "Current facet values"
 msgstr "目前屬性值"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
 msgid "Page {page} of {totalPages}"
 msgstr "第 {page} 頁，共 {totalPages} 頁"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 #~ msgid "Failed to cancel {rejected} job"
 #~ msgstr ""
 
-#: src/lib/components/date-range-picker.tsx:79
+#: src/lib/components/date-range-picker.tsx
 msgctxt "date-range"
 msgid "Last month"
 msgstr "上個月"
 
-#: src/app/routes/_authenticated/_countries/countries.tsx:59
+#: src/app/routes/_authenticated/_countries/countries.tsx
 msgid "Add Country"
 msgstr "新增國家"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:253
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Defaults to the default language."
 msgstr ""
 
-#: src/lib/components/data-input/custom-field-list-input.tsx:85
+#: src/lib/components/data-input/custom-field-list-input.tsx
 msgid "Remove item"
 msgstr "移除項目"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:369
-#: src/lib/components/shared/asset/asset-gallery.tsx:381
+#: src/lib/components/shared/asset/asset-gallery.tsx
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Video"
 msgstr "影片"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "less than"
 msgstr "小於"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:123
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "The variant could not be added. Ensure the parent product is enabled."
 msgstr "無法新增變體。請確保父產品已啟用。"
 
-#: src/lib/components/shared/paginated-list-data-table.tsx:478
+#: src/lib/components/shared/paginated-list-data-table.tsx
 #~ msgid "An unknown error occurred"
 #~ msgstr "發生未知錯誤"
 
-#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Metrics"
 msgstr "指標"
 
-#: src/lib/components/layout/nav-user.tsx:112
+#: src/lib/components/layout/nav-user.tsx
 msgid "Language"
 msgstr "語言"
 
-#: src/app/routes/_authenticated/_collections/collections.tsx:520
+#: src/app/routes/_authenticated/_collections/collections.tsx
 msgid "New Collection"
 msgstr "新增集合"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:76
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Refund and cancel order"
 msgstr "退款並取消訂單"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Email update verified"
 msgstr "電子郵件更新已驗證"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:34
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is between"
 msgstr "在之間"
 
-#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx
 msgid "Refund & Cancel"
 msgstr "退款並取消"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx
 msgid "Testing shipping methods..."
 msgstr "正在測試配送方式..."
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
 msgid "{label}"
 msgstr "{label}"
 
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Failed to create shipping method"
 msgstr "建立配送方式失敗"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
 #~ msgstr "已成功將 {entityIdsLength} {entityType} 指派給通路"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:253
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Global Languages"
 msgstr "全域語言"
 
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:39
-#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:98
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
 msgid "New administrator"
 msgstr "新增管理員"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:395
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Delete draft"
 msgstr "刪除草稿"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Source"
 msgstr "來源"
 
-#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
-#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+#: src/lib/components/data-table/data-table-bulk-actions.tsx
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx
 msgid "No actions available"
 msgstr "無可用動作"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:180
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:186
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Failed to update channel"
 msgstr "更新通路失敗"
 
-#: src/lib/components/shared/custom-fields-form.tsx:101
+#: src/lib/components/shared/custom-fields-form.tsx
 msgid "General"
 msgstr "一般"
 
-#: src/lib/components/shared/assigned-channels.tsx:43
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Failed to remove product from channel"
 #~ msgstr "從頻道移除產品失敗"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:227
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:232
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add new address"
 msgstr "新增地址"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Successfully updated facet"
 msgstr "已成功更新屬性"
 
-#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx
 msgid "Successfully created zone"
 msgstr "已成功建立區域"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Value"
 msgstr "值"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Customer updated"
 msgstr "客戶已更新"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:165
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 msgid "Price conversion factor"
 msgstr "價格轉換係數"
 
-#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx
 msgid "Seller order"
 msgstr "賣家訂單"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "New facet"
 msgstr "新增屬性"
 
-#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx:51
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+#: src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Are you sure you want to remove this option group from the product?"
 msgstr "您確定要從產品中移除此選項群組嗎？"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Description (alt)"
 msgstr "描述（替代文字）"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
-#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "No tags found"
 msgstr "找不到標籤"
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:304
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "Default currency"
 msgstr "預設貨幣"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "No payment or refund is required for these changes."
 msgstr "這些變更不需要付款或退款。"
 
-#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:72
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx
 msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
 msgstr ""
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Total Revenue"
 msgstr "總收入"
 
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "Next Execution"
 msgstr "下次執行"
 
-#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx
 msgid "Note is private"
 msgstr "備註為私人"
 
-#: src/lib/components/layout/language-dialog.tsx:124
+#: src/lib/components/layout/language-dialog.tsx
 msgid "Medium date"
 msgstr "中等日期"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Invalid number"
 msgstr "無效數字"
 
-#: src/lib/components/data-table/views-sheet.tsx:152
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "You haven't saved any views yet."
 msgstr "您尚未儲存任何檢視。"
 
-#: src/lib/components/data-table/views-sheet.tsx:173
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Are you sure you want to delete this view? This action cannot be undone."
 msgstr "確定要刪除此檢視嗎？此動作無法復原。"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "View order process"
 msgstr "檢視訂單流程"
 
-#: src/lib/components/data-table/views-sheet.tsx:100
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Failed to duplicate view"
 msgstr "複製檢視失敗"
 
-#: src/lib/components/shared/customer-address-form.tsx:223
+#: src/lib/components/shared/customer-address-form.tsx
 msgid "Use as the default shipping address"
 msgstr "用作預設配送地址"
 
-#: src/lib/components/data-input/slug-input.tsx:280
-#: src/lib/components/data-input/slug-input.tsx:282
+#: src/lib/components/data-input/slug-input.tsx
+#: src/lib/components/data-input/slug-input.tsx
 msgid "Edit slug manually"
 msgstr "手動編輯 slug"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
 msgid "Add filters to preview the collection contents."
 msgstr "新增篩選器以預覽集合內容。"
 
-#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx:169
+#: src/app/routes/_authenticated/_products/products_.$productId.option-groups.$productOptionGroupId.options_.$id.tsx
 #~ msgid "Product Option Group"
 #~ msgstr "商品選項群組"
 
-#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx
 msgid "Subtotal"
 msgstr "小計"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:50
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is less than"
 msgstr "小於"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Refund ID"
 msgstr "退款 ID"
 
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:93
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Order custom fields updated"
 msgstr "訂單自訂欄位已更新"
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
-#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Calculator"
 msgstr "計算機"
 
-#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx
 msgid "Failed to remove option group from channel: {message}"
 msgstr "從頻道中移除選項群組失敗: {message}"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+#: src/app/routes/_authenticated/_system/job-queue.tsx
 msgid "View job data"
 msgstr "檢視工作資料"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Move to the top level"
 msgstr "移動到頂層"
 
-#: src/lib/components/data-input/product-multi-selector-input.tsx:425
+#: src/lib/components/data-input/product-multi-selector-input.tsx
 msgid "Clear"
 msgstr "清除"
 
-#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx
 msgid "Orders Summary"
 msgstr "訂單摘要"
 
-#: src/lib/components/shared/asset/asset-gallery.tsx:349
+#: src/lib/components/shared/asset/asset-gallery.tsx
 msgid "Search assets..."
 msgstr "搜尋資源..."
 
-#: src/app/routes/_authenticated/_facets/facets.tsx:114
+#: src/app/routes/_authenticated/_facets/facets.tsx
 msgid "New Facet"
 msgstr "新增屬性"
 
-#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
 #~ msgid "Assign {entityType} to channel"
 #~ msgstr "將 {entityType} 指派給通路"
 
-#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
-#: src/lib/components/shared/confirmation-dialog.tsx:51
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx
+#: src/lib/components/shared/confirmation-dialog.tsx
 msgid "Continue"
 msgstr "繼續"
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
-#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
+#: src/app/routes/_authenticated/_promotions/promotions.tsx
 msgid "Promotions"
 msgstr "促銷"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Error message"
 msgstr "錯誤訊息"
 
-#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx
 msgid "Add stock level for another location"
 msgstr "為另一個位置新增庫存水平"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Delete Address"
 msgstr "刪除地址"
 
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Failed to update facet"
 msgstr "更新屬性失敗"
 
-#: src/lib/hooks/use-widget-filters.ts:17
+#: src/lib/hooks/use-widget-filters.ts
 msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
 msgstr "useWidgetFilters 必須在 WidgetFiltersProvider 中使用"
 
-#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx
 msgid "Edit Address"
 msgstr "編輯地址"
 
-#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx
 msgid "Failed to remove facet from channel: {message}"
 msgstr "從通路中移除屬性失敗：{message}"
 
-#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx
 msgid "Set link"
 msgstr "設定連結"
 
-#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+#: src/app/routes/_authenticated/_sellers/sellers.tsx
 msgid "New Seller"
 msgstr "新增賣家"
 
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Edit image"
 msgstr "編輯圖片"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:61
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Manage Variants"
 msgstr "管理變體"
 
-#: src/lib/components/shared/stock-level-label.tsx:18
+#: src/lib/components/shared/stock-level-label.tsx
 msgid "Stock allocated"
 msgstr "庫存已配置"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:45
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "greater than or equal"
 msgstr "大於或等於"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
 msgstr "設定將此變體視為缺貨的庫存水準。使用負值可啟用延期交貨支援。"
 
-#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx:255
+#: src/app/routes/_authenticated/_products/components/create-product-options-dialog.tsx
 #~ msgid "Create product options"
 #~ msgstr "建立商品選項"
 
-#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
-#: src/lib/components/layout/manage-languages-dialog.tsx:382
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "Saving..."
 msgstr "正在儲存..."
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:185
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "View result"
 msgstr "檢視結果"
 
-#: src/lib/components/data-table/data-table-pagination.tsx:20
+#: src/lib/components/data-table/data-table-pagination.tsx
 msgid "Rows per page"
 msgstr "每頁列數"
 
-#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx
 msgid "Loading collections..."
 msgstr "正在載入集合..."
 
-#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
 msgid "Successfully updated facet value"
 msgstr "已成功更新屬性值"
 
-#: src/lib/components/shared/entity-assets.tsx:290
-#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+#: src/lib/components/shared/entity-assets.tsx
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx
 msgid "Add asset"
 msgstr "新增資源"
 
-#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx:122
+#: src/app/routes/_authenticated/_facets/components/edit-facet-value.tsx
 #~ msgid "Save changes"
 #~ msgstr "儲存變更"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
 msgid "Customer added to group"
 msgstr "客戶已新增至群組"
 
-#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx
 msgid "Seller orders"
 msgstr "賣家訂單"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:104
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Failed to add option value"
 msgstr "新增選項值失敗"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:133
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Add option value to {groupName}"
 msgstr "向 {groupName} 新增選項值"
 
 #. placeholder {0}: error.message
-#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
 msgid "Failed to unset shipping address for order: {0}"
 msgstr ""
 
-#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
-#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:167
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
-#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:331
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "SKU"
 msgstr "SKU"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx
 msgid "{totalQuantity} item(s) refunded"
 msgstr "{totalQuantity}件商品已退款"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:263
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
 msgstr "尚未定義選項群組。新增選項群組以建立商品的不同變體（例如：尺寸、顏色、材質）"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
 msgid "New email:"
 msgstr "新電子郵件："
 
-#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
 msgid "Failed to update payment method"
 msgstr "更新付款方式失敗"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx
 msgid "Available:"
 msgstr "可用："
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Created at"
 msgstr "建立於"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
-#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx
 msgid "Failed to create product variant"
 msgstr "建立商品變體失敗"
 
-#: src/lib/components/data-input/relation-selector.tsx:417
+#: src/lib/components/data-input/relation-selector.tsx
 msgid "Search..."
 msgstr ""
 
 #. placeholder {0}: formatLanguageName(contentLanguage)
-#: src/lib/components/layout/channel-switcher.tsx:130
+#: src/lib/components/layout/channel-switcher.tsx
 msgid "Language: {0}"
 msgstr "語言：{0}"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:262
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "You don't have permission to view global language settings"
 msgstr "您沒有檢視全域語言設定的權限"
 
-#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
 msgid "Successfully created tax rate"
 msgstr "已成功建立稅率"
 
-#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
 msgid "Heading 6"
 msgstr "標題 6"
 
-#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx
 msgid "Added coupon codes"
 msgstr "已新增優惠券代碼"
 
-#: src/lib/components/layout/channel-switcher.tsx:180
+#: src/lib/components/layout/channel-switcher.tsx
 msgctxt "active language"
 msgid "Active"
 msgstr "活躍"
 
-#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx
 msgid "Tax base"
 msgstr "稅基"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx
 msgid "Load more"
 msgstr "載入更多"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Refund settled"
 msgstr "退款已完成"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/app/common/duplicate-bulk-action.tsx:97
+#: src/app/common/duplicate-bulk-action.tsx
 msgid "Successfully duplicated {count} {entityName}"
 msgstr "已成功複製 {count} {entityName}"
 
-#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx
 msgid "New Option Group"
 msgstr "新建選項群組"
 
-#: src/app/routes/_authenticated/_system/job-queue.tsx:191
-#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+#: src/app/routes/_authenticated/_system/job-queue.tsx
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx
 msgid "No result yet"
 msgstr "尚無結果"
 
-#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
 msgid "Payment settled"
 msgstr "付款已完成"
 
-#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx:38
+#: src/app/routes/_authenticated/_promotions/components/promotion-conditions-selector.tsx
 msgid "Available Conditions"
 msgstr "可用條件"
 
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
 msgid "Active filters"
 msgstr "使用中的篩選條件"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
-#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
-#: src/lib/components/data-table/data-table.tsx:434
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx
+#: src/lib/components/data-table/data-table.tsx
 msgid "Clear all"
 msgstr "全部清除"
 
-#: src/lib/components/data-table/human-readable-operator.tsx:42
+#: src/lib/components/data-table/human-readable-operator.tsx
 msgid "is greater than"
 msgstr "大於"
 
-#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx
 msgid "Close"
 msgstr "關閉"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Add payment to order"
 msgstr "向訂單新增付款"
 
-#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
-#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
-#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
-#: src/lib/components/data-input/product-multi-selector-input.tsx:154
-#: src/lib/components/data-input/relation-selector.tsx:427
-#: src/lib/components/shared/country-selector.tsx:86
-#: src/lib/components/shared/customer-group-selector.tsx:56
-#: src/lib/components/shared/customer-selector.tsx:88
-#: src/lib/components/shared/facet-value-selector.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx
+#: src/lib/components/data-input/product-multi-selector-input.tsx
+#: src/lib/components/data-input/relation-selector.tsx
+#: src/lib/components/shared/country-selector.tsx
+#: src/lib/components/shared/customer-group-selector.tsx
+#: src/lib/components/shared/customer-selector.tsx
+#: src/lib/components/shared/facet-value-selector.tsx
 msgid "Loading..."
 msgstr "正在載入..."
 
-#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:235
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx
 msgid "The token is used to specify the channel when making API requests."
 msgstr "在進行 API 要求時使用權杖來指定通路。"
 
-#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:67
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
 msgid "No addresses found"
 msgstr "找不到地址"
 
-#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx
 msgid "Fulfillment ID"
 msgstr "履行 ID"
 
-#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:295
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
 msgid "Select payments to refund"
 msgstr "選擇要退款的付款"
 
-#: src/app/common/delete-bulk-action.tsx:115
+#: src/app/common/delete-bulk-action.tsx
 msgid "Failed to delete {failed} {entityName}"
 msgstr "刪除 {failed} {entityName} 失敗"
 
-#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
 msgid "Out-of-stock threshold"
 msgstr "缺貨臨界值"
 
-#: src/lib/components/shared/assigned-channels.tsx:39
+#: src/lib/components/shared/assigned-channels.tsx
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "已成功從頻道移除產品"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+#: src/app/routes/_authenticated/_system/settings-store.tsx
 msgid "Failed to update value"
 msgstr "更新值失敗"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Failed to create API key"
 msgstr "建立 API Key 失敗"
 
-#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
-#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx
 msgid "Settle refund"
 msgstr "完成退款"
 
-#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx
 msgid "Payment method is required"
 msgstr "付款方式為必填欄位"
 
-#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:67
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:138
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Failed to add customer to group"
 msgstr "將客戶新增至群組失敗"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:256
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:272
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+#: src/app/routes/_authenticated/_products/products_.$id.tsx
 msgid "Manage variants"
 msgstr "管理變體"
 
-#: src/lib/components/data-table/views-sheet.tsx:49
+#: src/lib/components/data-table/views-sheet.tsx
 msgid "Applied global view \"{viewName}\""
 msgstr "已套用全域檢視「{viewName}」"
 
-#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx
 msgid "Customer registered"
 msgstr "客戶已註冊"
 
 #. js-lingui-explicit-id
-#: src/lib/framework/defaults.ts:244
+#: src/lib/framework/defaults.ts
 msgid "Zones"
 msgstr "區域"
 
-#: src/lib/components/shared/seller-selector.tsx:37
+#: src/lib/components/shared/seller-selector.tsx
 msgid "Search sellers..."
 msgstr "搜尋賣家..."
 
-#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
 msgid "Successfully created promotion"
 msgstr "已成功建立促銷"
 
-#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
 msgid "Option"
 msgstr "選項"
 
-#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx
 msgid "Order process"
 msgstr "訂單流程"
 
-#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:198
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Phone number"
 msgstr "電話號碼"
 
-#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
-#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx
 msgid "Private"
 msgstr "私人"
 
-#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
 msgid "Variant"
 msgstr "變體"
 
-#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx
 msgid "Successfully updated global settings"
 msgstr "已成功更新全域設定"
 
-#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx
 msgid "Successfully updated API key"
 msgstr "API Key 更新成功"
 
-#: src/lib/components/layout/manage-languages-dialog.tsx:294
+#: src/lib/components/layout/manage-languages-dialog.tsx
 msgid "These languages will be available for all channels to use"
 msgstr "這些語言將可供所有通路使用"

--- a/packages/dev-server/lingui.config.js
+++ b/packages/dev-server/lingui.config.js
@@ -1,8 +1,12 @@
 import { defineConfig } from '@lingui/cli';
+import { formatter } from '@lingui/format-po';
 
 export default defineConfig({
     sourceLocale: 'en',
     locales: ['en', 'de'],
+    // Line numbers in the `#:` reference comments churn on every unrelated edit
+    // to a source file, which makes the catalogs a constant source of merge conflicts.
+    format: formatter({ lineNumbers: false }),
     catalogs: [
         {
             path: '<rootDir>/test-plugins/reviews/dashboard/i18n/{locale}',

--- a/packages/dev-server/test-plugins/reviews/dashboard/i18n/de.po
+++ b/packages/dev-server/test-plugins/reviews/dashboard/i18n/de.po
@@ -6,7 +6,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
-#: test-plugins/reviews/dashboard/review-list.tsx:51
+#: test-plugins/reviews/dashboard/review-list.tsx
 msgid "Product Reviews"
 msgstr "Produkt Bewertungen"

--- a/packages/dev-server/test-plugins/reviews/dashboard/i18n/en.po
+++ b/packages/dev-server/test-plugins/reviews/dashboard/i18n/en.po
@@ -6,7 +6,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
-#: test-plugins/reviews/dashboard/review-list.tsx:51
+#: test-plugins/reviews/dashboard/review-list.tsx
 msgid "Product Reviews"
 msgstr "Product Reviews"


### PR DESCRIPTION
## Problem

The Dashboard's `.po` catalogs record the exact source line each message was found on:

```
#: src/lib/components/shared/customer-address-form.tsx:103
msgid "Full Name"
```

Those line numbers are recalculated on every `lingui extract`, so any edit that shifts code up or down rewrites them. Adding a single import at the top of a file changes the recorded line for every string below it. Across 27 locale files this produces large diffs that have nothing to do with translations, and the catalogs become a frequent source of merge conflicts between branches.

This is not hypothetical. Running extraction on `master` right now moves the reference for `Product Reviews` in the dev-server example plugin from `review-list.tsx:51` to `review-list.tsx:57`, purely because code above it moved. `scripts/check-i18n-sync.sh` already works around the symptom by filtering `#:` lines out of the diff and downgrading reference-only drift to a warning.

## Change

Pass an explicit PO formatter with `lineNumbers: false` in `packages/dashboard/lingui.config.js`. The references keep the file path, which is the part translators need for context, and drop the volatile line number:

```
#: src/lib/components/shared/customer-address-form.tsx
msgid "Full Name"
```

References now only change when a string genuinely moves to a different file.

The same change is applied to `packages/dev-server/lingui.config.js`, which is the working example the extension localization docs are modelled on.

`@lingui/format-po` is added to the Dashboard's `dependencies` rather than `devDependencies`, because `lingui.config.js` is listed in the package's `files` array and `vite/vite-plugin-translations.ts` loads it via `getConfig()` inside consumer projects at build time, so the import has to resolve for anyone installing `@vendure/dashboard`.

## Docs

Plugin authors hand-write their own `lingui.config.js` from the localization guide, so they hit the same churn in their own catalogs. Rather than complicate the getting-started template, the guide keeps its existing minimal config and gains a new section, "Reducing merge conflicts in your .po files", explaining the problem and showing how to turn line numbers off if it becomes an issue.

Two incidental fixes on lines already being touched: an unterminated ` title="lingui.config.js ` code fence attribute, and a sample `.po` reference that used this repo's `test-plugins/` path instead of the `src/plugins/` layout used elsewhere on the page.

## Commits

Split so the mechanical regeneration is reviewable apart from the substance:

1. `fix(dashboard): Omit source line numbers from i18n catalogs` — the config change
2. `fix(dashboard): Regenerate i18n catalogs without source line numbers` — the 27 regenerated catalogs
3. `docs: Explain how to disable .po line numbers in dashboard extensions`

## Verification

- Extraction was run on the **unmodified** config first and produced a clean git status, confirming the catalogs were already in sync. The entire regeneration diff is therefore attributable to this change rather than to accumulated drift.
- Every changed line in the 27 catalogs is a `#:` reference comment. No `msgid`, `msgstr`, or header line is touched. The diff is exactly 50,213 insertions and 50,213 deletions.
- A second extraction produces an empty diff, so the format round-trips without drifting. This is the same parse-and-write path the Vite plugin uses when compiling catalogs in consumer builds.
- `scripts/check-i18n-sync.sh`, the `dashboard i18n sync` CI job, reports "i18n catalogs are in sync" and exits 0.
- `lingui.config.js` was loaded standalone through `getConfig()` to confirm the new import resolves and yields a valid formatter.

Note for anyone with a branch in flight: this rewrites every reference line, so expect one conflict when rebasing, after which the problem goes away.

## Follow-up, not in this PR

While verifying that no line numbers survived, one catalog still had them: `src/i18n/locales/ko.po`. It is tracked and holds around 1005 Korean translations, but `ko` appears in neither the `locales` array in `lingui.config.js` nor `defaultAvailableLanguages` in `vite/constants.ts`, so `lingui extract` never updates it and the Display language selector can never offer it. `ja` has half the same problem: the catalog is kept current, but Japanese is missing from `defaultAvailableLanguages` and so cannot be selected either.

Deliberately left out of this PR, since making languages selectable is a separate decision. Korean also needs a call on quality first, as it sits at roughly 25% untranslated against 4% for every other locale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788079282&installation_model_id=20193&pr_number=5075&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5075&signature=33cce41b1fdebab31a44c1bb8ffdf309fe0afc611ed55bac7718c131ddd2aa34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->